### PR TITLE
[CLD-302]: feat(operations): introduce ExecutionOperationN

### DIFF
--- a/.changeset/cute-pans-cheer.md
+++ b/.changeset/cute-pans-cheer.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat(operations): introduce ExecutionOperationN

--- a/operations/execute_test.go
+++ b/operations/execute_test.go
@@ -3,6 +3,7 @@ package operations
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"sync"
 	"testing"
@@ -799,6 +800,481 @@ func Test_ExecuteOperation_Concurrent(t *testing.T) {
 	// We expect numGoroutines reports (1 per goroutine)
 	assert.Len(t, allReports, numGoroutines,
 		"Reporter should have %d reports", numGoroutines)
+}
+
+func Test_ExecuteOperationN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		n                 uint
+		multipleExecID    string
+		setupReporter     func() Reporter
+		options           []ExecuteOption[int, any]
+		simulateOpError   bool
+		input             int
+		wantOpCalledTimes int
+		wantReportsCount  int
+		wantErr           string
+	}{
+		{
+			name:              "execute operation multiple times",
+			n:                 3,
+			multipleExecID:    "test-multiple-1",
+			wantOpCalledTimes: 3,
+			wantReportsCount:  3,
+		},
+		{
+			name:              "execute operation with error",
+			n:                 2,
+			multipleExecID:    "test-multiple-2",
+			simulateOpError:   true,
+			wantOpCalledTimes: 1,
+			wantReportsCount:  0,
+			wantErr:           "fatal error",
+		},
+		{
+			name:           "reuse previous executions",
+			n:              3,
+			multipleExecID: "test-multiple-3",
+			setupReporter: func() Reporter {
+				r := NewMemoryReporter()
+				// Add two existing reports with the same multipleExecID
+				for i := range 2 {
+					report := NewReport(
+						Definition{ID: "plus1", Version: semver.MustParse("1.0.0"), Description: "test operation"},
+						1, 2, nil)
+					report.MultipleExecution = &MultipleExecution{
+						ID:    "test-multiple-3",
+						Order: uint(i), // #nosec G115
+					}
+					err := r.AddReport(genericReport(report))
+					if err != nil {
+						t.Fatalf("Failed to add report: %v", err)
+					}
+				}
+
+				return r
+			},
+			wantOpCalledTimes: 1, // Should only execute once more to get to n=3
+			wantReportsCount:  3,
+		},
+		{
+			name:           "all previous executions exist",
+			n:              2,
+			multipleExecID: "test-multiple-4",
+			setupReporter: func() Reporter {
+				r := NewMemoryReporter()
+				// Add two existing reports with the same multipleExecID
+				for i := range 2 {
+					report := NewReport(
+						Definition{ID: "plus1", Version: semver.MustParse("1.0.0"), Description: "test operation"},
+						1, 2, nil)
+					report.MultipleExecution = &MultipleExecution{
+						ID:    "test-multiple-4",
+						Order: uint(i), // #nosec G115
+					}
+					err := r.AddReport(genericReport(report))
+					if err != nil {
+						t.Fatalf("Failed to add report: %v", err)
+					}
+				}
+
+				return r
+			},
+			wantOpCalledTimes: 0, // Should skip all executions
+			wantReportsCount:  2,
+		},
+		{
+			name:           "all previous executions exist - more reports than n",
+			n:              2,
+			multipleExecID: "test-multiple-4",
+			setupReporter: func() Reporter {
+				r := NewMemoryReporter()
+				// Add two existing reports with the same multipleExecID
+				for i := range 4 {
+					report := NewReport(
+						Definition{ID: "plus1", Version: semver.MustParse("1.0.0"), Description: "test operation"},
+						1, 2, nil)
+					report.MultipleExecution = &MultipleExecution{
+						ID:    "test-multiple-4",
+						Order: uint(i), // #nosec G115
+					}
+					err := r.AddReport(genericReport(report))
+					if err != nil {
+						t.Fatalf("Failed to add report: %v", err)
+					}
+				}
+
+				return r
+			},
+			wantOpCalledTimes: 0, // Should skip all executions
+			wantReportsCount:  2,
+		},
+		{
+			name:           "error from reporter",
+			n:              2,
+			multipleExecID: "test-multiple-5",
+			setupReporter: func() Reporter {
+				return errorReporter{
+					Reporter:       NewMemoryReporter(),
+					AddReportError: errors.New("add report error"),
+				}
+			},
+			wantOpCalledTimes: 1,
+			wantReportsCount:  0,
+			wantErr:           "add report error",
+		},
+		{
+			name:              "with retry option",
+			n:                 1,
+			multipleExecID:    "test-multiple-6",
+			options:           []ExecuteOption[int, any]{WithRetry[int, any]()},
+			wantOpCalledTimes: 3, // 2 attempts with default retry
+			wantReportsCount:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handlerCalledTimes := 0
+			failTimes := 2 // First two calls will fail if retrying
+
+			handler := func(b Bundle, deps any, input int) (output int, err error) {
+				handlerCalledTimes++
+				if tt.simulateOpError {
+					return 0, NewUnrecoverableError(errors.New("fatal error"))
+				}
+
+				if failTimes > 0 && len(tt.options) > 0 {
+					failTimes--
+					return 0, errors.New("test error")
+				}
+
+				return input + 1, nil
+			}
+
+			op := NewOperation("plus1", semver.MustParse("1.0.0"), "test operation", handler)
+
+			var reporter Reporter
+			if tt.setupReporter != nil {
+				reporter = tt.setupReporter()
+			} else {
+				reporter = NewMemoryReporter()
+			}
+
+			bundle := NewBundle(context.Background, logger.Test(t), reporter)
+
+			reports, err := ExecuteOperationN(tt.n, tt.multipleExecID, bundle, op, nil, 1, tt.options...)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+				assert.Equal(t, tt.wantOpCalledTimes, handlerCalledTimes)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Len(t, reports, tt.wantReportsCount)
+			assert.Equal(t, tt.wantOpCalledTimes, handlerCalledTimes)
+
+			// Verify each report has the correct multipleExecution info
+			for i, report := range reports {
+				assert.Equal(t, tt.multipleExecID, report.MultipleExecution.ID)
+				assert.Equal(t, uint(i), report.MultipleExecution.Order) // #nosec G115
+				assert.Equal(t, 2, report.Output)                        // input + 1
+			}
+		})
+	}
+}
+
+func Test_ExecuteOperationN_Unserializable_Data(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     any
+		output    any
+		wantError string
+	}{
+		{
+			name:   "both input and output are serializable",
+			input:  1,
+			output: 2,
+		},
+		{
+			name:      "input is not serializable",
+			input:     func() {},
+			wantError: "operation plus1 input: data cannot be safely written to disk without data lost",
+		},
+		{
+			name:      "output is not serializable",
+			input:     1,
+			output:    func() {},
+			wantError: "operation plus1 output: data cannot be safely written to disk without data lost",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := func(b Bundle, deps any, input any) (output any, err error) {
+				return tt.output, nil
+			}
+
+			op := NewOperation("plus1", semver.MustParse("1.0.0"), "test operation", handler)
+			bundle := NewBundle(context.Background, logger.Test(t), NewMemoryReporter())
+
+			_, err := ExecuteOperationN(2, "test-multiple", bundle, op, nil, tt.input)
+
+			if tt.wantError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_ExecuteOperationN_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	op := NewOperation("increment", semver.MustParse("1.0.0"), "increment by 1",
+		func(b Bundle, deps any, input int) (output int, err error) {
+			// Introduce a small delay to increase chance of race conditions
+			time.Sleep(time.Millisecond)
+			return input + 1, nil
+		})
+
+	reporter := NewMemoryReporter()
+	bundle := NewBundle(context.Background, logger.Test(t), reporter)
+
+	const numGoroutines = 5
+	const execsPerGoroutine = 3
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	// Channel to collect results
+	type result struct {
+		reports []Report[int, int]
+		err     error
+	}
+	results := make(chan result, numGoroutines)
+
+	for i := range numGoroutines {
+		go func(i int) {
+			defer wg.Done()
+
+			multipleExecID := fmt.Sprintf("concurrent-test-%d", i)
+			reports, err := ExecuteOperationN(execsPerGoroutine, multipleExecID, bundle, op, nil, i)
+			results <- result{reports, err}
+		}(i)
+	}
+
+	wg.Wait()
+	close(results)
+
+	for res := range results {
+		require.NoError(t, res.err, "ExecuteOperationN should not return an error")
+		require.Len(t, res.reports, execsPerGoroutine)
+
+		// Verify each report in the result
+		for i, report := range res.reports {
+			assert.Equal(t, uint(i), report.MultipleExecution.Order) // #nosec G115
+			assert.Equal(t, report.Input+1, report.Output)
+		}
+	}
+
+	// Verify reporter has all reports
+	allReports, err := reporter.GetReports()
+	require.NoError(t, err)
+	assert.Len(t, allReports, numGoroutines*int(execsPerGoroutine))
+}
+
+func Test_loadSuccessfulMultipleExecutionReports(t *testing.T) {
+	t.Parallel()
+
+	version := semver.MustParse("1.0.0")
+	definition := Definition{
+		ID:          "plus1",
+		Version:     version,
+		Description: "plus 1",
+	}
+	MultipleExecutionID := "test-multiple-execution"
+
+	tests := []struct {
+		name          string
+		setupReporter func() Reporter
+		input         float64
+		execID        string
+		wantFound     bool
+		wantReports   int
+	}{
+		{
+			name: "Failed to GetReports",
+			setupReporter: func() Reporter {
+				return errorReporter{
+					GetReportsError: errors.New("failed to get reports"),
+				}
+			},
+			input:     1,
+			execID:    MultipleExecutionID,
+			wantFound: false,
+		},
+		{
+			name: "Reports found with matching MultipleExecutionID",
+			setupReporter: func() Reporter {
+				r := NewMemoryReporter()
+				// Add three reports with the same MultipleExecutionID
+				for i := range 3 {
+					report := NewReport(definition, 1, 2, nil)
+					report.MultipleExecution = &MultipleExecution{
+						ID:    MultipleExecutionID,
+						Order: uint(i), // #nosec G115
+					}
+					err := r.AddReport(genericReport(report))
+					require.NoError(t, err)
+				}
+
+				return r
+			},
+			input:       1,
+			execID:      MultipleExecutionID,
+			wantFound:   true,
+			wantReports: 3,
+		},
+		{
+			name: "No reports found with matching MultipleExecutionID",
+			setupReporter: func() Reporter {
+				r := NewMemoryReporter()
+				// Add reports with a different MultipleExecutionID
+				for i := range 2 {
+					report := NewReport(definition, 1, 2, nil)
+					report.MultipleExecution = &MultipleExecution{
+						ID:    "different-id",
+						Order: uint(i), // #nosec G115
+					}
+					err := r.AddReport(genericReport(report))
+					require.NoError(t, err)
+				}
+
+				// Add one report with no MultipleExecution
+				report := NewReport(definition, 1, 2, nil)
+				err := r.AddReport(genericReport(report))
+				require.NoError(t, err)
+
+				return r
+			},
+			input:     1,
+			execID:    MultipleExecutionID,
+			wantFound: false,
+		},
+		{
+			name: "Reports found but with errors",
+			setupReporter: func() Reporter {
+				r := NewMemoryReporter()
+				// Add reports with errors
+				for i := range 2 {
+					report := NewReport(definition, 1, 2, errors.New("execution error"))
+					report.MultipleExecution = &MultipleExecution{
+						ID:    MultipleExecutionID,
+						Order: uint(i), // #nosec G115
+					}
+					err := r.AddReport(genericReport(report))
+					require.NoError(t, err)
+				}
+
+				return r
+			},
+			input:     1,
+			execID:    MultipleExecutionID,
+			wantFound: false,
+		},
+		{
+			name:      "Current report with bad hash",
+			input:     math.NaN(),
+			execID:    MultipleExecutionID,
+			wantFound: false,
+		},
+		{
+			name: "Previous reports with bad hash",
+			setupReporter: func() Reporter {
+				r := NewMemoryReporter()
+				// Add reports with NaN input (which will cause hash calculation to fail)
+				for i := range 2 {
+					report := NewReport(definition, math.NaN(), 2, nil)
+					report.MultipleExecution = &MultipleExecution{
+						ID:    MultipleExecutionID,
+						Order: uint(i), // #nosec G115
+					}
+					err := r.AddReport(genericReport(report))
+					require.NoError(t, err)
+				}
+
+				return r
+			},
+			input:     1,
+			execID:    MultipleExecutionID,
+			wantFound: false,
+		},
+		{
+			name: "Reports found with mixed order",
+			setupReporter: func() Reporter {
+				r := NewMemoryReporter()
+				// Add reports in non-sequential order
+				orders := []uint{2, 0, 1}
+				for _, order := range orders {
+					report := NewReport(definition, 1, 2, nil)
+					report.MultipleExecution = &MultipleExecution{
+						ID:    MultipleExecutionID,
+						Order: order,
+					}
+					err := r.AddReport(genericReport(report))
+					require.NoError(t, err)
+				}
+
+				return r
+			},
+			input:       1,
+			execID:      MultipleExecutionID,
+			wantFound:   true,
+			wantReports: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			bundle := NewBundle(context.Background, logger.Test(t), NewMemoryReporter())
+			if tt.setupReporter != nil {
+				bundle.reporter = tt.setupReporter()
+			}
+
+			reports, found := loadSuccessfulMultipleExecutionReports[float64, int](
+				bundle, definition, tt.input, tt.execID)
+
+			assert.Equal(t, tt.wantFound, found)
+
+			if tt.wantFound {
+				assert.Len(t, reports, tt.wantReports)
+
+				// Verify reports are properly ordered
+				for i, report := range reports {
+					assert.Equal(t, tt.execID, report.MultipleExecution.ID)
+					assert.Equal(t, uint(i), report.MultipleExecution.Order) // #nosec G115
+					assert.Equal(t, definition, report.Def)
+				}
+			} else {
+				assert.Empty(t, reports)
+			}
+		})
+	}
 }
 
 type errorReporter struct {

--- a/operations/report.go
+++ b/operations/report.go
@@ -21,17 +21,17 @@ type Report[IN, OUT any] struct {
 	Err       *ReportError `json:"error"`
 	// stores a list of report ID for an operation that was executed as part of a sequence.
 	ChildOperationReports []string `json:"childOperationReports"`
-	// MultipleExecution is used to track the execution of an operation that was executed multiple times
-	MultipleExecution *MultipleExecution `json:"multipleExecution,omitempty"`
+	// ExecutionSeries is used to track the execution of an operation that was executed multiple times
+	ExecutionSeries *ExecutionSeries `json:"executionSeries,omitempty"`
 }
 
-// MultipleExecution is used to track the execution of an operation that was executed multiple times.
-// It contains the unique iD for the MultipleExecution and the order in which it was executed.
-type MultipleExecution struct {
-	// ID is a unique identifier for the multiple execution. Operation with the same MultipleExecutionID
-	// are executed as part of the same multiple execution.
+// ExecutionSeries is used to track the execution of an operation that was executed multiple times.
+// It contains the unique ID for the ExecutionSeries and the order in which it was executed.
+// Same Operation with the same executionSeriesID are executed as part of the same group together.
+type ExecutionSeries struct {
+	// ID is a unique identifier for an execution series.
 	ID string `json:"id"`
-	// Order is the order in which the operation was executed as part of the multiple execution.
+	// Order is the execution order in which the operation was executed as part of the execution series
 	Order uint `json:"order"`
 }
 
@@ -270,7 +270,7 @@ func genericReport[IN, OUT any](r Report[IN, OUT]) Report[any, any] {
 		Timestamp:             r.Timestamp,
 		Err:                   r.Err,
 		ChildOperationReports: r.ChildOperationReports,
-		MultipleExecution:     r.MultipleExecution,
+		ExecutionSeries:       r.ExecutionSeries,
 	}
 }
 
@@ -308,6 +308,6 @@ func typeReport[IN, OUT any](r Report[any, any]) (Report[IN, OUT], bool) {
 		Timestamp:             r.Timestamp,
 		Err:                   r.Err,
 		ChildOperationReports: r.ChildOperationReports,
-		MultipleExecution:     r.MultipleExecution,
+		ExecutionSeries:       r.ExecutionSeries,
 	}, true
 }

