### PR TITLE
feat(datastore) adds more serialization/deserialization tests

### DIFF
--- a/datastore/memory_address_ref_store_test.go
+++ b/datastore/memory_address_ref_store_test.go
@@ -650,7 +650,7 @@ func TestMemoryAddressRefStore_RecordsOrdering(t *testing.T) {
 	require.NoError(t, err, "Failed to unmarshal store")
 
 	// verify the records are in the same order
-	require.Equal(t, len(originalStore.Records), len(unmarshaledStore.Records),
+	require.Len(t, originalStore.Records, len(unmarshaledStore.Records),
 		"number of records should match after unmarshaling")
 
 	// compare each record to ensure order is maintained

--- a/datastore/memory_contract_metadata_store_test.go
+++ b/datastore/memory_contract_metadata_store_test.go
@@ -570,7 +570,7 @@ func TestMemoryContractMetadataStore_RecordsOrdering(t *testing.T) {
 	require.NoError(t, err, "Failed to unmarshal store")
 
 	// Verify the records are in the same order
-	require.Equal(t, len(originalStore.Records), len(unmarshaledStore.Records),
+	require.Len(t, originalStore.Records, len(unmarshaledStore.Records),
 		"number of records should match after unmarshaling")
 
 	// Compare each record to ensure order is maintained


### PR DESCRIPTION
This adds tests to confirm that ordering is maintained across the JSON `marshal/unmarshal` of address_refs and contract_metadata. This will be expanded to also cover custom metadata fields 