### PR TITLE
feat: add Family method to the Blockchain interface and implementations

### DIFF
--- a/.changeset/mighty-dodos-smoke.md
+++ b/.changeset/mighty-dodos-smoke.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+Adds a `Family` method to the `Blockchain` interface

--- a/chain/aptos/aptos_chain.go
+++ b/chain/aptos/aptos_chain.go
@@ -31,3 +31,8 @@ func (c Chain) String() string {
 func (c Chain) Name() string {
 	return chain_common.ChainMetadata{Selector: c.Selector}.Name()
 }
+
+// Family returns the family of the chain
+func (c Chain) Family() string {
+	return chain_common.ChainMetadata{Selector: c.Selector}.Family()
+}

--- a/chain/aptos/aptos_chain_test.go
+++ b/chain/aptos/aptos_chain_test.go
@@ -17,12 +17,14 @@ func TestChain_ChainInfot(t *testing.T) {
 		selector   uint64
 		wantName   string
 		wantString string
+		wantFamily string
 	}{
 		{
 			name:       "returns correct info",
 			selector:   chain_selectors.APTOS_MAINNET.Selector,
 			wantString: "aptos-mainnet (4741433654826277614)",
 			wantName:   chain_selectors.APTOS_MAINNET.Name,
+			wantFamily: chain_selectors.FamilyAptos,
 		},
 	}
 
@@ -30,12 +32,13 @@ func TestChain_ChainInfot(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			provider := aptos.Chain{
+			c := aptos.Chain{
 				Selector: tt.selector,
 			}
-			assert.Equal(t, tt.selector, provider.ChainSelector())
-			assert.Equal(t, tt.wantString, provider.String())
-			assert.Equal(t, tt.wantName, provider.Name())
+			assert.Equal(t, tt.selector, c.ChainSelector())
+			assert.Equal(t, tt.wantString, c.String())
+			assert.Equal(t, tt.wantName, c.Name())
+			assert.Equal(t, tt.wantFamily, c.Family())
 		})
 	}
 }

--- a/chain/blockchain.go
+++ b/chain/blockchain.go
@@ -1,9 +1,7 @@
 package chain
 
 import (
-	"sort"
-
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"slices"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
@@ -51,6 +49,7 @@ type BlockChain interface {
 	// Name returns the name of the chain
 	Name() string
 	ChainSelector() uint64
+	Family() string
 }
 
 // EVMChains returns a map of all EVM chains with their selectors.
@@ -166,41 +165,13 @@ func (b BlockChains) ListChainSelectors(options ...ChainSelectorsOption) []uint6
 
 	for selector, chain := range b.chains {
 		// Skip if in exclusion list
-		excluded := false
-		for _, exclude := range opts.excluding {
-			if selector == exclude {
-				excluded = true
-				break
-			}
-		}
-		if excluded {
+		if slices.Contains(opts.excluding, selector) {
 			continue
 		}
 
 		// Apply family filter if specified
 		if opts.family != "" {
-			switch chain.(type) {
-			case evm.Chain:
-				if opts.family != chain_selectors.FamilyEVM {
-					continue
-				}
-			case solana.Chain:
-				if opts.family != chain_selectors.FamilySolana {
-					continue
-				}
-			case aptos.Chain:
-				if opts.family != chain_selectors.FamilyAptos {
-					continue
-				}
-			case sui.Chain:
-				if opts.family != chain_selectors.FamilySui {
-					continue
-				}
-			case ton.Chain:
-				if opts.family != chain_selectors.FamilyTon {
-					continue
-				}
-			default:
+			if opts.family != chain.Family() {
 				continue
 			}
 		}
@@ -209,9 +180,7 @@ func (b BlockChains) ListChainSelectors(options ...ChainSelectorsOption) []uint6
 	}
 
 	// Sort for consistent output
-	sort.Slice(selectors, func(i, j int) bool {
-		return selectors[i] < selectors[j]
-	})
+	slices.Sort(selectors)
 
 	return selectors
 }

--- a/chain/blockchain_test.go
+++ b/chain/blockchain_test.go
@@ -3,9 +3,10 @@ package chain_test
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
@@ -15,12 +16,12 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/ton"
 )
 
-var evmChain1 = evm.Chain{Selector: 1}
-var evmChain2 = evm.Chain{Selector: 2}
-var solanaChain1 = solana.Chain{Selector: 3}
-var aptosChain1 = aptos.Chain{Selector: 4}
-var suiChain1 = sui.Chain{Selector: 5}
-var tonChain1 = ton.Chain{Selector: 6}
+var evmChain1 = evm.Chain{Selector: chain_selectors.TEST_90000001.Selector}
+var evmChain2 = evm.Chain{Selector: chain_selectors.TEST_90000002.Selector}
+var solanaChain1 = solana.Chain{Selector: chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector}
+var aptosChain1 = aptos.Chain{Selector: chain_selectors.APTOS_LOCALNET.Selector}
+var suiChain1 = sui.Chain{Selector: chain_selectors.SUI_LOCALNET.Selector}
+var tonChain1 = ton.Chain{Selector: chain_selectors.TON_LOCALNET.Selector}
 
 func TestNewBlockChains(t *testing.T) {
 	t.Parallel()
@@ -192,8 +193,9 @@ func TestBlockChainsListChainSelectors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
 			selectors := chains.ListChainSelectors(tc.options...)
-			assert.Equal(t, tc.expectedIDs, selectors, tc.description)
+			assert.ElementsMatch(t, tc.expectedIDs, selectors, tc.description)
 		})
 	}
 }

