### PR TITLE
feat(deployment):migrate in ocr secrets

### DIFF
--- a/.changeset/major-eyes-wish.md
+++ b/.changeset/major-eyes-wish.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+feat: migrate ocr secrets

--- a/deployment/ocr_secrets.go
+++ b/deployment/ocr_secrets.go
@@ -1,0 +1,23 @@
+package deployment
+
+import "github.com/ethereum/go-ethereum/crypto"
+
+// OCRSecrets are used to disseminate a shared secret to OCR nodes
+// through the blockchain where OCR configuration is stored. Its a low value secret used
+// to derive transmission order etc. They are extracted here such that they can common
+// across signers when multiple signers are signing the same OCR config.
+type OCRSecrets struct {
+	SharedSecret [16]byte
+	EphemeralSk  [32]byte
+}
+
+func (s OCRSecrets) IsEmpty() bool {
+	return s.SharedSecret == [16]byte{} || s.EphemeralSk == [32]byte{}
+}
+
+func XXXGenerateTestOCRSecrets() OCRSecrets {
+	var s OCRSecrets
+	copy(s.SharedSecret[:], crypto.Keccak256([]byte("shared"))[:16])
+	copy(s.EphemeralSk[:], crypto.Keccak256([]byte("ephemeral")))
+	return s
+}


### PR DESCRIPTION
Copy ocr secrets helpers from chainlink repo to here. This is a lift and shift, nothing was changed

[JIRA: https://smartcontract-it.atlassian.net/browse/CLD-130](https://smartcontract-it.atlassian.net/browse/CLD-153)