### PR TITLE
feat: The Initialize method on chain.Provider now requires a Context

### DIFF
--- a/.changeset/cold-steaks-matter.md
+++ b/.changeset/cold-steaks-matter.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+[BREAKING] The `chain.Provider` `Initialize` method now requires a context to be provided.

--- a/chain/aptos/provider/ctf_provider.go
+++ b/chain/aptos/provider/ctf_provider.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -75,7 +76,7 @@ func NewCTFChainProvider(
 
 // Initialize sets up the Aptos chain by validating the configuration, starting a CTF container,
 // generating a deployer signer account, and constructing the chain instance.
-func (p *CTFChainProvider) Initialize() (chain.BlockChain, error) {
+func (p *CTFChainProvider) Initialize(_ context.Context) (chain.BlockChain, error) {
 	if p.chain != nil {
 		return *p.chain, nil // Already initialized
 	}

--- a/chain/aptos/provider/ctf_provider_test.go
+++ b/chain/aptos/provider/ctf_provider_test.go
@@ -110,7 +110,7 @@ func Test_CTFChainProvider_Initialize(t *testing.T) {
 
 			p := NewCTFChainProvider(t, tt.giveSelector, tt.giveConfig)
 
-			got, err := p.Initialize()
+			got, err := p.Initialize(t.Context())
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 			} else {

--- a/chain/aptos/provider/rpc_provider.go
+++ b/chain/aptos/provider/rpc_provider.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -61,7 +62,7 @@ func NewRPCChainProvider(selector uint64, config RPCChainProviderConfig) *RPCCha
 
 // Initialize initializes the RPCChainProvider, validating the configuration and setting up the
 // Aptos chain client.
-func (p *RPCChainProvider) Initialize() (chain.BlockChain, error) {
+func (p *RPCChainProvider) Initialize(_ context.Context) (chain.BlockChain, error) {
 	if p.chain != nil {
 		return p.chain, nil // Already initialized
 	}

--- a/chain/aptos/provider/rpc_provider_test.go
+++ b/chain/aptos/provider/rpc_provider_test.go
@@ -109,7 +109,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 
 			p := NewRPCChainProvider(tt.giveSelector, tt.giveConfig)
 
-			got, err := p.Initialize()
+			got, err := p.Initialize(t.Context())
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 			} else {

--- a/chain/provider.go
+++ b/chain/provider.go
@@ -1,7 +1,9 @@
 package chain
 
+import "context"
+
 type Provider interface {
-	Initialize() (BlockChain, error)
+	Initialize(ctx context.Context) (BlockChain, error)
 	Name() string
 	ChainSelector() uint64
 	BlockChain() BlockChain

--- a/chain/solana/provider/ctf_provider.go
+++ b/chain/solana/provider/ctf_provider.go
@@ -99,7 +99,7 @@ func NewCTFChainProvider(
 
 // Initialize sets up the Solana chain by validating the configuration, starting a CTF container,
 // generating a deployer key, and constructing the chain instance.
-func (p *CTFChainProvider) Initialize() (chain.BlockChain, error) {
+func (p *CTFChainProvider) Initialize(_ context.Context) (chain.BlockChain, error) {
 	if p.chain != nil {
 		return *p.chain, nil // Already initialized
 	}

--- a/chain/solana/provider/ctf_provider_test.go
+++ b/chain/solana/provider/ctf_provider_test.go
@@ -148,7 +148,7 @@ func Test_CTFChainProvider_Initialize(t *testing.T) {
 				p.chain = tt.giveExistingChain // Simulate an already initialized chain
 			}
 
-			got, err := p.Initialize()
+			got, err := p.Initialize(t.Context())
 
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)

--- a/chain/solana/provider/rpc_provider.go
+++ b/chain/solana/provider/rpc_provider.go
@@ -87,7 +87,7 @@ func NewRPCChainProvider(selector uint64, config RPCChainProviderConfig) *RPCCha
 // Initialize initializes the RPCChainProvider. It generates the deployer keypair from the provided
 // configuration, writes it to the specified KeypairPath directory, and sets up the Solana client
 // with the provided HTTP RPC URL. It returns the initialized Solana chain instance.
-func (p *RPCChainProvider) Initialize() (chain.BlockChain, error) {
+func (p *RPCChainProvider) Initialize(_ context.Context) (chain.BlockChain, error) {
 	if p.chain != nil {
 		return *p.chain, nil // Already initialized
 	}

--- a/chain/solana/provider/rpc_provider_test.go
+++ b/chain/solana/provider/rpc_provider_test.go
@@ -209,7 +209,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 				p.chain = tt.giveExistingChain
 			}
 
-			got, err := p.Initialize()
+			got, err := p.Initialize(t.Context())
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 			} else {


### PR DESCRIPTION
The context parameter is now required for the `Initialize` method in the `chain.Provider` interface. This change is made to ensure that all providers can handle context-specific operations such as setting up clients.

BREAKING CHANGE: This change requires all calls to Initialize to pass a Context parameter. This is a breaking change as it modifies the signature of the `Initialize` method in the `chain.Provider` interface.