--- a/operations/report.go
+++ b/operations/report.go
@@ -21,6 +21,18 @@ type Report[IN, OUT any] struct {
 	Err       *ReportError `json:"error"`
 	// stores a list of report ID for an operation that was executed as part of a sequence.
 	ChildOperationReports []string `json:"childOperationReports"`
+	// MultipleExecution is used to track the execution of an operation that was executed multiple times
+	MultipleExecution *MultipleExecution `json:"multipleExecution,omitempty"`
+}
+
+// MultipleExecution is used to track the execution of an operation that was executed multiple times.
+// It contains the unique iD for the MultipleExecution and the order in which it was executed.
+type MultipleExecution struct {
+	// ID is a unique identifier for the multiple execution. Operation with the same MultipleExecutionID
+	// are executed as part of the same multiple execution.
+	ID string `json:"id"`
+	// Order is the order in which the operation was executed as part of the multiple execution.
+	Order uint `json:"order"`
 }
 
 // ToGenericReport converts the Report to a generic Report.
@@ -258,6 +270,7 @@ func genericReport[IN, OUT any](r Report[IN, OUT]) Report[any, any] {
 		Timestamp:             r.Timestamp,
 		Err:                   r.Err,
 		ChildOperationReports: r.ChildOperationReports,
+		MultipleExecution:     r.MultipleExecution,
 	}
 }
 
