### PR TITLE
[WILL NO MERGE]: [spike]: refactor chains in Environment

### DIFF
--- a/chain/aptos/aptos.go
+++ b/chain/aptos/aptos.go
@@ -1,12 +1,15 @@
-package deployment
+package aptos
 
 import (
 	"github.com/aptos-labs/aptos-go-sdk"
+
+	chain_common "github.com/smartcontractkit/chainlink-deployments-framework/chain/common"
 )
 
-// AptosChain represents an Aptos chain.
-type AptosChain struct {
-	Selector       uint64
+// Chain represents an Aptos chain.
+type Chain struct {
+	chain_common.ChainInfoProvider
+
 	Client         aptos.AptosRpcClient
 	DeployerSigner aptos.TransactionSigner
 	URL            string

--- a/chain/blockchain.go
+++ b/chain/blockchain.go
@@ -1,0 +1,153 @@
+package chain
+
+import (
+	"errors"
+	"sort"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+)
+
+var _ BlockChain = evm.Chain{}
+var _ BlockChain = solana.Chain{}
+var _ BlockChain = aptos.Chain{}
+
+type BlockChains struct {
+	chains map[uint64]BlockChain
+}
+
+type BlockChain interface {
+	String() string
+	Name() string
+	ChainSelector() uint64
+}
+
+func (b BlockChains) EVMChains() (map[uint64]evm.Chain, error) {
+	var evmChains = make(map[uint64]evm.Chain)
+	for selector, chain := range b.chains {
+		c, ok := chain.(evm.Chain)
+		if !ok {
+			continue
+		}
+		evmChains[selector] = c
+	}
+	return evmChains, nil
+}
+
+func (b BlockChains) SolanaChains() (map[uint64]solana.Chain, error) {
+	var solanaChains = make(map[uint64]solana.Chain)
+	for selector, chain := range b.chains {
+		c, ok := chain.(solana.Chain)
+		if !ok {
+			continue
+		}
+		solanaChains[selector] = c
+	}
+	return solanaChains, nil
+}
+
+func (b BlockChains) AptosChains() (map[uint64]aptos.Chain, error) {
+	var aptosChains = make(map[uint64]aptos.Chain)
+	for selector, chain := range b.chains {
+		c, ok := chain.(aptos.Chain)
+		if !ok {
+			continue
+		}
+		aptosChains[selector] = c
+	}
+	return aptosChains, nil
+}
+
+// ChainSelectorsOption defines a function type for configuring ChainSelectors
+type ChainSelectorsOption func(*chainSelectorsOptions)
+
+// chainSelectorsOptions holds configuration for chain selector filtering
+type chainSelectorsOptions struct {
+	family    string
+	excluding []uint64
+}
+
+// WithFamily returns an option to filter chains by family (evm, solana, aptos)
+func WithFamily(family string) ChainSelectorsOption {
+	return func(o *chainSelectorsOptions) {
+		o.family = family
+	}
+}
+
+// WithChainSelectorsExclusion returns an option to exclude specific chain selectors
+func WithChainSelectorsExclusion(chainSelectors []uint64) ChainSelectorsOption {
+	return func(o *chainSelectorsOptions) {
+		o.excluding = chainSelectors
+	}
+}
+
+// ListChainSelectors returns all chain selectors with optional filtering
+func (b BlockChains) ListChainSelectors(options ...ChainSelectorsOption) []uint64 {
+	// Initialize default options
+	opts := chainSelectorsOptions{
+		family:    "",
+		excluding: []uint64{},
+	}
+
+	// Apply all provided options
+	for _, option := range options {
+		option(&opts)
+	}
+
+	selectors := make([]uint64, 0, len(b.chains))
+
+	for selector, chain := range b.chains {
+		// Skip if in exclusion list
+		excluded := false
+		for _, exclude := range opts.excluding {
+			if selector == exclude {
+				excluded = true
+				break
+			}
+		}
+		if excluded {
+			continue
+		}
+
+		// Apply family filter if specified
+		if opts.family != "" {
+			switch chain.(type) {
+			case evm.Chain:
+				if opts.family != chain_selectors.FamilyEVM {
+					continue
+				}
+			case solana.Chain:
+				if opts.family != chain_selectors.FamilySolana {
+					continue
+				}
+			case aptos.Chain:
+				if opts.family != chain_selectors.FamilyAptos {
+					continue
+				}
+			default:
+				continue
+			}
+		}
+
+		selectors = append(selectors, selector)
+	}
+
+	// Sort for consistent output
+	sort.Slice(selectors, func(i, j int) bool {
+		return selectors[i] < selectors[j]
+	})
+
+	return selectors
+}
+
+func (b BlockChains) chainBySelector(selector uint64) (BlockChain, error) {
+	c, exists := b.chains[selector]
+	if !exists {
+		return nil, errors.New("chain does not exist")
+	}
+
+	return c, nil
+}

--- a/chain/common/chain_info_provider.go
+++ b/chain/common/chain_info_provider.go
@@ -1,0 +1,56 @@
+package common
+
+import (
+	"fmt"
+	"strconv"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+)
+
+type ChainInfoProvider struct {
+	Selector uint64
+}
+
+func (c ChainInfoProvider) ChainSelector() uint64 {
+	return c.Selector
+}
+
+func (c ChainInfoProvider) String() string {
+	chainInfo, err := ChainInfo(c.Selector)
+	if err != nil {
+		// we should never get here, if the selector is invalid it should not be in the environment
+		panic(err)
+	}
+
+	return fmt.Sprintf("%s (%d)", chainInfo.ChainName, chainInfo.ChainSelector)
+}
+
+func (c ChainInfoProvider) Name() string {
+	chainInfo, err := ChainInfo(c.Selector)
+	if err != nil {
+		// we should never get here, if the selector is invalid it should not be in the environment
+		panic(err)
+	}
+	if chainInfo.ChainName == "" {
+		return strconv.FormatUint(c.Selector, 10)
+	}
+
+	return chainInfo.ChainName
+}
+
+func ChainInfo(cs uint64) (chain_selectors.ChainDetails, error) {
+	id, err := chain_selectors.GetChainIDFromSelector(cs)
+	if err != nil {
+		return chain_selectors.ChainDetails{}, err
+	}
+	family, err := chain_selectors.GetSelectorFamily(cs)
+	if err != nil {
+		return chain_selectors.ChainDetails{}, err
+	}
+	info, err := chain_selectors.GetChainDetailsByChainIDAndFamily(id, family)
+	if err != nil {
+		return chain_selectors.ChainDetails{}, err
+	}
+
+	return info, nil
+}

--- a/chain/evm/evm.go
+++ b/chain/evm/evm.go
@@ -1,0 +1,42 @@
+package evm
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/zksync-sdk/zksync2-go/accounts"
+	"github.com/zksync-sdk/zksync2-go/clients"
+
+	chain_common "github.com/smartcontractkit/chainlink-deployments-framework/chain/common"
+)
+
+// OnchainClient is an EVM chain client.
+// For EVM specifically we can use existing geth interface
+// to abstract chain clients.
+type OnchainClient interface {
+	bind.ContractBackend
+	bind.DeployBackend
+	BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error)
+	NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (uint64, error)
+}
+
+// Chain represents an EVM chain.
+type Chain struct {
+	chain_common.ChainInfoProvider
+
+	Client OnchainClient
+	// Note the Sign function can be abstract supporting a variety of key storage mechanisms (e.g. KMS etc).
+	DeployerKey *bind.TransactOpts
+	Confirm     func(tx *types.Transaction) (uint64, error)
+	// Users are a set of keys that can be used to interact with the chain.
+	// These are distinct from the deployer key.
+	Users []*bind.TransactOpts
+
+	// ZK deployment specifics
+	IsZkSyncVM          bool
+	ClientZkSyncVM      *clients.Client
+	DeployerKeyZkSyncVM *accounts.Wallet
+}

