### PR TITLE
feat(datastore): Implement Stringer for ContractMetadata and AddressRef Keys

### DIFF
--- a/.changeset/early-forks-dress.md
+++ b/.changeset/early-forks-dress.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+feat(datastore): Implement Stringer for ContractMetadata and AddressRef Keys

--- a/datastore/address_ref_key.go
+++ b/datastore/address_ref_key.go
@@ -1,6 +1,8 @@
 package datastore
 
 import (
+	"fmt"
+
 	"github.com/Masterminds/semver/v3"
 )
 
@@ -8,6 +10,7 @@ import (
 // It is used to uniquely identify a record in the AddressRefStore.
 type AddressRefKey interface {
 	Comparable[AddressRefKey]
+	fmt.Stringer
 
 	// ChainSelector returns the chain-selector selector of the chain where the contract is deployed.
 	ChainSelector() uint64
@@ -52,6 +55,16 @@ func (a addressRefKey) Equals(other AddressRefKey) bool {
 		a.contractType == other.Type() &&
 		a.version.Equal(other.Version()) &&
 		a.qualifier == other.Qualifier()
+}
+
+// String returns a string representation of the addressRefKey.
+func (a addressRefKey) String() string {
+	return fmt.Sprintf("%d_%s_%s_%s",
+		a.chainSelector,
+		a.contractType,
+		a.version.String(),
+		a.qualifier,
+	)
 }
 
 // NewAddressRefKey creates a new AddressRefKey instance.

--- a/datastore/address_ref_key_test.go
+++ b/datastore/address_ref_key_test.go
@@ -68,3 +68,11 @@ func TestNewAddressRefKey(t *testing.T) {
 	assert.Equal(t, version, key.Version(), "Version should match")
 	assert.Equal(t, "qualifier1", key.Qualifier(), "Qualifier should match")
 }
+
+func TestAddressRefKey_String(t *testing.T) {
+	t.Parallel()
+
+	key := NewAddressRefKey(42, ContractType("MyType"), semver.MustParse("1.2.3"), "qual")
+	expected := "42_MyType_1.2.3_qual"
+	assert.Equal(t, expected, key.String())
+}

--- a/datastore/contract_metadata_key.go
+++ b/datastore/contract_metadata_key.go
@@ -1,9 +1,12 @@
 package datastore
 
+import "fmt"
+
 // ContractMetadataKey is an interface that represents a key for ContractMetadata records.
 // It is used to uniquely identify a record in the ContractMetadataStore.
 type ContractMetadataKey interface {
 	Comparable[ContractMetadataKey]
+	fmt.Stringer
 
 	// Address returns the address of the contract on the chain.
 	Address() string
@@ -31,6 +34,11 @@ func (c contractMetadataKey) Address() string { return c.address }
 func (c contractMetadataKey) Equals(other ContractMetadataKey) bool {
 	return c.chainSelector == other.ChainSelector() &&
 		c.address == other.Address()
+}
+
+// String returns a string representation of the ContractMetadataKey.
+func (c contractMetadataKey) String() string {
+	return fmt.Sprintf("%d_%s", c.chainSelector, c.address)
 }
 
 // NewContractMetadataKey creates a new ContractMetadataKey instance.

--- a/datastore/contract_metadata_key_test.go
+++ b/datastore/contract_metadata_key_test.go
@@ -61,3 +61,11 @@ func TestContractMetadataKey(t *testing.T) {
 	require.Equal(t, chainSelector, key.ChainSelector(), "ChainSelector should return the correct chain selector")
 	require.Equal(t, address, key.Address(), "Address should return the correct address")
 }
+
+func TestContractMetadataKey_String(t *testing.T) {
+	t.Parallel()
+
+	key := NewContractMetadataKey(99, "0xabc")
+	expected := "99_0xabc"
+	require.Equal(t, expected, key.String())
+}


### PR DESCRIPTION
This pull request introduces enhancements to the `datastore` package by implementing the `fmt.Stringer` interface for key types and adding corresponding unit tests. These changes improve the readability and debugging of key representations.

### Enhancements to key types:

* [`datastore/address_ref_key.go`](diffhunk://#diff-a8f748a3f09f8874d72a162c5254eff51b1666cedf9059510125a0c4daf5f2e3R4-R13): Added the `fmt.Stringer` interface to the `AddressRefKey` type, including a new `String` method that provides a formatted string representation of the key. [[1]](diffhunk://#diff-a8f748a3f09f8874d72a162c5254eff51b1666cedf9059510125a0c4daf5f2e3R4-R13) [[2]](diffhunk://#diff-a8f748a3f09f8874d72a162c5254eff51b1666cedf9059510125a0c4daf5f2e3R60-R69)
* [`datastore/contract_metadata_key.go`](diffhunk://#diff-d9574b8aedc2795d729a5c1d72ecf6974755c0cb3b4642b28a74e370e9d5a150R3-R9): Added the `fmt.Stringer` interface to the `ContractMetadataKey` type, including a new `String` method that provides a formatted string representation of the key. [[1]](diffhunk://#diff-d9574b8aedc2795d729a5c1d72ecf6974755c0cb3b4642b28a74e370e9d5a150R3-R9) [[2]](diffhunk://#diff-d9574b8aedc2795d729a5c1d72ecf6974755c0cb3b4642b28a74e370e9d5a150R39-R43)