@@ -295,5 +308,6 @@ func typeReport[IN, OUT any](r Report[any, any]) (Report[IN, OUT], bool) {
 		Timestamp:             r.Timestamp,
 		Err:                   r.Err,
 		ChildOperationReports: r.ChildOperationReports,
+		MultipleExecution:     r.MultipleExecution,
 	}, true
 }

--- a/operations/report_test.go
+++ b/operations/report_test.go
@@ -172,7 +172,7 @@ var reportJSON = `
     "message" : "test error"
   },
   "childOperationReports" : [ "157b4a77-bdcb-497d-899d-1e8bb44ced58" ],
-  "multipleExecution" : {
+  "executionSeries" : {
     "id" : "deploy-multiple-contracts",
     "order" : 1
   }
@@ -196,7 +196,7 @@ func Test_Report_Marshal(t *testing.T) {
 		Timestamp:             &timestamp,
 		Err:                   &ReportError{Message: "test error"},
 		ChildOperationReports: []string{"157b4a77-bdcb-497d-899d-1e8bb44ced58"},
-		MultipleExecution: &MultipleExecution{
+		ExecutionSeries: &ExecutionSeries{
 			ID:    "deploy-multiple-contracts",
 			Order: 1,
 		},
@@ -227,8 +227,8 @@ func Test_Report_Unmarshal(t *testing.T) {
 	assert.Len(t, report.ChildOperationReports, 1)
 	assert.Equal(t, "157b4a77-bdcb-497d-899d-1e8bb44ced58", report.ChildOperationReports[0])
 	assert.NotNil(t, report.Timestamp)
-	assert.Equal(t, "deploy-multiple-contracts", report.MultipleExecution.ID)
-	assert.Equal(t, uint(1), report.MultipleExecution.Order)
+	assert.Equal(t, "deploy-multiple-contracts", report.ExecutionSeries.ID)
+	assert.Equal(t, uint(1), report.ExecutionSeries.Order)
 }
 
 func Test_Report_ToGenericReport(t *testing.T) {
@@ -243,7 +243,7 @@ func Test_Report_ToGenericReport(t *testing.T) {
 		Timestamp:             &now,
 		Err:                   nil,
 		ChildOperationReports: []string{uuid.New().String()},
-		MultipleExecution: &MultipleExecution{
+		ExecutionSeries: &ExecutionSeries{
 			ID:    "deploy-multiple-contracts",
 			Order: 1,
 		},
@@ -257,8 +257,8 @@ func Test_Report_ToGenericReport(t *testing.T) {
 	assert.Equal(t, report.Timestamp, r.Timestamp)
 	assert.Equal(t, report.Err, r.Err)
 	assert.Equal(t, report.ChildOperationReports, r.ChildOperationReports)
-	assert.Equal(t, report.MultipleExecution.ID, r.MultipleExecution.ID)
-	assert.Equal(t, report.MultipleExecution.Order, r.MultipleExecution.Order)
+	assert.Equal(t, report.ExecutionSeries.ID, r.ExecutionSeries.ID)
+	assert.Equal(t, report.ExecutionSeries.Order, r.ExecutionSeries.Order)
 }
 
 func Test_SequenceReport_ToGenericReport(t *testing.T) {

--- a/operations/report_test.go
+++ b/operations/report_test.go
@@ -159,19 +159,23 @@ func Test_typeReport(t *testing.T) {
 
 var reportJSON = `
 {
-	"id": "6c5d66ad-f1e8-45b6-b83b-4f289b04045f",
-	"definition": {
-	  "id": "op1",
-	  "version": "1.0.0",
-	  "description": "test operation"
-	},
-	"output": "2",
-	"input": 1,
-	"timestamp": "2025-04-03T17:24:27.079966+11:00",
-	"error": {
-      "message": "test error"
-    },
-	"childOperationReports": ["157b4a77-bdcb-497d-899d-1e8bb44ced58"]
+  "id" : "6c5d66ad-f1e8-45b6-b83b-4f289b04045f",
+  "definition" : {
+    "id" : "op1",
+    "version" : "1.0.0",
+    "description" : "test operation"
+  },
+  "output" : "2",
+  "input" : 1,
+  "timestamp" : "2025-04-03T17:24:27.079966+11:00",
+  "error" : {
+    "message" : "test error"
+  },
+  "childOperationReports" : [ "157b4a77-bdcb-497d-899d-1e8bb44ced58" ],
+  "multipleExecution" : {
+    "id" : "deploy-multiple-contracts",
+    "order" : 1
+  }
 }`
 
 func Test_Report_Marshal(t *testing.T) {
@@ -192,6 +196,10 @@ func Test_Report_Marshal(t *testing.T) {
 		Timestamp:             &timestamp,
 		Err:                   &ReportError{Message: "test error"},
 		ChildOperationReports: []string{"157b4a77-bdcb-497d-899d-1e8bb44ced58"},
+		MultipleExecution: &MultipleExecution{
+			ID:    "deploy-multiple-contracts",
+			Order: 1,
+		},
 	}
 
 	bytes, err := json.MarshalIndent(report, "", "  ")
@@ -219,6 +227,8 @@ func Test_Report_Unmarshal(t *testing.T) {
 	assert.Len(t, report.ChildOperationReports, 1)
 	assert.Equal(t, "157b4a77-bdcb-497d-899d-1e8bb44ced58", report.ChildOperationReports[0])
 	assert.NotNil(t, report.Timestamp)
+	assert.Equal(t, "deploy-multiple-contracts", report.MultipleExecution.ID)
+	assert.Equal(t, uint(1), report.MultipleExecution.Order)
 }
 
 func Test_Report_ToGenericReport(t *testing.T) {
@@ -233,6 +243,10 @@ func Test_Report_ToGenericReport(t *testing.T) {
 		Timestamp:             &now,
 		Err:                   nil,
 		ChildOperationReports: []string{uuid.New().String()},
+		MultipleExecution: &MultipleExecution{
+			ID:    "deploy-multiple-contracts",
+			Order: 1,
+		},
 	}
 
 	r := report.ToGenericReport()
@@ -243,6 +257,8 @@ func Test_Report_ToGenericReport(t *testing.T) {
 	assert.Equal(t, report.Timestamp, r.Timestamp)
 	assert.Equal(t, report.Err, r.Err)
 	assert.Equal(t, report.ChildOperationReports, r.ChildOperationReports)
+	assert.Equal(t, report.MultipleExecution.ID, r.MultipleExecution.ID)
+	assert.Equal(t, report.MultipleExecution.Order, r.MultipleExecution.Order)
 }
 
 func Test_SequenceReport_ToGenericReport(t *testing.T) {


### PR DESCRIPTION
There is a scenario discovered when an operation with same input has to be run multiple times, eg when deploying the same MCMS contract multiple times so it can be associated with different roles.

This commit introduces `ExecutionOperationN`, it will execute the provided operation N times.

For idempotency behaviour, we went to ensure on reruns, the `ExecutionOperationN` will return the successful prior results in the same order in the slice. That is why we need to remember the order.

Usage
```go
// execute 3 times
linkDeployReports, err := operations.ExecuteOperationN(
			b, DeployLinkOp, deps, operations.EmptyInput{},
			"deploy-multiple-link-contract", 3,
			operations.WithRetry[operations.EmptyInput, EthereumDeps](),
		)
```

Report
```
  {
    "id": "15ac8420-0b59-4293-a188-948ad43643da",
    "definition": {
      "id": "deploy-link-token-op",
      "version": "1.0.0",
      "description": "Deploy LINK Contract Operation"
    },
    "output": "0x9dc98d0a1362d1aa83a10569c45ef4ee3ef97071",
    "input": {},
    "timestamp": "2025-06-04T15:36:02.066618+10:00",
    "error": null,
    "childOperationReports": null,
    "executionSeries": {
      "id": "deploy-multiple-times",
      "order": 1
    }
  }
```

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-302