### PR TITLE
fix(sonar):include lint in schedule main

### DIFF
--- a/.github/workflows/schedule-main.yml
+++ b/.github/workflows/schedule-main.yml
@@ -46,7 +46,6 @@ jobs:
 
   sonarqube:
     name: Sonar Scan
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     needs: [ ci-test, ci-lint-misc,  ci-lint ]
     steps:
@@ -55,3 +54,4 @@ jobs:
         with:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           sonar-host-url: ${{ secrets.SONAR_HOST_URL }}
+          include-lint: true


### PR DESCRIPTION
This pull request updates the SonarQube workflow in `.github/workflows/schedule-main.yml` to improve its configuration and functionality. The changes include removing a conditional check and adding a new parameter to the SonarQube step.

Updates to SonarQube workflow:

* Removed the conditional `if: github.event_name == 'pull_request'` from the SonarQube job, allowing it to run regardless of the event type.
* Added a new `include-lint: true` parameter to the SonarQube step to include linting results in the scan.