### PR TITLE
feat(multiclient): wraps debug calls with retry logic

### DIFF
--- a/.changeset/clean-carrots-hide.md
+++ b/.changeset/clean-carrots-hide.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+feat(multiclient): wraps debug calls with retry logic

--- a/deployment/multiclient.go
+++ b/deployment/multiclient.go
@@ -184,6 +184,102 @@ func (mc *MultiClient) HeaderByNumber(ctx context.Context, number *big.Int) (*ty
 	return header, err
 }
 
+func (mc *MultiClient) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
+	var gasPrice *big.Int
+	err := mc.retryWithBackups("SuggestGasPrice", func(client *ethclient.Client) error {
+		var err error
+		gasPrice, err = client.SuggestGasPrice(ctx)
+
+		return err
+	})
+
+	return gasPrice, err
+}
+
+func (mc *MultiClient) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
+	var gasTipCap *big.Int
+	err := mc.retryWithBackups("SuggestGasTipCap", func(client *ethclient.Client) error {
+		var err error
+		gasTipCap, err = client.SuggestGasTipCap(ctx)
+
+		return err
+	})
+
+	return gasTipCap, err
+}
+
+func (mc *MultiClient) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
+	var code []byte
+	err := mc.retryWithBackups("PendingCodeAt", func(client *ethclient.Client) error {
+		var err error
+		code, err = client.PendingCodeAt(ctx, account)
+
+		return err
+	})
+
+	return code, err
+}
+
+func (mc *MultiClient) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
+	var count uint64
+	err := mc.retryWithBackups("PendingNonceAt", func(client *ethclient.Client) error {
+		var err error
+		count, err = client.PendingNonceAt(ctx, account)
+
+		return err
+	})
+
+	return count, err
+}
+
+func (mc *MultiClient) EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error) {
+	var gas uint64
+	err := mc.retryWithBackups("EstimateGas", func(client *ethclient.Client) error {
+		var err error
+		gas, err = client.EstimateGas(ctx, call)
+
+		return err
+	})
+
+	return gas, err
+}
+
+func (mc *MultiClient) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
+	var balance *big.Int
+	err := mc.retryWithBackups("BalanceAt", func(client *ethclient.Client) error {
+		var err error
+		balance, err = client.BalanceAt(ctx, account, blockNumber)
+
+		return err
+	})
+
+	return balance, err
+}
+
+func (mc *MultiClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	var logs []types.Log
+	err := mc.retryWithBackups("FilterLogs", func(client *ethclient.Client) error {
+		var err error
+		logs, err = client.FilterLogs(ctx, q)
+
+		return err
+	})
+
+	return logs, err
+}
+
+func (mc *MultiClient) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+	var sub ethereum.Subscription
+	err := mc.retryWithBackups("SubscribeFilterLogs", func(client *ethclient.Client) error {
+		var err error
+		sub, err = client.SubscribeFilterLogs(ctx, q, ch)
+
+		return err
+	})
+
+	return sub, err
+}
+
 func (mc *MultiClient) WaitMined(ctx context.Context, tx *types.Transaction) (*types.Receipt, error) {
 	mc.lggr.Debugf("Waiting for tx %s to be mined for chain %s", tx.Hash().Hex(), mc.chainName)
 	// no retries here because we want to wait for the tx to be mined
@@ -271,113 +367,4 @@ func (mc *MultiClient) dialWithRetry(rpc RPC, lggr logger.Logger) (*ethclient.Cl
 	}
 
 	return client, nil
-}
-
-// The following methods are reimplemented to improve debuggability and better surface
-// errors that may occur when using ethclient.Client methods directly.
-// This is a temporary solution and may be removed in the future.
-func (mc *MultiClient) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
-	var gasPrice *big.Int
-	err := mc.callWithDebug("SuggestGasPrice", func(client *ethclient.Client) error {
-		var err error
-		gasPrice, err = client.SuggestGasPrice(ctx)
-
-		return err
-	})
-
-	return gasPrice, err
-}
-
-func (mc *MultiClient) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
-	var gasTipCap *big.Int
-	err := mc.callWithDebug("SuggestGasTipCap", func(client *ethclient.Client) error {
-		var err error
-		gasTipCap, err = client.SuggestGasTipCap(ctx)
-
-		return err
-	})
-
-	return gasTipCap, err
-}
-
-func (mc *MultiClient) PendingCodeAt(ctx context.Context, account common.Address) ([]byte, error) {
-	var code []byte
-	err := mc.callWithDebug("PendingCodeAt", func(client *ethclient.Client) error {
-		var err error
-		code, err = client.PendingCodeAt(ctx, account)
-
-		return err
-	})
-
-	return code, err
-}
-
-func (mc *MultiClient) PendingNonceAt(ctx context.Context, account common.Address) (uint64, error) {
-	var count uint64
-	err := mc.callWithDebug("PendingNonceAt", func(client *ethclient.Client) error {
-		var err error
-		count, err = client.PendingNonceAt(ctx, account)
-
-		return err
-	})
-
-	return count, err
-}
-
-func (mc *MultiClient) EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error) {
-	var gas uint64
-	err := mc.callWithDebug("EstimateGas", func(client *ethclient.Client) error {
-		var err error
-		gas, err = client.EstimateGas(ctx, call)
-
-		return err
-	})
-
-	return gas, err
-}
-
-func (mc *MultiClient) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
-	var balance *big.Int
-	err := mc.callWithDebug("BalanceAt", func(client *ethclient.Client) error {
-		var err error
-		balance, err = client.BalanceAt(ctx, account, blockNumber)
-
-		return err
-	})
-
-	return balance, err
-}
-
-func (mc *MultiClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
-	var logs []types.Log
-	err := mc.callWithDebug("FilterLogs", func(client *ethclient.Client) error {
-		var err error
-		logs, err = client.FilterLogs(ctx, q)
-
-		return err
-	})
-
-	return logs, err
-}
-
-func (mc *MultiClient) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
-	var sub ethereum.Subscription
-	err := mc.callWithDebug("SubscribeFilterLogs", func(client *ethclient.Client) error {
-		var err error
-		sub, err = client.SubscribeFilterLogs(ctx, q, ch)
-
-		return err
-	})
-
-	return sub, err
-}
-
-func (mc *MultiClient) callWithDebug(callName string, call func(*ethclient.Client) error) error {
-	mc.lggr.Debugf("Calling %s for chain %s", callName, mc.chainName)
-	var err = call(mc.Client)
-	if err != nil {
-		mc.lggr.Errorf("error '%s' when calling %s for chain %s", MaybeDataErr(err), callName, mc.chainName)
-	}
-
-	return err
 }


### PR DESCRIPTION
This PR replaces temporary debug-wrapped calls in MultiClient with proper retry logic to improve resilience and reduce the impact of transient failures. Recent improvements (debug logs and refined retry logic) have stabilized MultiClient. The debug wrappers are no longer needed and can be replaced with the same retry logic that already wraps other calls.