### PR TITLE
[CLD-329]: BUG: fix(report): set ChildOperationReports in typedReport

### DIFF
--- a/.changeset/wet-parks-start.md
+++ b/.changeset/wet-parks-start.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix: ChildOperationReports not set correctly

--- a/operations/report.go
+++ b/operations/report.go
@@ -288,11 +288,12 @@ func typeReport[IN, OUT any](r Report[any, any]) (Report[IN, OUT], bool) {
 	}
 
 	return Report[IN, OUT]{
-		ID:        r.ID,
-		Def:       r.Def,
-		Output:    output,
-		Input:     input,
-		Timestamp: r.Timestamp,
-		Err:       r.Err,
+		ID:                    r.ID,
+		Def:                   r.Def,
+		Output:                output,
+		Input:                 input,
+		Timestamp:             r.Timestamp,
+		Err:                   r.Err,
+		ChildOperationReports: r.ChildOperationReports,
 	}, true
 }

--- a/operations/report_test.go
+++ b/operations/report_test.go
@@ -133,8 +133,16 @@ func Test_typeReport(t *testing.T) {
 		ChildOperationReports: []string{uuid.New().String()},
 	}
 
-	_, ok := typeReport[map[string]interface{}, float64](report)
+	res, ok := typeReport[map[string]interface{}, float64](report)
 	assert.True(t, ok)
+	assert.Equal(t, "1", res.ID)
+	assert.Equal(t, Definition{}, res.Def)
+	assert.Equal(t, map[string]interface{}{"a": float64(1)}, res.Input)
+	assert.InEpsilon(t, float64(2), res.Output, 0)
+	assert.Equal(t, &now, res.Timestamp)
+	assert.Nil(t, res.Err)
+	assert.Len(t, res.ChildOperationReports, 1)
+	assert.Equal(t, report.ChildOperationReports[0], res.ChildOperationReports[0])
 
 	// supports unmarshalling into a different type as long it is compatible
 	_, ok = typeReport[Input, int](report)


### PR DESCRIPTION
Caught a bug where ChildOperationReports were not copied over when typedReport is calling. This has no impact on functionality as `ChildOperationReports` is purely used as reference in JSON for users. But for correctness, it should copy the value over.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-329