### PR TITLE
Data store/add address filter

### DIFF
--- a/.changeset/yummy-clouds-argue.md
+++ b/.changeset/yummy-clouds-argue.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+Add an address filter to datastore

--- a/datastore/filters.go
+++ b/datastore/filters.go
@@ -39,6 +39,13 @@ func addressRefFilter(predicate func(record AddressRef) bool) FilterFunc[Address
 	}
 }
 
+// AddressRefByAddress returns a filter that only includes records with the provided address
+func AddressRefByAddress(address string) FilterFunc[AddressRefKey, AddressRef] {
+	return addressRefFilter(func(record AddressRef) bool {
+		return record.Address == address
+	})
+}
+
 // AddressRefByChainSelector returns a filter that only includes records with the provided chain.
 func AddressRefByChainSelector(chainSelector uint64) FilterFunc[AddressRefKey, AddressRef] {
 	return addressRefFilter(func(record AddressRef) bool {

--- a/datastore/filters_test.go
+++ b/datastore/filters_test.go
@@ -7,6 +7,83 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAddressRefByAddress(t *testing.T) {
+	t.Parallel()
+
+	var (
+		recordOne = AddressRef{
+			Address:       "0x123456",
+			ChainSelector: 1,
+			Type:          "type1",
+			Version:       semver.MustParse("0.5.0"),
+			Qualifier:     "qual1",
+			Labels: NewLabelSet(
+				"label1", "label2", "label3",
+			),
+		}
+
+		recordTwo = AddressRef{
+			Address:       "0x123456",
+			ChainSelector: 2,
+			Type:          "typeX",
+			Version:       semver.MustParse("0.5.0"),
+			Qualifier:     "qual1",
+			Labels: NewLabelSet(
+				"label13", "label23", "label33",
+			),
+		}
+
+		recordThree = AddressRef{
+			Address:       "0x456789",
+			ChainSelector: 2,
+			Type:          "typeX",
+			Version:       semver.MustParse("0.5.0"),
+			Qualifier:     "qual1",
+			Labels: NewLabelSet(
+				"label13", "label23", "label33",
+			),
+		}
+	)
+
+	tests := []struct {
+		name           string
+		givenState     []AddressRef
+		giveAddress    string
+		expectedResult []AddressRef
+	}{
+		{
+			name: "success: returns 2 records with given address",
+			givenState: []AddressRef{
+				recordOne,
+				recordTwo,
+				recordThree,
+			},
+			giveAddress:    "0x123456",
+			expectedResult: []AddressRef{recordOne, recordTwo},
+		},
+		{
+			name: "success: returns 1 record with given address",
+			givenState: []AddressRef{
+				recordOne,
+				recordTwo,
+				recordThree,
+			},
+			giveAddress:    "0x456789",
+			expectedResult: []AddressRef{recordThree},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			filter := AddressRefByAddress(tt.giveAddress)
+			filteredRecords := filter(tt.givenState)
+			assert.Equal(t, tt.expectedResult, filteredRecords)
+		})
+	}
+}
+
 func TestAddressRefByChainSelector(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Add an address filter. Usecase I have for this is to quickly check if the contract address I have is the expected one
```
records := store.Filter(
			AddressRefByAddress("0x1234"),
			AddressRefByChainSelector(1),
			AddressRefByType(ContractType("MyType")),
			AddressRefByVersion("0.5.0"),
		)

if len(records) == 1 .... 

```

It probably should have it's own dedicated function in the datastore to get a single expected record.

