### PR TITLE
refactor: remove proposals field from ChangesetOutput

### DIFF
--- a/.changeset/cruel-keys-bathe.md
+++ b/.changeset/cruel-keys-bathe.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+The deprecated `Proposals` field on the `ChangesetOutput` has been removed in favour of `MCMSTimelockProposals`

--- a/deployment/changeset.go
+++ b/deployment/changeset.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/smartcontractkit/ccip-owner-contracts/pkg/proposal/timelock"
 	"github.com/smartcontractkit/mcms"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
@@ -106,10 +105,8 @@ type ProposedJob struct {
 // this changeset.
 type ChangesetOutput struct {
 	// Deprecated: Prefer Jobs instead.
-	JobSpecs map[string][]string `deprecated:"true"`
-	Jobs     []ProposedJob
-	// Deprecated: Prefer MCMSTimelockProposals instead, will be removed in future
-	Proposals                  []timelock.MCMSWithTimelockProposal
+	JobSpecs                   map[string][]string `deprecated:"true"`
+	Jobs                       []ProposedJob
 	MCMSTimelockProposals      []mcms.TimelockProposal
 	DescribedTimelockProposals []string
 	MCMSProposals              []mcms.Proposal

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/ethereum/go-ethereum v1.15.3
 	github.com/gagliardetto/solana-go v1.12.0
 	github.com/google/uuid v1.6.0
-	github.com/smartcontractkit/ccip-owner-contracts v0.1.0
 	github.com/smartcontractkit/chain-selectors v1.0.57
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250425163923-16aa375957b7
 	github.com/smartcontractkit/chainlink-common v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,6 @@ github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMT
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
-github.com/smartcontractkit/ccip-owner-contracts v0.1.0 h1:GiBDtlx7539o7AKlDV+9LsA7vTMPv+0n7ClhSFnZFAk=
-github.com/smartcontractkit/ccip-owner-contracts v0.1.0/go.mod h1:NnT6w4Kj42OFFXhSx99LvJZWPpMjmo4+CpDEWfw61xY=
 github.com/smartcontractkit/chain-selectors v1.0.57 h1:KApvb/Kpn15YalY7khFQaHH3mb7teX7JF/gwvq3ti7M=
 github.com/smartcontractkit/chain-selectors v1.0.57/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250425163923-16aa375957b7 h1:j6Vo/NX2ABsPdGxETC5pfQLcz/h6iLJu/Yx+8AhPa34=


### PR DESCRIPTION
Removes the `Proposals` field from the `ChangesetOutput` struct. Use the `MCMSTimelockProposals` struct instead which provides an implementation based on the upgraded `mcms` library

BREAKING CHANGE:  This field was previously marked as deprecated and has now been removed.