--- a/deployment/changeset_test.go
+++ b/deployment/changeset_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 )
 
@@ -103,12 +104,10 @@ func NewNoopEnvironment(t *testing.T) Environment {
 			datastore.DefaultMetadata,
 			datastore.DefaultMetadata,
 		]().Seal(),
-		map[uint64]Chain{},
-		map[uint64]SolChain{},
-		map[uint64]AptosChain{},
 		[]string{},
 		nil,
 		t.Context,
 		XXXGenerateTestOCRSecrets(),
+		chain.BlockChains{},
 	)
 }

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -5,22 +5,18 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"slices"
-	"sort"
-	"strconv"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/zksync-sdk/zksync2-go/accounts"
-	"github.com/zksync-sdk/zksync2-go/clients"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	csav1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/csa"
 	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
 	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
@@ -44,47 +40,6 @@ type OffchainClient interface {
 	csav1.CSAServiceClient
 }
 
-// Chain represents an EVM chain.
-type Chain struct {
-	// Selectors used as canonical chain identifier.
-	Selector uint64
-	Client   OnchainClient
-	// Note the Sign function can be abstract supporting a variety of key storage mechanisms (e.g. KMS etc).
-	DeployerKey *bind.TransactOpts
-	Confirm     func(tx *types.Transaction) (uint64, error)
-	// Users are a set of keys that can be used to interact with the chain.
-	// These are distinct from the deployer key.
-	Users []*bind.TransactOpts
-
-	// ZK deployment specifics
-	IsZkSyncVM          bool
-	ClientZkSyncVM      *clients.Client
-	DeployerKeyZkSyncVM *accounts.Wallet
-}
-
-func (c Chain) String() string {
-	chainInfo, err := ChainInfo(c.Selector)
-	if err != nil {
-		// we should never get here, if the selector is invalid it should not be in the environment
-		panic(err)
-	}
-
-	return fmt.Sprintf("%s (%d)", chainInfo.ChainName, chainInfo.ChainSelector)
-}
-
-func (c Chain) Name() string {
-	chainInfo, err := ChainInfo(c.Selector)
-	if err != nil {
-		// we should never get here, if the selector is invalid it should not be in the environment
-		panic(err)
-	}
-	if chainInfo.ChainName == "" {
-		return strconv.FormatUint(c.Selector, 10)
-	}
-
-	return chainInfo.ChainName
-}
-
 func MaybeDataErr(err error) error {
 	//revive:disable
 	var d rpc.DataError
@@ -100,7 +55,6 @@ func MaybeDataErr(err error) error {
 // including on and offchain components. It is intended to be
 // cross-family to enable a coherent view of a product deployed
 // to all its chains.
-// TODO: Add SolChains, AptosChain etc.
 // using Go bindings/libraries from their respective
 // repositories i.e. chainlink-solana, chainlink-cosmos
 // You can think of ExistingAddresses as a set of
@@ -121,15 +75,13 @@ type Environment struct {
 		datastore.DefaultMetadata,
 		datastore.DefaultMetadata,
 	]
-	Chains      map[uint64]Chain
-	SolChains   map[uint64]SolChain
-	AptosChains map[uint64]AptosChain
-	NodeIDs     []string
-	Offchain    OffchainClient
-	GetContext  func() context.Context
-	OCRSecrets  OCRSecrets
+	NodeIDs    []string
+	Offchain   OffchainClient
+	GetContext func() context.Context
+	OCRSecrets OCRSecrets
 	// OperationsBundle contains dependencies required by the operations API.
 	OperationsBundle operations.Bundle
+	BlockChains      chain.BlockChains
 }
 
 func NewEnvironment(
@@ -140,28 +92,24 @@ func NewEnvironment(
 		datastore.DefaultMetadata,
 		datastore.DefaultMetadata,
 	],
-	chains map[uint64]Chain,
-	solChains map[uint64]SolChain,
-	aptosChains map[uint64]AptosChain,
 	nodeIDs []string,
 	offchain OffchainClient,
 	ctx func() context.Context,
 	secrets OCRSecrets,
+	BlockChains chain.BlockChains,
 ) *Environment {
 	return &Environment{
 		Name:              name,
 		Logger:            logger,
 		ExistingAddresses: existingAddrs,
 		DataStore:         dataStore,
-		Chains:            chains,
-		SolChains:         solChains,
-		AptosChains:       aptosChains,
 		NodeIDs:           nodeIDs,
 		Offchain:          offchain,
 		GetContext:        ctx,
 		OCRSecrets:        secrets,
 		// default to memory reporter as that is the only reporter available for now
 		OperationsBundle: operations.NewBundle(ctx, logger, operations.NewMemoryReporter()),
+		BlockChains:      BlockChains,
 	}
 }
 
@@ -187,118 +135,18 @@ func (e Environment) Clone() Environment {
 		Logger:            e.Logger,
 		ExistingAddresses: ab,
 		DataStore:         ds.Seal(),
-		Chains:            e.Chains,
-		SolChains:         e.SolChains,
-		AptosChains:       e.AptosChains,
 		NodeIDs:           e.NodeIDs,
 		Offchain:          e.Offchain,
 		GetContext:        e.GetContext,
 		OCRSecrets:        e.OCRSecrets,
 		OperationsBundle:  e.OperationsBundle,
+		BlockChains:       e.BlockChains,
 	}
-}
-
-func (e Environment) AllChainSelectors() []uint64 {
-	selectors := make([]uint64, 0, len(e.Chains))
-	for sel := range e.Chains {
-		selectors = append(selectors, sel)
-	}
-	sort.Slice(selectors, func(i, j int) bool {
-		return selectors[i] < selectors[j]
-	})
-
-	return selectors
-}
-
-func (e Environment) AllChainSelectorsExcluding(excluding []uint64) []uint64 {
-	selectors := make([]uint64, 0, len(e.Chains))
-	for sel := range e.Chains {
-		excluded := false
-		for _, toExclude := range excluding {
-			if sel == toExclude {
-				excluded = true
-			}
-		}
-		if excluded {
-			continue
-		}
-		selectors = append(selectors, sel)
-	}
-	sort.Slice(selectors, func(i, j int) bool {
-		return selectors[i] < selectors[j]
-	})
-
-	return selectors
-}
-
-func (e Environment) AllChainSelectorsSolana() []uint64 {
-	selectors := make([]uint64, 0, len(e.SolChains))
-	for sel := range e.SolChains {
-		selectors = append(selectors, sel)
-	}
-	sort.Slice(selectors, func(i, j int) bool {
-		return selectors[i] < selectors[j]
-	})
-
-	return selectors
-}
-
-func (e Environment) AllChainSelectorsAptos() []uint64 {
-	selectors := make([]uint64, 0, len(e.AptosChains))
-	for sel := range e.AptosChains {
-		selectors = append(selectors, sel)
-	}
-	sort.Slice(selectors, func(i, j int) bool {
-		return selectors[i] < selectors[j]
-	})
-
-	return selectors
-}
-
-func (e Environment) AllChainSelectorsAllFamilies() []uint64 {
-	selectors := make([]uint64, 0, len(e.Chains)+len(e.SolChains)+len(e.AptosChains))
-	for sel := range e.Chains {
-		selectors = append(selectors, sel)
-	}
-	for sel := range e.SolChains {
-		selectors = append(selectors, sel)
-	}
-	for sel := range e.AptosChains {
-		selectors = append(selectors, sel)
-	}
-	sort.Slice(selectors, func(i, j int) bool {
-		return selectors[i] < selectors[j]
-	})
-
-	return selectors
-}
-
-func (e Environment) AllChainSelectorsAllFamiliesExcluding(excluding []uint64) []uint64 {
-	selectors := e.AllChainSelectorsAllFamilies()
-	ret := make([]uint64, 0)
-	// remove the excluded selectors
-	for _, sel := range selectors {
-		if slices.Contains(excluding, sel) {
-			continue
-		}
-		ret = append(ret, sel)
-	}
-
-	return ret
-}
-
-func (e Environment) AllDeployerKeys() []common.Address {
-	deployerKeys := make([]common.Address, 0, len(e.Chains))
-	for sel := range e.Chains {
-		deployerKeys = append(deployerKeys, e.Chains[sel].DeployerKey.From)
-	}
-
-	return deployerKeys
 }
 
 // ConfirmIfNoError confirms the transaction if no error occurred.
 // if the error is a DataError, it will return the decoded error message and data.
