### PR TITLE
feat: adds datastore conversion utilities

### DIFF
--- a/.changeset/funny-countries-notice.md
+++ b/.changeset/funny-countries-notice.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+feat: adds datastore conversion utilities

--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Linting Go
         uses: smartcontractkit/.github/actions/ci-lint-go@eeb76b5870e3c17856d5a60fd064a053c023b5f5 # ci-lint-go@1.0.0
         with:
+          only-new-issues: "false"
           golangci-lint-version: v2.0.2
           # Override the lint args because the detault ones are not compatible with golangci-lint v2
           golangci-lint-args: --output.checkstyle.path=golangci-lint-report.xml

--- a/datastore/transform.go
+++ b/datastore/transform.go
@@ -15,75 +15,75 @@ func ToDefault[CM Cloneable[CM], EM Cloneable[EM]](
 	converted := NewMemoryDataStore[DefaultMetadata, DefaultMetadata]()
 
 	// Copy all addressRef over to the new data store, no conversion is needed
-	addressRefs, err := dataStore.Addresses().Fetch()
-	if err != nil {
-		return nil, fmt.Errorf("error fetching AddressRefs: %w", err)
+	addressRefs, addrErr := dataStore.Addresses().Fetch()
+	if addrErr != nil {
+		return nil, fmt.Errorf("error fetching AddressRefs: %w", addrErr)
 	}
 
 	for _, ar := range addressRefs {
-		err = converted.Addresses().Add(ar)
-		if err != nil {
+		addrErr = converted.Addresses().Add(ar)
+		if addrErr != nil {
 			return nil, fmt.Errorf("error adding AddressRef: for %s@%v: %w",
-				ar.Address, ar.ChainSelector, err)
+				ar.Address, ar.ChainSelector, addrErr)
 		}
 	}
 
 	// Copy all contractMetadata over to the new data store and convert the metadata
 	// to a JSON string. This is done by marshaling the metadata into a JSON string.
-	contractMetadata, err := dataStore.ContractMetadata().Fetch()
-	if err != nil {
-		return nil, fmt.Errorf("error fetching ContractMetadata: %w", err)
+	contractMetadata, cmetaErr := dataStore.ContractMetadata().Fetch()
+	if cmetaErr != nil {
+		return nil, fmt.Errorf("error fetching ContractMetadata: %w", cmetaErr)
 	}
 
 	for _, cm := range contractMetadata {
-		jsonData, err := json.Marshal(cm.Metadata)
-		if err != nil {
+		jsonData, cmetaErr := json.Marshal(cm.Metadata)
+		if cmetaErr != nil {
 			return nil, fmt.Errorf("error marshaling ContractMetadata for %s@%v: %w",
-				cm.Address, cm.ChainSelector, err)
+				cm.Address, cm.ChainSelector, cmetaErr)
 		}
 
-		err = converted.ContractMetadata().Add(ContractMetadata[DefaultMetadata]{
+		cmetaErr = converted.ContractMetadata().Add(ContractMetadata[DefaultMetadata]{
 			ChainSelector: cm.ChainSelector,
 			Address:       cm.Address,
 			Metadata: DefaultMetadata{
 				Data: string(jsonData),
 			},
 		})
-		if err != nil {
+		if cmetaErr != nil {
 			return nil, fmt.Errorf("error adding ContractMetadata for %s@%v: %w",
-				cm.Address, cm.ChainSelector, err)
+				cm.Address, cm.ChainSelector, cmetaErr)
 		}
 	}
 
 	// Fetch the EnvMetadata and check if it was set.
-	envMetadata, err := dataStore.EnvMetadata().Get()
-	if err != nil {
-		if errors.Is(err, ErrEnvMetadataNotSet) {
+	envMetadata, envmetaErr := dataStore.EnvMetadata().Get()
+	if envmetaErr != nil {
+		if errors.Is(envmetaErr, ErrEnvMetadataNotSet) {
 			// If the env metadata was not set, Get() will return ErrEnvMetadataNotSet.
 			// In this case, we don't need to do anything.
 			return converted, nil
 		}
 
-		return nil, err
+		return nil, envmetaErr
 	}
 
 	// Convert the EnvMetadata to a JSON string. This is done by marshaling the metadata
 	// into a JSON string.
-	jsonData, err := json.Marshal(envMetadata.Metadata)
-	if err != nil {
-		return nil, fmt.Errorf("error marshaling EnvMetadata: %w", err)
+	jsonData, envmetaErr := json.Marshal(envMetadata.Metadata)
+	if envmetaErr != nil {
+		return nil, fmt.Errorf("error marshaling EnvMetadata: %w", envmetaErr)
 	}
 
 	// Set the EnvMetadata in the new data store with the JSON string.
-	err = converted.EnvMetadata().Set(EnvMetadata[DefaultMetadata]{
+	envmetaErr = converted.EnvMetadata().Set(EnvMetadata[DefaultMetadata]{
 		Domain:      envMetadata.Domain,
 		Environment: envMetadata.Environment,
 		Metadata: DefaultMetadata{
 			Data: string(jsonData),
 		},
 	})
-	if err != nil {
-		return nil, fmt.Errorf("error updating EnvMetadata: %w", err)
+	if envmetaErr != nil {
+		return nil, fmt.Errorf("error updating EnvMetadata: %w", envmetaErr)
 	}
 
 	return converted, nil
@@ -98,74 +98,74 @@ func FromDefault[CM Cloneable[CM], EM Cloneable[EM]](
 	converted := NewMemoryDataStore[CM, EM]()
 
 	// Copy all addressRef over to the new data store, no conversion is needed
-	addressRefs, err := defaultStore.Addresses().Fetch()
-	if err != nil {
-		return nil, fmt.Errorf("error fetching AddressRefs: %w", err)
+	addressRefs, addrErr := defaultStore.Addresses().Fetch()
+	if addrErr != nil {
+		return nil, fmt.Errorf("error fetching AddressRefs: %w", addrErr)
 	}
 
 	for _, ar := range addressRefs {
-		err = converted.Addresses().Add(ar)
-		if err != nil {
+		addrErr = converted.Addresses().Add(ar)
+		if addrErr != nil {
 			return nil, fmt.Errorf("error adding AddressRef: for %s@%v: %w",
-				ar.Address, ar.ChainSelector, err)
+				ar.Address, ar.ChainSelector, addrErr)
 		}
 	}
 
 	// Copy all contractMetadata over to the new data store and convert the metadata
 	// to the domain specific type. This is done by unmarshaling the JSON string
 	// representing the metadata into the concrete type.
-	contractMetadata, err := defaultStore.ContractMetadata().Fetch()
-	if err != nil {
-		return nil, fmt.Errorf("error fetching ContractMetadata: %w", err)
+	contractMetadata, cmetaErr := defaultStore.ContractMetadata().Fetch()
+	if cmetaErr != nil {
+		return nil, fmt.Errorf("error fetching ContractMetadata: %w", cmetaErr)
 	}
 
 	for _, cm := range contractMetadata {
 		var metadata CM
-		err = json.Unmarshal([]byte(cm.Metadata.Data), &metadata)
-		if err != nil {
+		cmetaErr = json.Unmarshal([]byte(cm.Metadata.Data), &metadata)
+		if cmetaErr != nil {
 			return nil, fmt.Errorf("error unmarshaling ContractMetadata for %s@%v: %w",
-				cm.Address, cm.ChainSelector, err)
+				cm.Address, cm.ChainSelector, cmetaErr)
 		}
 
-		err = converted.ContractMetadata().Add(ContractMetadata[CM]{
+		cmetaErr = converted.ContractMetadata().Add(ContractMetadata[CM]{
 			ChainSelector: cm.ChainSelector,
 			Address:       cm.Address,
 			Metadata:      metadata,
 		})
-		if err != nil {
+		if cmetaErr != nil {
 			return nil, fmt.Errorf("error adding ContractMetadata for %s@%v: %w",
-				cm.Address, cm.ChainSelector, err)
+				cm.Address, cm.ChainSelector, cmetaErr)
 		}
 	}
 
 	// Fetch the EnvMetadata and check if it was set.
-	envMetadata, err := defaultStore.EnvMetadata().Get()
-	if err != nil {
-		if errors.Is(err, ErrEnvMetadataNotSet) {
+	envMetadata, envmetaErr := defaultStore.EnvMetadata().Get()
+	if envmetaErr != nil {
+		if errors.Is(envmetaErr, ErrEnvMetadataNotSet) {
 			// If the env metadata was not set, Get() will return ErrEnvMetadataNotSet.
 			// In this case, we don't need to do anything.
 			return converted.Seal(), nil
 		}
 
-		return nil, err
+		return nil, envmetaErr
 	}
 
 	// Convert the EnvMetadata to the domain specific type. This is done by unmarshaling
 	// the JSON string representing the metadata into the concrete type.
 	var metadata EM
-	err = json.Unmarshal([]byte(envMetadata.Metadata.Data), &metadata)
-	if err != nil {
-		return nil, fmt.Errorf("error unmarshaling EnvMetadata: %w", err)
+	envmetaErr = json.Unmarshal([]byte(envMetadata.Metadata.Data), &metadata)
+	if envmetaErr != nil {
+		return nil, fmt.Errorf("error unmarshaling EnvMetadata: %w", envmetaErr)
 	}
 
 	// Set the EnvMetadata in the new data store with the domain specific type.
-	err = converted.EnvMetadata().Set(EnvMetadata[EM]{
+	envmetaErr = converted.EnvMetadata().Set(EnvMetadata[EM]{
 		Domain:      envMetadata.Domain,
 		Environment: envMetadata.Environment,
 		Metadata:    metadata,
 	})
-	if err != nil {
-		return nil, fmt.Errorf("error updating EnvMetadata: %w", err)
+	if envmetaErr != nil {
+		return nil, fmt.Errorf("error updating EnvMetadata: %w", envmetaErr)
 	}
 
 	return converted.Seal(), nil

--- a/datastore/transform.go
+++ b/datastore/transform.go
@@ -21,7 +21,7 @@ func ToDefault[CM Cloneable[CM], EM Cloneable[EM]](
 	}
 
 	for _, ar := range addressRefs {
-		err := converted.Addresses().Add(ar)
+		err = converted.Addresses().Add(ar)
 		if err != nil {
 			return nil, fmt.Errorf("error adding AddressRef: for %s@%v: %w",
 				ar.Address, ar.ChainSelector, err)
@@ -63,6 +63,7 @@ func ToDefault[CM Cloneable[CM], EM Cloneable[EM]](
 			// In this case, we don't need to do anything.
 			return converted, nil
 		}
+
 		return nil, err
 	}
 
@@ -103,7 +104,7 @@ func FromDefault[CM Cloneable[CM], EM Cloneable[EM]](
 	}
 
 	for _, ar := range addressRefs {
-		err := converted.Addresses().Add(ar)
+		err = converted.Addresses().Add(ar)
 		if err != nil {
 			return nil, fmt.Errorf("error adding AddressRef: for %s@%v: %w",
 				ar.Address, ar.ChainSelector, err)
@@ -111,7 +112,7 @@ func FromDefault[CM Cloneable[CM], EM Cloneable[EM]](
 	}
 
 	// Copy all contractMetadata over to the new data store and convert the metadata
-	// to to the domain specific type. This is done by unmarshaling the JSON string
+	// to the domain specific type. This is done by unmarshaling the JSON string
 	// representing the metadata into the concrete type.
 	contractMetadata, err := defaultStore.ContractMetadata().Fetch()
 	if err != nil {
@@ -120,7 +121,7 @@ func FromDefault[CM Cloneable[CM], EM Cloneable[EM]](
 
 	for _, cm := range contractMetadata {
 		var metadata CM
-		err := json.Unmarshal([]byte(cm.Metadata.Data), &metadata)
+		err = json.Unmarshal([]byte(cm.Metadata.Data), &metadata)
 		if err != nil {
 			return nil, fmt.Errorf("error unmarshaling ContractMetadata for %s@%v: %w",
 				cm.Address, cm.ChainSelector, err)
@@ -145,6 +146,7 @@ func FromDefault[CM Cloneable[CM], EM Cloneable[EM]](
 			// In this case, we don't need to do anything.
 			return converted.Seal(), nil
 		}
+
 		return nil, err
 	}
 

--- a/datastore/transform.go
+++ b/datastore/transform.go
@@ -23,7 +23,8 @@ func ToDefault[CM Cloneable[CM], EM Cloneable[EM]](
 	for _, ar := range addressRefs {
 		err := converted.Addresses().Add(ar)
 		if err != nil {
-			return nil, fmt.Errorf("error adding AddressRef: %w", err)
+			return nil, fmt.Errorf("error adding AddressRef: for %s@%v: %w",
+				ar.Address, ar.ChainSelector, err)
 		}
 	}
 
@@ -37,7 +38,8 @@ func ToDefault[CM Cloneable[CM], EM Cloneable[EM]](
 	for _, cm := range contractMetadata {
 		jsonData, err := json.Marshal(cm.Metadata)
 		if err != nil {
-			return nil, fmt.Errorf("error marshaling ContractMetadata: %w", err)
+			return nil, fmt.Errorf("error marshaling ContractMetadata for %s@%v: %w",
+				cm.Address, cm.ChainSelector, err)
 		}
 
 		err = converted.ContractMetadata().Add(ContractMetadata[DefaultMetadata]{
@@ -48,7 +50,8 @@ func ToDefault[CM Cloneable[CM], EM Cloneable[EM]](
 			},
 		})
 		if err != nil {
-			return nil, fmt.Errorf("error adding ContractMetadata: %w", err)
+			return nil, fmt.Errorf("error adding ContractMetadata for %s@%v: %w",
+				cm.Address, cm.ChainSelector, err)
 		}
 	}
 
@@ -102,7 +105,8 @@ func FromDefault[CM Cloneable[CM], EM Cloneable[EM]](
 	for _, ar := range addressRefs {
 		err := converted.Addresses().Add(ar)
 		if err != nil {
-			return nil, fmt.Errorf("error adding AddressRef: %w", err)
+			return nil, fmt.Errorf("error adding AddressRef: for %s@%v: %w",
+				ar.Address, ar.ChainSelector, err)
 		}
 	}
 
@@ -118,7 +122,8 @@ func FromDefault[CM Cloneable[CM], EM Cloneable[EM]](
 		var metadata CM
 		err := json.Unmarshal([]byte(cm.Metadata.Data), &metadata)
 		if err != nil {
-			return nil, fmt.Errorf("error unmarshaling ContractMetadata: %w", err)
+			return nil, fmt.Errorf("error unmarshaling ContractMetadata for %s@%v: %w",
+				cm.Address, cm.ChainSelector, err)
 		}
 
 		err = converted.ContractMetadata().Add(ContractMetadata[CM]{
@@ -127,7 +132,8 @@ func FromDefault[CM Cloneable[CM], EM Cloneable[EM]](
 			Metadata:      metadata,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("error adding ContractMetadata: %w", err)
+			return nil, fmt.Errorf("error adding ContractMetadata for %s@%v: %w",
+				cm.Address, cm.ChainSelector, err)
 		}
 	}
 

--- a/datastore/transform.go
+++ b/datastore/transform.go
@@ -1,0 +1,164 @@
+package datastore
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ToDefault is a utility function that converts a DataStore with domain specific
+// metadata types into a DataStore with DefaultMetadata types.
+// NOTE: It is assumed that the domain specific metadata types are JSON serializable.
+func ToDefault[CM Cloneable[CM], EM Cloneable[EM]](
+	dataStore DataStore[CM, EM],
+) (MutableDataStore[DefaultMetadata, DefaultMetadata], error) {
+	converted := NewMemoryDataStore[DefaultMetadata, DefaultMetadata]()
+
+	// Copy all addressRef over to the new data store, no conversion is needed
+	addressRefs, err := dataStore.Addresses().Fetch()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching AddressRefs: %w", err)
+	}
+
+	for _, ar := range addressRefs {
+		err := converted.Addresses().Add(ar)
+		if err != nil {
+			return nil, fmt.Errorf("error adding AddressRef: %w", err)
+		}
+	}
+
+	// Copy all contractMetadata over to the new data store and convert the metadata
+	// to a JSON string. This is done by marshaling the metadata into a JSON string.
+	contractMetadata, err := dataStore.ContractMetadata().Fetch()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching ContractMetadata: %w", err)
+	}
+
+	for _, cm := range contractMetadata {
+		jsonData, err := json.Marshal(cm.Metadata)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling ContractMetadata: %w", err)
+		}
+
+		err = converted.ContractMetadata().Add(ContractMetadata[DefaultMetadata]{
+			ChainSelector: cm.ChainSelector,
+			Address:       cm.Address,
+			Metadata: DefaultMetadata{
+				Data: string(jsonData),
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error adding ContractMetadata: %w", err)
+		}
+	}
+
+	// Fetch the EnvMetadata and check if it was set.
+	envMetadata, err := dataStore.EnvMetadata().Get()
+	if err != nil {
+		if errors.Is(err, ErrEnvMetadataNotSet) {
+			// If the env metadata was not set, Get() will return ErrEnvMetadataNotSet.
+			// In this case, we don't need to do anything.
+			return converted, nil
+		}
+		return nil, err
+	}
+
+	// Convert the EnvMetadata to a JSON string. This is done by marshaling the metadata
+	// into a JSON string.
+	jsonData, err := json.Marshal(envMetadata.Metadata)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling EnvMetadata: %w", err)
+	}
+
+	// Set the EnvMetadata in the new data store with the JSON string.
+	err = converted.EnvMetadata().Set(EnvMetadata[DefaultMetadata]{
+		Domain:      envMetadata.Domain,
+		Environment: envMetadata.Environment,
+		Metadata: DefaultMetadata{
+			Data: string(jsonData),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error updating EnvMetadata: %w", err)
+	}
+
+	return converted, nil
+}
+
+// FromDefault is a utility function that converts a DataStore with DefaultMetadata types
+// into a DataStore with domain specific metadata types.
+// NOTE: It is assumed that the domain specific metadata types are JSON deserializable.
+func FromDefault[CM Cloneable[CM], EM Cloneable[EM]](
+	defaultStore DataStore[DefaultMetadata, DefaultMetadata],
+) (DataStore[CM, EM], error) {
+	converted := NewMemoryDataStore[CM, EM]()
+
+	// Copy all addressRef over to the new data store, no conversion is needed
+	addressRefs, err := defaultStore.Addresses().Fetch()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching AddressRefs: %w", err)
+	}
+
+	for _, ar := range addressRefs {
+		err := converted.Addresses().Add(ar)
+		if err != nil {
+			return nil, fmt.Errorf("error adding AddressRef: %w", err)
+		}
+	}
+
+	// Copy all contractMetadata over to the new data store and convert the metadata
+	// to to the domain specific type. This is done by unmarshaling the JSON string
+	// representing the metadata into the concrete type.
+	contractMetadata, err := defaultStore.ContractMetadata().Fetch()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching ContractMetadata: %w", err)
+	}
+
+	for _, cm := range contractMetadata {
+		var metadata CM
+		err := json.Unmarshal([]byte(cm.Metadata.Data), &metadata)
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshaling ContractMetadata: %w", err)
+		}
+
+		err = converted.ContractMetadata().Add(ContractMetadata[CM]{
+			ChainSelector: cm.ChainSelector,
+			Address:       cm.Address,
+			Metadata:      metadata,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("error adding ContractMetadata: %w", err)
+		}
+	}
+
+	// Fetch the EnvMetadata and check if it was set.
+	envMetadata, err := defaultStore.EnvMetadata().Get()
+	if err != nil {
+		if errors.Is(err, ErrEnvMetadataNotSet) {
+			// If the env metadata was not set, Get() will return ErrEnvMetadataNotSet.
+			// In this case, we don't need to do anything.
+			return converted.Seal(), nil
+		}
+		return nil, err
+	}
+
+	// Convert the EnvMetadata to the domain specific type. This is done by unmarshaling
+	// the JSON string representing the metadata into the concrete type.
+	var metadata EM
+	err = json.Unmarshal([]byte(envMetadata.Metadata.Data), &metadata)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling EnvMetadata: %w", err)
+	}
+
+	// Set the EnvMetadata in the new data store with the domain specific type.
+	err = converted.EnvMetadata().Set(EnvMetadata[EM]{
+		Domain:      envMetadata.Domain,
+		Environment: envMetadata.Environment,
+		Metadata:    metadata,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error updating EnvMetadata: %w", err)
+	}
+
+	return converted.Seal(), nil
+}

--- a/datastore/transform_test.go
+++ b/datastore/transform_test.go
@@ -20,6 +20,8 @@ func (cm CustomMetadata) Clone() CustomMetadata {
 }
 
 func TestToDefault(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		setup    func() MutableDataStore[CustomMetadata, CustomMetadata]
@@ -102,12 +104,13 @@ func TestToDefault(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, tt.expected, defaultStore)
-
 		})
 	}
 }
 
 func TestFromDefault(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		setup    func() MutableDataStore[DefaultMetadata, DefaultMetadata]

--- a/datastore/transform_test.go
+++ b/datastore/transform_test.go
@@ -1,0 +1,195 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/require"
+)
+
+// CustomMetadata is a placeholder type for testing purposes.
+type CustomMetadata struct {
+	Field string `json:"field"`
+}
+
+// Clone creates a deep copy of CustomMetadata.
+func (cm CustomMetadata) Clone() CustomMetadata {
+	return CustomMetadata{
+		Field: cm.Field,
+	}
+}
+
+func TestToDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func() MutableDataStore[CustomMetadata, CustomMetadata]
+		expected MutableDataStore[DefaultMetadata, DefaultMetadata]
+	}{
+		{
+			name: "successful conversion",
+			setup: func() MutableDataStore[CustomMetadata, CustomMetadata] {
+				ds := NewMemoryDataStore[CustomMetadata, CustomMetadata]()
+
+				err := ds.Addresses().Add(AddressRef{
+					Address:       "addr1",
+					Type:          "type1",
+					Version:       semver.MustParse("1.0.0"),
+					ChainSelector: 1,
+					Qualifier:     "qualifier1",
+					Labels:        NewLabelSet("label1", "label2"),
+				})
+				require.NoError(t, err)
+
+				err = ds.ContractMetadata().Add(ContractMetadata[CustomMetadata]{
+					ChainSelector: 1,
+					Address:       "contract1",
+					Metadata:      CustomMetadata{Field: "value1"},
+				})
+				require.NoError(t, err)
+
+				err = ds.EnvMetadata().Set(EnvMetadata[CustomMetadata]{
+					Domain:      "domain1",
+					Environment: "env1",
+					Metadata:    CustomMetadata{Field: "envValue1"},
+				})
+				require.NoError(t, err)
+
+				return ds
+			},
+			expected: &MemoryDataStore[DefaultMetadata, DefaultMetadata]{
+				AddressRefStore: &MemoryAddressRefStore{
+					Records: []AddressRef{
+						{
+							Address:       "addr1",
+							Type:          "type1",
+							Version:       semver.MustParse("1.0.0"),
+							ChainSelector: 1,
+							Qualifier:     "qualifier1",
+							Labels:        NewLabelSet("label1", "label2"),
+						},
+					},
+				},
+				ContractMetadataStore: &MemoryContractMetadataStore[DefaultMetadata]{
+					Records: []ContractMetadata[DefaultMetadata]{
+						{
+							ChainSelector: 1,
+							Address:       "contract1",
+							Metadata: DefaultMetadata{
+								Data: `{"field":"value1"}`,
+							},
+						},
+					},
+				},
+				EnvMetadataStore: &MemoryEnvMetadataStore[DefaultMetadata]{
+					Record: &EnvMetadata[DefaultMetadata]{
+						Domain:      "domain1",
+						Environment: "env1",
+						Metadata: DefaultMetadata{
+							Data: `{"field":"envValue1"}`,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataStore := tt.setup()
+
+			// Test ToDefault
+			defaultStore, err := ToDefault(dataStore.Seal())
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expected, defaultStore)
+
+		})
+	}
+}
+
+func TestFromDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func() MutableDataStore[DefaultMetadata, DefaultMetadata]
+		expected DataStore[CustomMetadata, CustomMetadata]
+	}{
+		{
+			name: "successful conversion",
+			setup: func() MutableDataStore[DefaultMetadata, DefaultMetadata] {
+				ds := NewMemoryDataStore[DefaultMetadata, DefaultMetadata]()
+
+				err := ds.Addresses().Add(AddressRef{
+					Address:       "addr1",
+					Type:          "type1",
+					Version:       semver.MustParse("1.0.0"),
+					ChainSelector: 1,
+					Qualifier:     "qualifier1",
+					Labels:        NewLabelSet("label1", "label2"),
+				})
+				require.NoError(t, err)
+
+				err = ds.ContractMetadata().Add(ContractMetadata[DefaultMetadata]{
+					ChainSelector: 1,
+					Address:       "contract1",
+					Metadata: DefaultMetadata{
+						Data: `{"field":"value1"}`,
+					},
+				})
+				require.NoError(t, err)
+
+				err = ds.EnvMetadata().Set(EnvMetadata[DefaultMetadata]{
+					Domain:      "domain1",
+					Environment: "env1",
+					Metadata: DefaultMetadata{
+						Data: `{"field":"envValue1"}`,
+					},
+				})
+				require.NoError(t, err)
+
+				return ds
+			},
+			expected: &sealedMemoryDataStore[CustomMetadata, CustomMetadata]{
+				AddressRefStore: &MemoryAddressRefStore{
+					Records: []AddressRef{
+						{
+							Address:       "addr1",
+							Type:          "type1",
+							Version:       semver.MustParse("1.0.0"),
+							ChainSelector: 1,
+							Qualifier:     "qualifier1",
+							Labels:        NewLabelSet("label1", "label2"),
+						},
+					},
+				},
+				ContractMetadataStore: &MemoryContractMetadataStore[CustomMetadata]{
+					Records: []ContractMetadata[CustomMetadata]{
+						{
+							ChainSelector: 1,
+							Address:       "contract1",
+							Metadata:      CustomMetadata{Field: "value1"},
+						},
+					},
+				},
+				EnvMetadataStore: &MemoryEnvMetadataStore[CustomMetadata]{
+					Record: &EnvMetadata[CustomMetadata]{
+						Domain:      "domain1",
+						Environment: "env1",
+						Metadata:    CustomMetadata{Field: "envValue1"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataStore := tt.setup()
+
+			// Test FromDefault
+			customStore, err := FromDefault[CustomMetadata, CustomMetadata](dataStore.Seal())
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expected, customStore)
+		})
+	}
+}

--- a/datastore/transform_test.go
+++ b/datastore/transform_test.go
@@ -97,6 +97,8 @@ func TestToDefault(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			dataStore := tt.setup()
 
 			// Test ToDefault
@@ -186,6 +188,8 @@ func TestFromDefault(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			dataStore := tt.setup()
 
 			// Test FromDefault


### PR DESCRIPTION
This PR adds `datastore` utility functions for converting between domain-specific types and the DefaultMetadata type.

### Metadata Transformation Utilities:
* [`datastore/transform.go`](https://github.com/smartcontractkit/chainlink-deployments-framework/blob/c4a09a68da380674a03b8e56c74d53d91c2ddcfc/datastore/transform.go): Added `ToDefault` and `FromDefault` utility functions for converting between domain-specific metadata types and `DefaultMetadata` types