### PR TITLE
fix(ci): lint new files on pull requests

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Linting Go
         uses: smartcontractkit/.github/actions/ci-lint-go@eeb76b5870e3c17856d5a60fd064a053c023b5f5 # ci-lint-go@1.0.0
         with:
+          only-new-issues: "false"
           golangci-lint-version: v2.0.2
           # Override the lint args because the detault ones are not compatible with golangci-lint v2
           golangci-lint-args: --output.checkstyle.path=golangci-lint-report.xml


### PR DESCRIPTION
Fix to proper linting on PR:
On pull_request with only-new-issues: true → ✅ it passes (those files are not checked).

On merge_group with only-new-issues: false (or fallback to full run) → ❌ it fails, because that file is now part of the full scan.