### PR TITLE
feat: change operations retry logic to be opt-in

### DIFF
--- a/.changeset/tangy-plums-draw.md
+++ b/.changeset/tangy-plums-draw.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+BREAKING: Operations retry logic is now opt in. Use the `WithRetry` method in your `ExecuteOperation` call to enable retries

--- a/operations/report.go
+++ b/operations/report.go
@@ -44,7 +44,7 @@ type SequenceReport[IN, OUT any] struct {
 // This is useful when we want to return the report as a generic type in the changeset.output.
 func (r SequenceReport[IN, OUT]) ToGenericSequenceReport() SequenceReport[any, any] {
 	return SequenceReport[any, any]{
-		Report:           genericReport[IN, OUT](r.Report),
+		Report:           genericReport(r.Report),
 		ExecutionReports: r.ExecutionReports,
 	}
 }

--- a/operations/report_test.go
+++ b/operations/report_test.go
@@ -69,7 +69,7 @@ func Test_NewReport(t *testing.T) {
 
 	testErr := errors.New("test error")
 	childOperationID := uuid.New().String()
-	report := NewReport[int, int](op.def, 1, 2, testErr, childOperationID)
+	report := NewReport(op.def, 1, 2, testErr, childOperationID)
 	assert.NotEmpty(t, report.ID)
 	assert.Equal(t, op.def, report.Def)
 	assert.Equal(t, 1, report.Input)


### PR DESCRIPTION
BREAKING CHANGE: The retry logic for operations is now opt-in. To enable the retry, the caller must now provide the `WithRetry` option to the `ExecuteOperation`. This change is intended to provide greater control over the retry behavior and to avoid unintended retries in certain scenarios.