--- a/chain/evm/evm_chain.go
+++ b/chain/evm/evm_chain.go
@@ -55,3 +55,8 @@ func (c Chain) String() string {
 func (c Chain) Name() string {
 	return chain_common.ChainMetadata{Selector: c.Selector}.Name()
 }
+
+// Family returns the family of the chain
+func (c Chain) Family() string {
+	return chain_common.ChainMetadata{Selector: c.Selector}.Family()
+}

--- a/chain/evm/evm_chain_test.go
+++ b/chain/evm/evm_chain_test.go
@@ -17,12 +17,14 @@ func TestChain_ChainInfot(t *testing.T) {
 		selector   uint64
 		wantName   string
 		wantString string
+		wantFamily string
 	}{
 		{
 			name:       "returns correct info",
 			selector:   chain_selectors.ETHEREUM_MAINNET.Selector,
 			wantString: "ethereum-mainnet (5009297550715157269)",
 			wantName:   chain_selectors.ETHEREUM_MAINNET.Name,
+			wantFamily: chain_selectors.FamilyEVM,
 		},
 	}
 
@@ -30,12 +32,13 @@ func TestChain_ChainInfot(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			provider := evm.Chain{
+			c := evm.Chain{
 				Selector: tt.selector,
 			}
-			assert.Equal(t, tt.selector, provider.ChainSelector())
-			assert.Equal(t, tt.wantString, provider.String())
-			assert.Equal(t, tt.wantName, provider.Name())
+			assert.Equal(t, tt.selector, c.ChainSelector())
+			assert.Equal(t, tt.wantString, c.String())
+			assert.Equal(t, tt.wantName, c.Name())
+			assert.Equal(t, tt.wantFamily, c.Family())
 		})
 	}
 }

--- a/chain/internal/common/chain_metadata.go
+++ b/chain/internal/common/chain_metadata.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/utils"
 )
 
@@ -38,4 +40,14 @@ func (c ChainMetadata) Name() string {
 	}
 
 	return chainInfo.ChainName
+}
+
+// Family returns the family of the chain
+func (c ChainMetadata) Family() string {
+	family, err := chain_selectors.GetSelectorFamily(c.Selector)
+	if err != nil {
+		return ""
+	}
+
+	return family
 }

--- a/chain/internal/common/chain_metadata_test.go
+++ b/chain/internal/common/chain_metadata_test.go
@@ -17,12 +17,14 @@ func TestChainInfoProvider(t *testing.T) {
 		selector   uint64
 		wantName   string
 		wantString string
+		wantFamily string
 	}{
 		{
 			name:       "returns correct info",
 			selector:   chain_selectors.ETHEREUM_MAINNET.Selector,
 			wantString: "ethereum-mainnet (5009297550715157269)",
 			wantName:   chain_selectors.ETHEREUM_MAINNET.Name,
+			wantFamily: chain_selectors.FamilyEVM,
 		},
 		{
 			name:       "returns empty for unknown chain",
@@ -36,12 +38,13 @@ func TestChainInfoProvider(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			provider := common.ChainMetadata{
+			c := common.ChainMetadata{
 				Selector: tt.selector,
 			}
-			assert.Equal(t, tt.selector, provider.ChainSelector())
-			assert.Equal(t, tt.wantString, provider.String())
-			assert.Equal(t, tt.wantName, provider.Name())
+			assert.Equal(t, tt.selector, c.ChainSelector())
+			assert.Equal(t, tt.wantString, c.String())
+			assert.Equal(t, tt.wantName, c.Name())
+			assert.Equal(t, tt.wantFamily, c.Family())
 		})
 	}
 }

