### PR TITLE
fix: Update SUI & Ton to compose ChainMetadata

### DIFF
--- a/.changeset/ninety-bottles-ring.md
+++ b/.changeset/ninety-bottles-ring.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+chains: update sui & ton to compose ChainMetadata

--- a/chain/aptos/aptos_chain.go
+++ b/chain/aptos/aptos_chain.go
@@ -17,6 +17,9 @@ type Chain struct {
 	Confirm func(txHash string, opts ...any) error
 }
 
+// Author note: Have to implement the blockhain interface methods explicitly below
+// instead of composing the ChainMetadata struct to avoid breaking change since there are existing usage.
+
 // ChainSelector returns the chain selector of the chain
 func (c Chain) ChainSelector() uint64 {
 	return c.Selector

--- a/chain/blockchain_test.go
+++ b/chain/blockchain_test.go
@@ -20,8 +20,8 @@ var evmChain1 = evm.Chain{Selector: chain_selectors.TEST_90000001.Selector}
 var evmChain2 = evm.Chain{Selector: chain_selectors.TEST_90000002.Selector}
 var solanaChain1 = solana.Chain{Selector: chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector}
 var aptosChain1 = aptos.Chain{Selector: chain_selectors.APTOS_LOCALNET.Selector}
-var suiChain1 = sui.Chain{Selector: chain_selectors.SUI_LOCALNET.Selector}
-var tonChain1 = ton.Chain{Selector: chain_selectors.TON_LOCALNET.Selector}
+var suiChain1 = sui.Chain{ChainMetadata: sui.ChainMetadata{Selector: chain_selectors.SUI_LOCALNET.Selector}}
+var tonChain1 = ton.Chain{ChainMetadata: ton.ChainMetadata{Selector: chain_selectors.TON_LOCALNET.Selector}}
 
 func TestNewBlockChains(t *testing.T) {
 	t.Parallel()

--- a/chain/evm/evm_chain.go
+++ b/chain/evm/evm_chain.go
@@ -41,6 +41,9 @@ type Chain struct {
 	DeployerKeyZkSyncVM *accounts.Wallet
 }
 
+// Author note: Have to implement the blockhain interface methods explicitly below
+// instead of composing the ChainMetadata struct to avoid breaking change since there are existing usage.
+
 // ChainSelector returns the chain selector of the chain
 func (c Chain) ChainSelector() uint64 {
 	return c.Selector

--- a/chain/internal/common/chain_metadata_test.go
+++ b/chain/internal/common/chain_metadata_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/common"
 )
 
-func TestChainInfoProvider(t *testing.T) {
+func TestChainMetadata(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/chain/solana/solana_chain.go
+++ b/chain/solana/solana_chain.go
@@ -175,6 +175,9 @@ func parseProgramID(output string, prefix string) (string, error) {
 	return output[startIdx : startIdx+endIdx], nil
 }
 
+// Author note: Have to implement the blockhain interface methods explicitly below
+// instead of composing the ChainMetadata struct to avoid breaking change since there are existing usage.
+
 // ChainSelector returns the chain selector of the chain
 func (c Chain) ChainSelector() uint64 {
 	return c.Selector

--- a/chain/sui/sui_chain.go
+++ b/chain/sui/sui_chain.go
@@ -8,34 +8,16 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/common"
 )
 
+type ChainMetadata = common.ChainMetadata
+
 // Chain represents an Sui chain.
 type Chain struct {
-	Selector uint64
-	Client   *suiclient.ClientImpl
+	ChainMetadata
+	Client *suiclient.ClientImpl
 	// TODO: sui-go currently does not have a working Signer interface, so we
 	// have the raw private key for now.
 	DeployerKey ed25519.PrivateKey
 	URL         string
 
 	Confirm func(txHash string, opts ...any) error
-}
-
-// ChainSelector returns the chain selector of the chain
-func (c Chain) ChainSelector() uint64 {
-	return c.Selector
-}
-
-// String returns chain name and selector "<name> (<selector>)"
-func (c Chain) String() string {
-	return common.ChainMetadata{Selector: c.Selector}.String()
-}
-
-// Name returns the name of the chain
-func (c Chain) Name() string {
-	return common.ChainMetadata{Selector: c.Selector}.Name()
-}
-
-// Family returns the family of the chain
-func (c Chain) Family() string {
-	return common.ChainMetadata{Selector: c.Selector}.Family()
 }

--- a/chain/sui/sui_chain_test.go
+++ b/chain/sui/sui_chain_test.go
@@ -33,7 +33,7 @@ func TestChain_ChainInfot(t *testing.T) {
 			t.Parallel()
 
 			c := sui.Chain{
-				Selector: tt.selector,
+				ChainMetadata: sui.ChainMetadata{Selector: tt.selector},
 			}
 			assert.Equal(t, tt.selector, c.ChainSelector())
 			assert.Equal(t, tt.wantString, c.String())

--- a/chain/ton/ton_chain.go
+++ b/chain/ton/ton_chain.go
@@ -8,32 +8,14 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/common"
 )
 
+type ChainMetadata = common.ChainMetadata
+
 // Chain represents a TON chain.
 type Chain struct {
-	Selector      uint64           // Canonical chain identifier
+	ChainMetadata                  // Contains canonical chain identifier
 	Client        *ton.APIClient   // RPC client via Lite Server
 	Wallet        *wallet.Wallet   // Wallet abstraction (signing, sending)
 	WalletAddress *address.Address // Address of deployer wallet
 	URL           string           // Liteserver URL
 	DeployerSeed  string           // Optional: mnemonic or raw seed
-}
-
-// ChainSelector returns the chain selector of the chain
-func (c Chain) ChainSelector() uint64 {
-	return c.Selector
-}
-
-// String returns chain name and selector "<name> (<selector>)"
-func (c Chain) String() string {
-	return common.ChainMetadata{Selector: c.Selector}.String()
-}
-
-// Name returns the name of the chain
-func (c Chain) Name() string {
-	return common.ChainMetadata{Selector: c.Selector}.Name()
-}
-
-// Family returns the family of the chain
-func (c Chain) Family() string {
-	return common.ChainMetadata{Selector: c.Selector}.Family()
 }

--- a/chain/ton/ton_chain_test.go
+++ b/chain/ton/ton_chain_test.go
@@ -33,7 +33,7 @@ func TestChain_ChainInfot(t *testing.T) {
 			t.Parallel()
 
 			c := ton.Chain{
-				Selector: tt.selector,
+				ChainMetadata: ton.ChainMetadata{Selector: tt.selector},
 			}
 			assert.Equal(t, tt.selector, c.ChainSelector())
 			assert.Equal(t, tt.wantString, c.String())


### PR DESCRIPTION
The original intention was not to compose ChainMetadata and just use it directly by explicitly implementing the ChainMetadata interface and calling ChainMetadatato avoid breaking existing compatibility with EVM, SOL and APTOS and also the clunky initiation code.

However this introduces some duplication across all chains.

So the compromise is to still have the duplication in the existing chains but for new chains, they will compose the ChainMetadata and to avoid referencing another package for the ChainMetadata (clunky), the type alias is introduced.