### PR TITLE
feat(datastore): removes Clone requirement for custom metadata types

### DIFF
--- a/.changeset/silver-rules-add.md
+++ b/.changeset/silver-rules-add.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+feat(datastore): removes Clone requirement for custom metadata types

--- a/datastore/abstract.go
+++ b/datastore/abstract.go
@@ -1,13 +1,5 @@
 package datastore
 
-// Cloneable provides a Clone() method which returns a semi-deep copy of the type.
-type Cloneable[R any] interface {
-	// Clone() returns a semi-deep copy of the type. The implementation should call Clone() on
-	// any nested Cloneable fields, and perform a shallow copy of any slices or maps.
-	// NOTE: Handling non-Cloneable references to Cloneable types is beyond the intended scope of this interface.
-	Clone() R
-}
-
 // Comparable provides an Equals() method which returns true if the two instances are equal, false otherwise.
 type Comparable[T any] interface {
 	// Equals()	returns true if the two instances are equal, false otherwise.
@@ -29,11 +21,6 @@ type Getter[K Comparable[K], R UniqueRecord[K, R]] interface {
 	Get(K) (R, error)
 }
 
-// Record represents a data entry that can be cloned.
-type Record[R any] interface {
-	Cloneable[R]
-}
-
 // PrimaryKeyHolder is an interface for types that can provide a unique identifier key for themselves.
 type PrimaryKeyHolder[K Comparable[K]] interface {
 	// Key() returns the primary key for the implementing type.
@@ -42,7 +29,6 @@ type PrimaryKeyHolder[K Comparable[K]] interface {
 
 // UniqueRecord represents a data entry that is both Cloneable and uniquely identifiable by its primary key.
 type UniqueRecord[K Comparable[K], R PrimaryKeyHolder[K]] interface {
-	Cloneable[R]
 	PrimaryKeyHolder[K]
 }
 
@@ -82,7 +68,7 @@ type MutableStore[K Comparable[K], R UniqueRecord[K, R]] interface {
 }
 
 // UnaryStore is an interface that represents a read-only store that is limited to a single record.
-type UnaryStore[R Record[R]] interface {
+type UnaryStore[R any] interface {
 	// Get returns the record or an error.
 	// if the record exists, the error should be nil.
 	// If the record does not exist, the error should not be nil.
@@ -90,7 +76,7 @@ type UnaryStore[R Record[R]] interface {
 }
 
 // MutableUnaryStore is an interface that represents a mutable store that contains a single record.
-type MutableUnaryStore[R Record[R]] interface {
+type MutableUnaryStore[R any] interface {
 	// Get returns a copy of the record or an error.
 	// If the record exists, the error should be nil.
 	// If the record does not exist, the error should not be nil.

--- a/datastore/clone.go
+++ b/datastore/clone.go
@@ -1,0 +1,28 @@
+package datastore
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// clone creates a copy of the given value using JSON serialization.
+// It returns the cloned value or an error if the cloning process fails.
+func clone[T any](v T) (T, error) {
+	var zero T
+	b, err := json.Marshal(v)
+	if err != nil {
+		return zero, err
+	}
+
+	// Use a JSON decoder to handle numbers as json.Number
+	// This allows us to preserve the original types of numbers during unmarshaling.
+	// This is particularly useful for large integers that might not fit into standard int types.
+	var clone T
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	decoder.UseNumber()
+	if err = decoder.Decode(&clone); err != nil {
+		return zero, err
+	}
+
+	return clone, err
+}

--- a/datastore/clone_test.go
+++ b/datastore/clone_test.go
@@ -1,0 +1,57 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+)
+
+type testStruct struct {
+	A uint64
+	B string
+	C []int
+}
+
+type chanStruct struct {
+	A  uint64
+	Ch chan int
+}
+
+func TestClone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    any
+		wantErr string
+	}{
+		{
+			name: "simple struct",
+			give: testStruct{A: chain_selectors.APTOS_MAINNET.Selector, B: "foo", C: []int{1, 2, 3}},
+		},
+		{
+			name:    "struct with channel",
+			give:    chanStruct{A: chain_selectors.APTOS_MAINNET.Selector, Ch: make(chan int)},
+			wantErr: "json: unsupported type: chan int",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clone, err := clone(tt.give)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err, "clone should not return an error for %s", tt.name)
+				typed, err := As[testStruct](clone)
+				require.NoError(t, err, "As should not return an error for %s", tt.name)
+				require.Equal(t, tt.give, typed)
+			}
+		})
+	}
+}

--- a/datastore/contract_metadata.go
+++ b/datastore/contract_metadata.go
@@ -11,7 +11,7 @@ var _ UniqueRecord[ContractMetadataKey, ContractMetadata[DefaultMetadata]] = Con
 // ContractMetadata is a generic struct that holds the metadata for a contract on a specific chain.
 // It implements the Record interface and is used to store contract metadata in the datastore.
 // The metadata is generic and can be of any type that implements the Cloneable interface.
-type ContractMetadata[M Cloneable[M]] struct {
+type ContractMetadata[M any] struct {
 	// Address is the address of the contract on the chain.
 	Address string `json:"address"`
 	// ChainSelector is the chain-selector of the chain where the contract is deployed.
@@ -23,12 +23,17 @@ type ContractMetadata[M Cloneable[M]] struct {
 
 // Clone creates a copy of the ContractMetadata.
 // The Metadata field is cloned using the Clone method of the Cloneable interface.
-func (r ContractMetadata[M]) Clone() ContractMetadata[M] {
+func (r ContractMetadata[M]) Clone() (ContractMetadata[M], error) {
+	metaClone, err := clone(r.Metadata)
+	if err != nil {
+		return ContractMetadata[M]{}, err
+	}
+
 	return ContractMetadata[M]{
 		ChainSelector: r.ChainSelector,
 		Address:       r.Address,
-		Metadata:      r.Metadata.Clone(),
-	}
+		Metadata:      metaClone,
+	}, nil
 }
 
 // Key returns the ContractMetadataKey for the ContractMetadata.

--- a/datastore/contract_metadata_test.go
+++ b/datastore/contract_metadata_test.go
@@ -15,7 +15,8 @@ func TestContractMetadata_Clone(t *testing.T) {
 		Metadata:      DefaultMetadata{Data: "test data"},
 	}
 
-	cloned := original.Clone()
+	cloned, err := original.Clone()
+	require.NoError(t, err, "Clone should not return an error")
 
 	require.Equal(t, original.ChainSelector, cloned.ChainSelector)
 	require.Equal(t, original.Address, cloned.Address)

--- a/datastore/env_metadata.go
+++ b/datastore/env_metadata.go
@@ -4,10 +4,7 @@ import "errors"
 
 var ErrEnvMetadataNotSet = errors.New("no environment metadata set")
 
-// EnvMetadata implements the Record interface
-var _ Record[EnvMetadata[DefaultMetadata]] = EnvMetadata[DefaultMetadata]{}
-
-type EnvMetadata[M Cloneable[M]] struct {
+type EnvMetadata[M any] struct {
 	// Metadata is the metadata associated with the domain and environment.
 	// It is a generic type that can be of any type that implements the Cloneable interface.
 	Metadata M `json:"metadata"`
@@ -15,8 +12,14 @@ type EnvMetadata[M Cloneable[M]] struct {
 
 // Clone creates a copy of the EnvMetadata.
 // The Metadata field is cloned using the Clone method of the Cloneable interface.
-func (r EnvMetadata[M]) Clone() EnvMetadata[M] {
-	return EnvMetadata[M]{
-		Metadata: r.Metadata.Clone(),
+func (r EnvMetadata[M]) Clone() (EnvMetadata[M], error) {
+	metaClone, err := clone(r.Metadata)
+	if err != nil {
+		// If cloning fails, we return an empty EnvMetadata with the error.
+		return EnvMetadata[M]{}, err
 	}
+
+	return EnvMetadata[M]{
+		Metadata: metaClone,
+	}, nil
 }

--- a/datastore/env_metadata_test.go
+++ b/datastore/env_metadata_test.go
@@ -13,7 +13,8 @@ func TestEnvMetadata_Clone(t *testing.T) {
 		Metadata: DefaultMetadata{Data: "test-value"},
 	}
 
-	cloned := original.Clone()
+	cloned, err := original.Clone()
+	require.NoError(t, err, "Clone should not return an error")
 
 	require.Equal(t, original.Metadata, cloned.Metadata)
 	require.NotSame(t, &original.Metadata, &cloned.Metadata) // Ensure Metadata is a deep copy

--- a/datastore/filters.go
+++ b/datastore/filters.go
@@ -75,7 +75,7 @@ func AddressRefByQualifier(qualifier string) FilterFunc[AddressRefKey, AddressRe
 }
 
 // ContractMetadataByChainSelector returns a filter that only includes records with the provided chain.
-func ContractMetadataByChainSelector[M Cloneable[M]](chainSelector uint64) FilterFunc[ContractMetadataKey, ContractMetadata[M]] {
+func ContractMetadataByChainSelector[M any](chainSelector uint64) FilterFunc[ContractMetadataKey, ContractMetadata[M]] {
 	return func(records []ContractMetadata[M]) []ContractMetadata[M] {
 		filtered := make([]ContractMetadata[M], 0, len(records)) // Pre-allocate capacity
 		for _, record := range records {

--- a/datastore/memory_datastore.go
+++ b/datastore/memory_datastore.go
@@ -19,8 +19,7 @@ type Sealer[T any] interface {
 // BaseDataStore is an interface that defines the basic operations for a data store.
 // It is parameterized by the type of address reference store and contract metadata store it uses.
 type BaseDataStore[
-	T Cloneable[T],
-	U Cloneable[U],
+	T, U any,
 	R AddressRefStore, CM ContractMetadataStore[T], EM EnvMetadataStore[U],
 ] interface {
 	Addresses() R
@@ -29,12 +28,12 @@ type BaseDataStore[
 }
 
 // DataStore is an interface that defines the operations for a read-only data store.
-type DataStore[T Cloneable[T], U Cloneable[U]] interface {
+type DataStore[T, U any] interface {
 	BaseDataStore[T, U, AddressRefStore, ContractMetadataStore[T], EnvMetadataStore[U]]
 }
 
 // MutableDataStore is an interface that defines the operations for a mutable data store.
-type MutableDataStore[T Cloneable[T], U Cloneable[U]] interface {
+type MutableDataStore[T any, U any] interface {
 	Merger[DataStore[T, U]]
 	Sealer[DataStore[T, U]]
 
@@ -44,7 +43,7 @@ type MutableDataStore[T Cloneable[T], U Cloneable[U]] interface {
 // MemoryDataStore is a concrete implementation of the MutableDataStore interface.
 var _ MutableDataStore[DefaultMetadata, DefaultMetadata] = &MemoryDataStore[DefaultMetadata, DefaultMetadata]{}
 
-type MemoryDataStore[CM Cloneable[CM], EM Cloneable[EM]] struct {
+type MemoryDataStore[CM any, EM any] struct {
 	AddressRefStore       *MemoryAddressRefStore           `json:"addressRefStore"`
 	ContractMetadataStore *MemoryContractMetadataStore[CM] `json:"contractMetadataStore"`
 	EnvMetadataStore      *MemoryEnvMetadataStore[EM]      `json:"envMetadataStore"`
@@ -52,7 +51,7 @@ type MemoryDataStore[CM Cloneable[CM], EM Cloneable[EM]] struct {
 
 // NewMemoryDataStore creates a new instance of MemoryDataStore.
 // NOTE: The instance returned is mutable and can be modified.
-func NewMemoryDataStore[CM Cloneable[CM], EM Cloneable[EM]]() *MemoryDataStore[CM, EM] {
+func NewMemoryDataStore[CM any, EM any]() *MemoryDataStore[CM, EM] {
 	return &MemoryDataStore[CM, EM]{
 		AddressRefStore:       NewMemoryAddressRefStore(),
 		ContractMetadataStore: NewMemoryContractMetadataStore[CM](),
@@ -134,7 +133,7 @@ func (s *MemoryDataStore[CM, EM]) Merge(other DataStore[CM, EM]) error {
 // It represents a sealed data store that cannot be modified further.
 var _ DataStore[DefaultMetadata, DefaultMetadata] = &sealedMemoryDataStore[DefaultMetadata, DefaultMetadata]{}
 
-type sealedMemoryDataStore[CM Cloneable[CM], EM Cloneable[EM]] struct {
+type sealedMemoryDataStore[CM any, EM any] struct {
 	AddressRefStore       *MemoryAddressRefStore           `json:"addressRefStore"`
 	ContractMetadataStore *MemoryContractMetadataStore[CM] `json:"contractMetadataStore"`
 	EnvMetadataStore      *MemoryEnvMetadataStore[EM]      `json:"envMetadataStore"`

--- a/datastore/memory_env_metadata_store.go
+++ b/datastore/memory_env_metadata_store.go
@@ -5,17 +5,17 @@ import (
 )
 
 // EnvMetadataStore is an interface that defines the methods for a store that manages environment metadata.
-type EnvMetadataStore[M Cloneable[M]] interface {
+type EnvMetadataStore[M any] interface {
 	UnaryStore[EnvMetadata[M]]
 }
 
 // MutableEnvMetadataStore is an interface that defines the methods for a mutable store that manages environment metadata.
-type MutableEnvMetadataStore[M Cloneable[M]] interface {
+type MutableEnvMetadataStore[M any] interface {
 	MutableUnaryStore[EnvMetadata[M]]
 }
 
 // MemoryEnvMetadataStore is a concrete implementation of the EnvMetadataStore interface.
-type MemoryEnvMetadataStore[M Cloneable[M]] struct {
+type MemoryEnvMetadataStore[M any] struct {
 	mu     sync.RWMutex
 	Record *EnvMetadata[M] `json:"record"`
 }
@@ -27,7 +27,7 @@ var _ EnvMetadataStore[DefaultMetadata] = &MemoryEnvMetadataStore[DefaultMetadat
 var _ MutableEnvMetadataStore[DefaultMetadata] = &MemoryEnvMetadataStore[DefaultMetadata]{}
 
 // NewMemoryEnvMetadataStore creates a new MemoryEnvMetadataStore instance.
-func NewMemoryEnvMetadataStore[M Cloneable[M]]() *MemoryEnvMetadataStore[M] {
+func NewMemoryEnvMetadataStore[M any]() *MemoryEnvMetadataStore[M] {
 	return &MemoryEnvMetadataStore[M]{Record: nil}
 }
 
@@ -42,7 +42,7 @@ func (s *MemoryEnvMetadataStore[M]) Get() (EnvMetadata[M], error) {
 		return EnvMetadata[M]{}, ErrEnvMetadataNotSet
 	}
 
-	return s.Record.Clone(), nil
+	return s.Record.Clone()
 }
 
 // Set sets the EnvMetadata record in the store. If the record already exists, it will be replaced.

--- a/datastore/transform.go
+++ b/datastore/transform.go
@@ -9,7 +9,7 @@ import (
 // ToDefault is a utility function that converts a DataStore with domain specific
 // metadata types into a DataStore with DefaultMetadata types.
 // NOTE: It is assumed that the domain specific metadata types are JSON serializable.
-func ToDefault[CM Cloneable[CM], EM Cloneable[EM]](
+func ToDefault[CM any, EM any](
 	dataStore DataStore[CM, EM],
 ) (MutableDataStore[DefaultMetadata, DefaultMetadata], error) {
 	converted := NewMemoryDataStore[DefaultMetadata, DefaultMetadata]()
@@ -90,7 +90,7 @@ func ToDefault[CM Cloneable[CM], EM Cloneable[EM]](
 // FromDefault is a utility function that converts a DataStore with DefaultMetadata types
 // into a DataStore with domain specific metadata types.
 // NOTE: It is assumed that the domain specific metadata types are JSON deserializable.
-func FromDefault[CM Cloneable[CM], EM Cloneable[EM]](
+func FromDefault[CM any, EM any](
 	defaultStore DataStore[DefaultMetadata, DefaultMetadata],
 ) (DataStore[CM, EM], error) {
 	converted := NewMemoryDataStore[CM, EM]()
@@ -165,4 +165,19 @@ func FromDefault[CM Cloneable[CM], EM Cloneable[EM]](
 	}
 
 	return converted.Seal(), nil
+}
+
+// As is a utility function that converts a source value of any type to a destination type T.
+// It uses JSON marshaling and unmarshaling to perform the conversion.
+func As[T any](src any) (T, error) {
+	var zero T
+	bytes, err := json.Marshal(src)
+	if err != nil {
+		return zero, err
+	}
+
+	var dst T
+	err = json.Unmarshal(bytes, &dst)
+
+	return dst, err
 }


### PR DESCRIPTION
This PR simplifies `datastore` custom metadata handling by removing the need for users to implement Clone.
We now provide a built-in generic Clone implementation using Go’s JSON serialization, based on the assumption that all metadata types are JSON-serializable, which has always been the case.