--- a/chain/solana/solana_chain.go
+++ b/chain/solana/solana_chain.go
@@ -189,3 +189,8 @@ func (c Chain) String() string {
 func (c Chain) Name() string {
 	return common.ChainMetadata{Selector: c.Selector}.Name()
 }
+
+// Family returns the family of the chain
+func (c Chain) Family() string {
+	return common.ChainMetadata{Selector: c.Selector}.Family()
+}

--- a/chain/solana/solana_chain_test.go
+++ b/chain/solana/solana_chain_test.go
@@ -17,12 +17,14 @@ func TestChain_ChainInfot(t *testing.T) {
 		selector   uint64
 		wantName   string
 		wantString string
+		wantFamily string
 	}{
 		{
 			name:       "returns correct info",
 			selector:   chain_selectors.SOLANA_MAINNET.Selector,
 			wantString: "solana-mainnet (124615329519749607)",
 			wantName:   chain_selectors.SOLANA_MAINNET.Name,
+			wantFamily: chain_selectors.FamilySolana,
 		},
 	}
 
@@ -30,12 +32,13 @@ func TestChain_ChainInfot(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			provider := solana.Chain{
+			c := solana.Chain{
 				Selector: tt.selector,
 			}
-			assert.Equal(t, tt.selector, provider.ChainSelector())
-			assert.Equal(t, tt.wantString, provider.String())
-			assert.Equal(t, tt.wantName, provider.Name())
+			assert.Equal(t, tt.selector, c.ChainSelector())
+			assert.Equal(t, tt.wantString, c.String())
+			assert.Equal(t, tt.wantName, c.Name())
+			assert.Equal(t, tt.wantFamily, c.Family())
 		})
 	}
 }

--- a/chain/sui/sui_chain.go
+++ b/chain/sui/sui_chain.go
@@ -34,3 +34,8 @@ func (c Chain) String() string {
 func (c Chain) Name() string {
 	return common.ChainMetadata{Selector: c.Selector}.Name()
 }
+
+// Family returns the family of the chain
+func (c Chain) Family() string {
+	return common.ChainMetadata{Selector: c.Selector}.Family()
+}

--- a/chain/sui/sui_chain_test.go
+++ b/chain/sui/sui_chain_test.go
@@ -17,12 +17,14 @@ func TestChain_ChainInfot(t *testing.T) {
 		selector   uint64
 		wantName   string
 		wantString string
+		wantFamily string
 	}{
 		{
 			name:       "returns correct info",
 			selector:   chain_selectors.SUI_MAINNET.Selector,
 			wantString: "sui-mainnet (17529533435026248318)",
 			wantName:   chain_selectors.SUI_MAINNET.Name,
+			wantFamily: chain_selectors.FamilySui,
 		},
 	}
 
@@ -30,12 +32,13 @@ func TestChain_ChainInfot(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			provider := sui.Chain{
+			c := sui.Chain{
 				Selector: tt.selector,
 			}
-			assert.Equal(t, tt.selector, provider.ChainSelector())
-			assert.Equal(t, tt.wantString, provider.String())
-			assert.Equal(t, tt.wantName, provider.Name())
+			assert.Equal(t, tt.selector, c.ChainSelector())
+			assert.Equal(t, tt.wantString, c.String())
+			assert.Equal(t, tt.wantName, c.Name())
+			assert.Equal(t, tt.wantFamily, c.Family())
 		})
 	}
 }

--- a/chain/ton/ton_chain.go
+++ b/chain/ton/ton_chain.go
@@ -32,3 +32,8 @@ func (c Chain) String() string {
 func (c Chain) Name() string {
 	return common.ChainMetadata{Selector: c.Selector}.Name()
 }
+
+// Family returns the family of the chain
+func (c Chain) Family() string {
+	return common.ChainMetadata{Selector: c.Selector}.Family()
+}

--- a/chain/ton/ton_chain_test.go
+++ b/chain/ton/ton_chain_test.go
@@ -17,12 +17,14 @@ func TestChain_ChainInfot(t *testing.T) {
 		selector   uint64
 		wantName   string
 		wantString string
+		wantFamily string
 	}{
 		{
 			name:       "returns correct info",
 			selector:   chain_selectors.TON_MAINNET.Selector,
 			wantString: "ton-mainnet (16448340667252469081)",
 			wantName:   chain_selectors.TON_MAINNET.Name,
+			wantFamily: chain_selectors.FamilyTon,
 		},
 	}
 
@@ -30,12 +32,13 @@ func TestChain_ChainInfot(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			provider := ton.Chain{
+			c := ton.Chain{
 				Selector: tt.selector,
 			}
-			assert.Equal(t, tt.selector, provider.ChainSelector())
-			assert.Equal(t, tt.wantString, provider.String())
-			assert.Equal(t, tt.wantName, provider.Name())
+			assert.Equal(t, tt.selector, c.ChainSelector())
+			assert.Equal(t, tt.wantString, c.String())
+			assert.Equal(t, tt.wantName, c.Name())
+			assert.Equal(t, tt.wantFamily, c.Family())
 		})
 	}
 }


### PR DESCRIPTION
This change introduces a new method, `Family`, to the `Blockchain` interface and updates the chain implementations to return the family name of the respective blockchain.

This allows for better identification of the family rather than relying on the type of the chain itself.

The `ListChainSelectors` method is updated to use this method to simplify it's implementation.