### PR TITLE
fix(addressbook): fix error message

### DIFF
--- a/.changeset/small-towns-unite.md
+++ b/.changeset/small-towns-unite.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix incorrect error message order

--- a/deployment/address_book.go
+++ b/deployment/address_book.go
@@ -6,11 +6,10 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/exp/maps"
-
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
 	chainsel "github.com/smartcontractkit/chain-selectors"
+	"golang.org/x/exp/maps"
 )
 
 var (
@@ -124,17 +123,17 @@ type AddressBookMap struct {
 func (m *AddressBookMap) save(chainSelector uint64, address string, typeAndVersion TypeAndVersion) error {
 	family, err := chainsel.GetSelectorFamily(chainSelector)
 	if err != nil {
-		return fmt.Errorf("%w: chain selector %d", ErrInvalidChainSelector, chainSelector)
+		return fmt.Errorf("chain selector %d: %w", chainSelector, ErrInvalidChainSelector)
 	}
 	if family == chainsel.FamilyEVM {
 		if address == "" || address == common.HexToAddress("0x0").Hex() {
-			return fmt.Errorf("%w: address cannot be empty", ErrInvalidAddress)
+			return fmt.Errorf("address cannot be empty: %w", ErrInvalidAddress)
 		}
 		if common.IsHexAddress(address) {
 			// IMPORTANT: WE ALWAYS STANDARDIZE ETHEREUM ADDRESS STRINGS TO EIP55
 			address = common.HexToAddress(address).Hex()
 		} else {
-			return fmt.Errorf("%w: address %s is not a valid Ethereum address, only Ethereum addresses supported for EVM chains", ErrInvalidAddress, address)
+			return fmt.Errorf("address %s is not a valid Ethereum address, only Ethereum addresses supported for EVM chains: %w", address, ErrInvalidAddress)
 		}
 	}
 
@@ -178,14 +177,14 @@ func (m *AddressBookMap) Addresses() (map[uint64]map[string]TypeAndVersion, erro
 func (m *AddressBookMap) AddressesForChain(chainSelector uint64) (map[string]TypeAndVersion, error) {
 	_, err := chainsel.GetChainIDFromSelector(chainSelector)
 	if err != nil {
-		return nil, fmt.Errorf("%w: chain selector %d", ErrInvalidChainSelector, chainSelector)
+		return nil, fmt.Errorf("chain selector %d: %w", chainSelector, ErrInvalidChainSelector)
 	}
 
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
 	if _, exists := m.addressesByChain[chainSelector]; !exists {
-		return nil, fmt.Errorf("%w: chain selector %d", ErrChainNotFound, chainSelector)
+		return nil, fmt.Errorf("chain selector %d: %w", chainSelector, ErrChainNotFound)
 	}
 
 	// maps are mutable and pass via a pointer

--- a/deployment/address_book_test.go
+++ b/deployment/address_book_test.go
@@ -36,6 +36,11 @@ func TestAddressBook_Save(t *testing.T) {
 	// Valid chain but not present.
 	_, err = ab.AddressesForChain(chainsel.TEST_90000002.Selector)
 	require.ErrorIs(t, err, ErrChainNotFound)
+	require.ErrorContains(t, err, "chain selector 5548718428018410741: chain not found")
+
+	// invalid chain
+	_, err = ab.AddressesForChain(0)
+	require.ErrorContains(t, err, "chain selector 0: invalid chain selector")
 
 	// Invalid selector
 	err = ab.Save(0, addr1, onRamp100)
@@ -75,6 +80,18 @@ func TestAddressBook_Save(t *testing.T) {
 			addr2: onRamp110,
 		},
 	}, addresses)
+
+	// save with bad chain selector
+	err = ab.Save(0, addr1, onRamp100)
+	require.ErrorContains(t, err, "chain selector 0: invalid chain selector")
+
+	// save with empty address
+	err = ab.Save(chainsel.TEST_90000001.Selector, "", onRamp100)
+	require.ErrorContains(t, err, "address cannot be empty: invalid address")
+
+	// save with bad address
+	err = ab.Save(chainsel.TEST_90000001.Selector, "bad address", onRamp100)
+	require.ErrorContains(t, err, "address bad address is not a valid Ethereum address, only Ethereum addresses supported for EVM chains: invalid address")
 }
 
 func TestAddressBook_Merge(t *testing.T) {


### PR DESCRIPTION
During the previous [lint fixes here](https://github.com/smartcontractkit/chainlink-deployments-framework/pull/71/files), the strings in the error message were reversed, we should maintain the same order. This is causing some tests to fail in Chainlink.

Added unit tests for it.