### PR TITLE
[CLD-272]: feat(operations): enable concurrency support

### DIFF
--- a/.changeset/itchy-dragons-shout.md
+++ b/.changeset/itchy-dragons-shout.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat: Concurrency support for Operations API

--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Build and test
         uses: smartcontractkit/.github/actions/ci-test-go@eeb76b5870e3c17856d5a60fd064a053c023b5f5 # ci-test-go@1.0.0
         with:
-          go-test-cmd: go test -coverprofile=coverage.txt $(go list ./...)
+          go-test-cmd: go test -race -coverprofile=coverage.txt $(go list ./...)
           use-go-cache: true


### PR DESCRIPTION
CCIP team has raised that they want to start using Operations API and they have a use case where they wan to deploy multiple contracts in parallel (multiple go routine calling executeSequence), currently Operations API is not thread safe due to the reporter.

- update MemoryReporter and RecentReporter to be thread safe

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-272