### PR TITLE
feature: adds a package with operations testing utilities

### DIFF
--- a/.changeset/wild-vans-drive.md
+++ b/.changeset/wild-vans-drive.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+Adds an `operations/optest` package containing test utility functions.

--- a/operations/optest/optest.go
+++ b/operations/optest/optest.go
@@ -1,0 +1,20 @@
+// Package optest provides utilities for operations testing.
+package optest
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+)
+
+// NewBundle creates a new operations bundle for testing with a no-op logger
+// and a memory reporter.
+func NewBundle(t *testing.T) operations.Bundle {
+	t.Helper()
+
+	return operations.NewBundle(
+		t.Context, logger.Nop(), operations.NewMemoryReporter(),
+	)
+}


### PR DESCRIPTION
There are common patterns when testing Operations that we can provide to users as a package. This commit adds a package with a single function to create a testing OperationBundle, but can be extended in the future to include more utilities as they emerge from user feedback.