### PR TITLE
logs(multiclient):add retry success log

### DIFF
--- a/deployment/multiclient.go
+++ b/deployment/multiclient.go
@@ -236,6 +236,8 @@ func (mc *MultiClient) retryWithBackups(opName string, op func(*ethclient.Client
 			return nil
 		}, retry.Attempts(mc.RetryConfig.Attempts), retry.Delay(mc.RetryConfig.Delay))
 		if err2 == nil {
+			mc.lggr.Infof("traceID(%s): Successfully executed op %s after retry attempt using client index %d for chain %s", traceID.String(), opName, i, mc.chainName)
+
 			return nil
 		}
 		mc.lggr.Infof("traceID(%s): Client at index %d failed, trying next client chain %s", traceID.String(), i, mc.chainName)


### PR DESCRIPTION
We see warnings for retry attempts but we never confirm we were successful after them. It's to make better ux for the users.