### PR TITLE
fix(chains): remove unused error

### DIFF
--- a/.changeset/fuzzy-maps-rhyme.md
+++ b/.changeset/fuzzy-maps-rhyme.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix: remove unused error return value

--- a/chain/blockchain.go
+++ b/chain/blockchain.go
@@ -53,7 +53,7 @@ type BlockChain interface {
 }
 
 // EVMChains returns a map of all EVM chains with their selectors.
-func (b BlockChains) EVMChains() (map[uint64]evm.Chain, error) {
+func (b BlockChains) EVMChains() map[uint64]evm.Chain {
 	var evmChains = make(map[uint64]evm.Chain)
 	for selector, chain := range b.chains {
 		c, ok := chain.(evm.Chain)
@@ -63,11 +63,11 @@ func (b BlockChains) EVMChains() (map[uint64]evm.Chain, error) {
 		evmChains[selector] = c
 	}
 
-	return evmChains, nil
+	return evmChains
 }
 
 // SolanaChains returns a map of all Solana chains with their selectors.
-func (b BlockChains) SolanaChains() (map[uint64]solana.Chain, error) {
+func (b BlockChains) SolanaChains() map[uint64]solana.Chain {
 	var solanaChains = make(map[uint64]solana.Chain)
 	for selector, chain := range b.chains {
 		c, ok := chain.(solana.Chain)
@@ -77,11 +77,11 @@ func (b BlockChains) SolanaChains() (map[uint64]solana.Chain, error) {
 		solanaChains[selector] = c
 	}
 
-	return solanaChains, nil
+	return solanaChains
 }
 
 // AptosChains returns a map of all Aptos chains with their selectors.
-func (b BlockChains) AptosChains() (map[uint64]aptos.Chain, error) {
+func (b BlockChains) AptosChains() map[uint64]aptos.Chain {
 	var aptosChains = make(map[uint64]aptos.Chain)
 	for selector, chain := range b.chains {
 		c, ok := chain.(aptos.Chain)
@@ -91,11 +91,11 @@ func (b BlockChains) AptosChains() (map[uint64]aptos.Chain, error) {
 		aptosChains[selector] = c
 	}
 
-	return aptosChains, nil
+	return aptosChains
 }
 
 // SuiChains returns a map of all Sui chains with their selectors.
-func (b BlockChains) SuiChains() (map[uint64]sui.Chain, error) {
+func (b BlockChains) SuiChains() map[uint64]sui.Chain {
 	var suiChains = make(map[uint64]sui.Chain)
 	for selector, chain := range b.chains {
 		c, ok := chain.(sui.Chain)
@@ -105,11 +105,11 @@ func (b BlockChains) SuiChains() (map[uint64]sui.Chain, error) {
 		suiChains[selector] = c
 	}
 
-	return suiChains, nil
+	return suiChains
 }
 
 // TonChains returns a map of all Ton chains with their selectors.
-func (b BlockChains) TonChains() (map[uint64]ton.Chain, error) {
+func (b BlockChains) TonChains() map[uint64]ton.Chain {
 	var tonChains = make(map[uint64]ton.Chain)
 	for selector, chain := range b.chains {
 		c, ok := chain.(ton.Chain)
@@ -119,7 +119,7 @@ func (b BlockChains) TonChains() (map[uint64]ton.Chain, error) {
 		tonChains[selector] = c
 	}
 
-	return tonChains, nil
+	return tonChains
 }
 
 // ChainSelectorsOption defines a function type for configuring ChainSelectors

--- a/chain/blockchain_test.go
+++ b/chain/blockchain_test.go
@@ -52,8 +52,7 @@ func TestBlockChainsEVMChains(t *testing.T) {
 
 	chains := buildBlockChains()
 
-	evmChains, err := chains.EVMChains()
-	require.NoError(t, err)
+	evmChains := chains.EVMChains()
 
 	assert.Len(t, evmChains, 2, "expected 2 EVM chains")
 
@@ -69,8 +68,7 @@ func TestBlockChainsSolanaChains(t *testing.T) {
 
 	chains := buildBlockChains()
 
-	solanaChains, err := chains.SolanaChains()
-	require.NoError(t, err)
+	solanaChains := chains.SolanaChains()
 
 	assert.Len(t, solanaChains, 1, "expected 1 Solana chain")
 
@@ -83,8 +81,7 @@ func TestBlockChainsAptosChains(t *testing.T) {
 
 	chains := buildBlockChains()
 
-	aptosChains, err := chains.AptosChains()
-	require.NoError(t, err)
+	aptosChains := chains.AptosChains()
 
 	assert.Len(t, aptosChains, 1, "expected 1 Aptos chain")
 
@@ -97,8 +94,7 @@ func TestBlockChainsSuiChains(t *testing.T) {
 
 	chains := buildBlockChains()
 
-	suiChains, err := chains.SuiChains()
-	require.NoError(t, err)
+	suiChains := chains.SuiChains()
 
 	assert.Len(t, suiChains, 1, "expected 1 Sui chain")
 
@@ -111,8 +107,7 @@ func TestBlockChainsTonChains(t *testing.T) {
 
 	chains := buildBlockChains()
 
-	tonChains, err := chains.TonChains()
-	require.NoError(t, err)
+	tonChains := chains.TonChains()
 
 	assert.Len(t, tonChains, 1, "expected 1 Ton chain")
 


### PR DESCRIPTION
blockchain getter functions return value for error is always nil, so it is not used at all, lets get rid of it.