### PR TITLE
feat(operations): add useful params to inputhook

### DIFF
--- a/.changeset/sour-mangos-roll.md
+++ b/.changeset/sour-mangos-roll.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat: expose error and attempts on the inputHook

--- a/operations/execute_test.go
+++ b/operations/execute_test.go
@@ -67,7 +67,8 @@ func Test_ExecuteOperation(t *testing.T) {
 		{
 			name: "NewInputHook",
 			options: []ExecuteOption[int, any]{
-				WithRetryInput(func(input int, deps any) int {
+				WithRetryInput(func(attempt uint, err error, input int, deps any) int {
+					require.ErrorContains(t, err, "test error")
 					// update input to 5 after first failed attempt
 					return 5
 				}),


### PR DESCRIPTION
The number of attempts and error can be useful to allow user to decide for example gas number for the next attempt.