-func ConfirmIfNoError(chain Chain, tx *types.Transaction, err error) (uint64, error) {
+func ConfirmIfNoError(chain evm.Chain, tx *types.Transaction, err error) (uint64, error) {
 	if err != nil {
 		//revive:disable
 		var d rpc.DataError
@@ -315,7 +163,7 @@ func ConfirmIfNoError(chain Chain, tx *types.Transaction, err error) (uint64, er
 
 // ConfirmIfNoErrorWithABI confirms the transaction if no error occurred.
 // if the error is a DataError, it will return the decoded error message and data.
-func ConfirmIfNoErrorWithABI(chain Chain, tx *types.Transaction, abi string, err error) (uint64, error) {
+func ConfirmIfNoErrorWithABI(chain evm.Chain, tx *types.Transaction, abi string, err error) (uint64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("transaction reverted on chain %s: Error %w",
 			chain.String(), DecodedErrFromABIIfDataErr(err, abi))

--- a/deployment/helpers.go
+++ b/deployment/helpers.go
@@ -15,6 +15,8 @@ import (
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 )
 
 // SimTransactOpts is useful to generate just the calldata for a given gethwrapper method.
@@ -120,9 +122,9 @@ type ContractDeploy[C any] struct {
 // confirmed or the address could not be saved.
 func DeployContract[C any](
 	lggr logger.Logger,
-	chain Chain,
+	chain evm.Chain,
 	addressBook AddressBook,
-	deploy func(chain Chain) ContractDeploy[C],
+	deploy func(chain evm.Chain) ContractDeploy[C],
 ) (*ContractDeploy[C], error) {
 	contractDeploy := deploy(chain)
 	if contractDeploy.Err != nil {


### PR DESCRIPTION
An attempt to refactor to remove the coupling of different chains (aptos, solana, evm) with the Environment struct.

Note: This is a spike to see how the new design would look, we would have to implement it in a way to support graceful migration in Chainlink Repo


## Design Choices

- new field under `Environment` call Blockchains which has a private field of map to an interface type replaces all the chain specific fields. No longer we have a new map field for each new chain that we want to support.

```
chains map[uint64]Chain,
solChains map[uint64]SolChain,
aptosChains map[uint64]AptosChain,
```

now represented as

```
chains map[uint64]BlockChain
```
where as `BlockChain` is an interface

Users will be still able to access the specific chain type using the newly provided method, `EVMBySelector`, `SolanaBySelector` etc.

### Benefits

This stops the top level `Environment` struct from containing all the chain fields and grow with every new chain which is not scalable. 

Chain Devs no longer need to update Environment struct to add the new Chain field

Better encapsulation on the chain type, currently in changeset we see usage of `e.SolChain[chainSelector]` or `e.Chain[chainSelector]` everywhere in the changeset, this exposes the underneath data structure as a map which can make things hard to change in future.

---

- Introduce methods `EVMBySelector`, `SolanaBySelector` etc to allow users to get access to the concrete chain type if Blockchain interface is not enough.

In an Ideal world, we want to just work with a single type and standarise all behaviour from all chain families, however this is no feasible as each chain can vary a lot (more reasoning [here](https://chainlink-core.slack.com/archives/C07CF8V02KX/p1744725286124229?thread_ts=1744650825.564109&cid=C07CF8V02KX)).

Which is why the new design is more a hybrid, it works with the single interface type at the `Environment` level but when required, methods are be provided to access those concrete types.

---

- all chains implementations are moved into a new root folder `chain` with each chain type having it owns package.

```
├── chain
│   ├── aptos
│   │   └── aptos.go
│   ├── blockchain.go
│   ├── evm
│   │   └── evm.go
│   └── solana
│       └── solana.go
```

### Benefits

This allows us to assign appropriate product CODEOWNERS to the right chain package. Better ownership control.

Avoid any changes on the core framework code (Environment). To add new chains, only the package `chain` will need to be updated.

--- 

- the existing methods `AllChainSelectorsAllFamiliesExcluding`, `AllChainSelectorsAllFamilies`, `AllChainSelectorsAptos` , `AllChainSelectorsSolana` ,`AllChainSelectors` , `AllChainSelectorsExcluding` are replaced with a single method `ListChainSelectors`  supported by functional options for filtering

```
// WithChainSelectorsExclusion
// WithFamily
func (b BlockChains) ListChainSelectors(options ...ChainSelectorsOption) []uint64 {
```

### Benefit:

The existing design did not scale well, we would have to introduce a new `AllChainSelectors<Chain>` for every new chain we want to support.

Chain dev no longer have to remember to update this file to add the new function
