### PR TITLE
refactor: use chain sel from loop instead of chain.ChainSelector()

### DIFF
--- a/.changeset/four-phones-take.md
+++ b/.changeset/four-phones-take.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+refactor: use chain sel from loop instead of chain.ChainSelector()

--- a/chain/blockchain.go
+++ b/chain/blockchain.go
@@ -190,17 +190,17 @@ func (b BlockChains) ListChainSelectors(options ...ChainSelectorsOption) []uint6
 // It handles both value and pointer types, allowing for flexibility in how chains are stored.
 func getChainsByType[VT any, PT any](b BlockChains) map[uint64]VT {
 	chains := make(map[uint64]VT, len(b.chains))
-	for _, chain := range b.chains {
+	for sel, chain := range b.chains {
 		switch c := any(chain).(type) {
 		case VT:
-			chains[chain.ChainSelector()] = c
+			chains[sel] = c
 		case PT:
 			val := reflect.ValueOf(c)
 			if val.Kind() == reflect.Ptr && !val.IsNil() {
 				elem := val.Elem()
 				if elem.CanInterface() {
 					if v, ok := elem.Interface().(VT); ok {
-						chains[chain.ChainSelector()] = v
+						chains[sel] = v
 					}
 				}
 			}


### PR DESCRIPTION
No behaviour change, i had to do this because in Chainlink, there are many tests where they do
```
 cldf_chain.NewBlockChains(map[uint64]cldf_chain.BlockChain{
		chainselectors.SOLANA_DEVNET.Selector: cldf_solana.Chain{},
	})
```

So when we do .EVMChains(), the chainselector is 0 because cldf_solana.Chain{} is set to default value.

I could update the code on Chainlink but this involves more code change.