### PR TITLE
chore(datastore): updates datastore docstrings

### DIFF
--- a/datastore/abstract.go
+++ b/datastore/abstract.go
@@ -27,7 +27,7 @@ type PrimaryKeyHolder[K Comparable[K]] interface {
 	Key() K
 }
 
-// UniqueRecord represents a data entry that is both Cloneable and uniquely identifiable by its primary key.
+// UniqueRecord represents a data entry that is uniquely identifiable by its primary key.
 type UniqueRecord[K Comparable[K], R PrimaryKeyHolder[K]] interface {
 	PrimaryKeyHolder[K]
 }

--- a/datastore/address_ref.go
+++ b/datastore/address_ref.go
@@ -24,7 +24,7 @@ func (ct ContractType) String() string {
 	return string(ct)
 }
 
-// AddressRef implements the Record interface
+// AddressRef implements the UniqueRecord interface
 var _ UniqueRecord[AddressRefKey, AddressRef] = AddressRef{}
 
 type AddressRef struct {

--- a/datastore/contract_metadata.go
+++ b/datastore/contract_metadata.go
@@ -5,24 +5,22 @@ import "errors"
 var ErrContractMetadataNotFound = errors.New("no contract metadata record can be found for the provided key")
 var ErrContractMetadataExists = errors.New("a contract metadata record with the supplied key already exists")
 
-// ContractMetadata implements the Record interface
+// ContractMetadata implements the UniqueRecord interface
 var _ UniqueRecord[ContractMetadataKey, ContractMetadata] = ContractMetadata{}
 
-// ContractMetadata is a generic struct that holds the metadata for a contract on a specific chain.
-// It implements the Record interface and is used to store contract metadata in the datastore.
-// The metadata is generic and can be of any type that implements the Cloneable interface.
+// ContractMetadata is a struct that holds the metadata for a contract on a specific chain.
+// It implements the UniqueRecord interface and is used to store contract metadata in the datastore.
+// NOTE: Metadata can be of any type. To convert from any to a specific type, use the utility method As.
 type ContractMetadata struct {
 	// Address is the address of the contract on the chain.
 	Address string `json:"address"`
 	// ChainSelector is the chain-selector of the chain where the contract is deployed.
 	ChainSelector uint64 `json:"chainSelector"`
 	// Metadata is the metadata associated with the contract.
-	// It is a generic type that can be of any type that implements the Cloneable interface.
 	Metadata any `json:"metadata"`
 }
 
 // Clone creates a copy of the ContractMetadata.
-// The Metadata field is cloned using the Clone method of the Cloneable interface.
 func (r ContractMetadata) Clone() (ContractMetadata, error) {
 	metaClone, err := clone(r.Metadata)
 	if err != nil {

--- a/datastore/env_metadata.go
+++ b/datastore/env_metadata.go
@@ -4,14 +4,14 @@ import "errors"
 
 var ErrEnvMetadataNotSet = errors.New("no environment metadata set")
 
+// EnvMetadata is a struct that holds the metadata for a domain and environment.
+// NOTE: Metadata can be of any type. To convert from any to a specific type, use the utility method As.
 type EnvMetadata struct {
 	// Metadata is the metadata associated with the domain and environment.
-	// It is a generic type that can be of any type that implements the Cloneable interface.
 	Metadata any `json:"metadata"`
 }
 
 // Clone creates a copy of the EnvMetadata.
-// The Metadata field is cloned using the Clone method of the Cloneable interface.
 func (r EnvMetadata) Clone() (EnvMetadata, error) {
 	metaClone, err := clone(r.Metadata)
 	if err != nil {

--- a/datastore/memory_contract_metadata_store.go
+++ b/datastore/memory_contract_metadata_store.go
@@ -30,12 +30,13 @@ var _ ContractMetadataStore = &MemoryContractMetadataStore{}
 var _ MutableContractMetadataStore = &MemoryContractMetadataStore{}
 
 // NewMemoryContractMetadataStore creates a new MemoryContractMetadataStore instance.
-// It is a generic function that takes a type parameter M which must implement the Cloneable interface.
 func NewMemoryContractMetadataStore() *MemoryContractMetadataStore {
 	return &MemoryContractMetadataStore{Records: []ContractMetadata{}}
 }
 
 // Get returns the ContractMetadata for the provided key, or an error if no such record exists.
+// NOTE: The returned ContractMetadata will have an any type for the Metadata field.
+// To convert it to a specific type, use the utility method As.
 func (s *MemoryContractMetadataStore) Get(key ContractMetadataKey) (ContractMetadata, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -49,6 +50,8 @@ func (s *MemoryContractMetadataStore) Get(key ContractMetadataKey) (ContractMeta
 }
 
 // Fetch returns a copy of all ContractMetadata in the store.
+// NOTE: The returned ContractMetadata will have an any type for the Metadata field.
+// To convert it to a specific type, use the utility method As.
 func (s *MemoryContractMetadataStore) Fetch() ([]ContractMetadata, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -68,6 +71,8 @@ func (s *MemoryContractMetadataStore) Fetch() ([]ContractMetadata, error) {
 // Filter returns a copy of all ContractMetadata in the store that pass all of the provided filters.
 // Filters are applied in the order they are provided.
 // If no filters are provided, all records are returned.
+// NOTE: The returned ContractMetadata will have an any type for the Metadata field.
+// To convert it to a specific type, use the utility method As.
 func (s *MemoryContractMetadataStore) Filter(filters ...FilterFunc[ContractMetadataKey, ContractMetadata]) []ContractMetadata {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/datastore/memory_datastore.go
+++ b/datastore/memory_datastore.go
@@ -17,7 +17,8 @@ type Sealer[T any] interface {
 }
 
 // BaseDataStore is an interface that defines the basic operations for a data store.
-// It is parameterized by the type of address reference store and contract metadata store it uses.
+// It is parameterized by the type of address reference store, contract metadata store and
+// env metadata store it uses.
 type BaseDataStore[
 	R AddressRefStore, CM ContractMetadataStore, EM EnvMetadataStore,
 ] interface {

--- a/datastore/memory_env_metadata_store.go
+++ b/datastore/memory_env_metadata_store.go
@@ -34,6 +34,8 @@ func NewMemoryEnvMetadataStore() *MemoryEnvMetadataStore {
 // Get returns a copy of the stored EnvMetadata record if it exists or an error if any occurred.
 // If no record exist, it returns an empty EnvMetadata and ErrEnvMetadataNotSet.
 // If the record exists, it returns a copy of the record and a nil error.
+// NOTE: The returned EnvMetadata will have an any type for the Metadata field.
+// To convert it to a specific type, use the utility method As.
 func (s *MemoryEnvMetadataStore) Get() (EnvMetadata, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/datastore/transform.go
+++ b/datastore/transform.go
@@ -5,7 +5,19 @@ import (
 )
 
 // As is a utility function that converts a source value of any type to a destination type T.
-// It uses JSON marshaling and unmarshaling to perform the conversion.
+// It uses JSON marshaling and unmarshaling to perform the conversion. It can be used to
+// convert metadata of any type to a specific type, as shown in the example below.
+//
+// Example usage:
+//
+//	record, err := store.ContractMetadata().Get(NewContractMetadataKey(chainSelector, address))
+//	if err != nil {
+//	    return nil, err
+//	}
+//	concrete, err := As[ConcreteMetadataType](record.Metadata)
+//	if err != nil {
+//	    return nil, err
+//	}
 func As[T any](src any) (T, error) {
 	var zero T
 	bytes, err := json.Marshal(src)


### PR DESCRIPTION
This PR updates all relevant docstrings following the removal of generics from datastore. Comments have been adjusted to reflect the new any-based metadata model and guide users on using the As helper for type conversion where needed.