### PR TITLE
feat(operations): allow force run

### DIFF
--- a/.changeset/short-donuts-shine.md
+++ b/.changeset/short-donuts-shine.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+operations api: allow force run

--- a/operations/report.go
+++ b/operations/report.go
@@ -21,6 +21,8 @@ type Report[IN, OUT any] struct {
 	Err       *ReportError `json:"error"`
 	// stores a list of report ID for an operation that was executed as part of a sequence.
 	ChildOperationReports []string `json:"childOperationReports"`
+	// indicates if the operation was forced to run even if the same op was run previously with the same input.
+	Forced bool `json:"forced,omitempty"`
 }
 
 // ToGenericReport converts the Report to a generic Report.
@@ -258,6 +260,7 @@ func genericReport[IN, OUT any](r Report[IN, OUT]) Report[any, any] {
 		Timestamp:             r.Timestamp,
 		Err:                   r.Err,
 		ChildOperationReports: r.ChildOperationReports,
+		Forced:                r.Forced,
 	}
 }
 
@@ -288,11 +291,13 @@ func typeReport[IN, OUT any](r Report[any, any]) (Report[IN, OUT], bool) {
 	}
 
 	return Report[IN, OUT]{
-		ID:        r.ID,
-		Def:       r.Def,
-		Output:    output,
-		Input:     input,
-		Timestamp: r.Timestamp,
-		Err:       r.Err,
+		ID:                    r.ID,
+		Def:                   r.Def,
+		Output:                output,
+		Input:                 input,
+		Timestamp:             r.Timestamp,
+		Err:                   r.Err,
+		ChildOperationReports: r.ChildOperationReports,
+		Forced:                r.Forced,
 	}, true
 }

--- a/operations/report_test.go
+++ b/operations/report_test.go
@@ -78,6 +78,7 @@ func Test_NewReport(t *testing.T) {
 	require.ErrorContains(t, report.Err, testErr.Error())
 	assert.Len(t, report.ChildOperationReports, 1)
 	assert.Equal(t, childOperationID, report.ChildOperationReports[0])
+	assert.False(t, report.Forced)
 }
 
 func Test_RecentReporter(t *testing.T) {
@@ -131,10 +132,20 @@ func Test_typeReport(t *testing.T) {
 		Timestamp:             &now,
 		Err:                   nil,
 		ChildOperationReports: []string{uuid.New().String()},
+		Forced:                true,
 	}
 
-	_, ok := typeReport[map[string]interface{}, float64](report)
+	res, ok := typeReport[map[string]interface{}, float64](report)
 	assert.True(t, ok)
+	assert.Equal(t, "1", res.ID)
+	assert.Equal(t, Definition{}, res.Def)
+	assert.Equal(t, map[string]interface{}{"a": float64(1)}, res.Input)
+	assert.InEpsilon(t, float64(2), res.Output, 0)
+	assert.Equal(t, &now, res.Timestamp)
+	assert.Nil(t, res.Err)
+	assert.Len(t, res.ChildOperationReports, 1)
+	assert.Equal(t, report.ChildOperationReports[0], res.ChildOperationReports[0])
+	assert.True(t, res.Forced)
 
 	// supports unmarshalling into a different type as long it is compatible
 	_, ok = typeReport[Input, int](report)
@@ -225,6 +236,7 @@ func Test_Report_ToGenericReport(t *testing.T) {
 		Timestamp:             &now,
 		Err:                   nil,
 		ChildOperationReports: []string{uuid.New().String()},
+		Forced:                true,
 	}
 
 	r := report.ToGenericReport()
@@ -235,6 +247,7 @@ func Test_Report_ToGenericReport(t *testing.T) {
 	assert.Equal(t, report.Timestamp, r.Timestamp)
 	assert.Equal(t, report.Err, r.Err)
 	assert.Equal(t, report.ChildOperationReports, r.ChildOperationReports)
+	assert.True(t, r.Forced)
 }
 
 func Test_SequenceReport_ToGenericReport(t *testing.T) {


### PR DESCRIPTION
There is a scenario discovered when an operation with same input has to be run multiple times, eg when deploying the same MCMS contract so it can be associated with different roles.

This commit introduces a new functional option for executeOperation that allow users to force run regardless of previous successful execution.

```
		linkDeployReport, err := operations.ExecuteOperation(
			b, DeployLinkOp, deps, operations.EmptyInput{},
			operations.WithForceRun[operations.EmptyInput, EthereumDeps](),
		)
```

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-302