### PR TITLE
[CLD-361]: fix(operations): use map for operation registry

### DIFF
--- a/.changeset/tidy-fans-wink.md
+++ b/.changeset/tidy-fans-wink.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix(operations): optimization on dynamic execution

--- a/operations/operation.go
+++ b/operations/operation.go
@@ -104,11 +104,7 @@ func (o *Operation[IN, OUT, DEP]) execute(b Bundle, deps DEP, input IN) (output 
 // Warning: The input and output types will be converted to `any`, so type safety is lost.
 func (o *Operation[IN, OUT, DEP]) AsUntyped() *Operation[any, any, any] {
 	return &Operation[any, any, any]{
-		def: Definition{
-			ID:          o.def.ID,
-			Version:     o.def.Version,
-			Description: o.def.Description,
-		},
+		def: o.def,
 		handler: func(b Bundle, deps any, input any) (any, error) {
 			var typedInput IN
 			if input != nil {
@@ -126,7 +122,7 @@ func (o *Operation[IN, OUT, DEP]) AsUntyped() *Operation[any, any, any] {
 				}
 			}
 
-			return o.execute(b, typedDeps, typedInput)
+			return o.handler(b, typedDeps, typedInput)
 		},
 	}
 }

--- a/operations/registry.go
+++ b/operations/registry.go
@@ -1,37 +1,58 @@
 package operations
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrOperationNotFound = errors.New("operation not found in registry")
 
 // OperationRegistry is a store for operations that allows retrieval based on their definitions.
 type OperationRegistry struct {
-	ops []*Operation[any, any, any]
+	ops map[string]*Operation[any, any, any]
 }
 
 // NewOperationRegistry creates a new OperationRegistry with the provided untyped operations.
 func NewOperationRegistry(ops ...*Operation[any, any, any]) *OperationRegistry {
-	return &OperationRegistry{
-		ops: ops,
+	reg := &OperationRegistry{
+		ops: make(map[string]*Operation[any, any, any]),
 	}
+	for _, op := range ops {
+		key := generateRegistryKey(op.Def())
+		reg.ops[key] = op
+	}
+
+	return reg
 }
 
 // Retrieve retrieves an operation from the store based on its definition.
 // It returns an error if the operation is not found.
 // The definition must match the operation's ID and version.
+// Description of the definition is not used for retrieval, only ID and Version.
+// This allows for simplicity in retrieving operations with the same ID and version only without having to provide the description.
+// This is useful when definition has to be provided via manual input.
 func (s OperationRegistry) Retrieve(def Definition) (*Operation[any, any, any], error) {
-	for _, op := range s.ops {
-		if op.ID() == def.ID && op.Version() == def.Version.String() {
-			return op, nil
-		}
+	key := generateRegistryKey(def)
+	if op, ok := s.ops[key]; ok {
+		return op, nil
 	}
 
-	return nil, errors.New("operation not found in registry")
+	return nil, ErrOperationNotFound
 }
 
 // RegisterOperation registers new operations in the registry.
 // To register operations with different input, output, and dependency types,
 // call RegisterOperation multiple times with different type parameters.
+// If the same operation is registered multiple times, it will overwrite the previous one.
 func RegisterOperation[D, I, O any](r *OperationRegistry, op ...*Operation[D, I, O]) {
 	for _, o := range op {
-		r.ops = append(r.ops, o.AsUntyped())
+		key := generateRegistryKey(o.Def())
+		r.ops[key] = o.AsUntyped()
 	}
+}
+
+// generateRegistryKey creates a unique key for the operation registry based on the operation's ID and version.
+// This key is used to store and retrieve operations in the registry.
+func generateRegistryKey(def Definition) string {
+	return fmt.Sprintf("%s:%s", def.ID, def.Version)
 }


### PR DESCRIPTION
- Use map instead of slice for faster lookup in the operation registry
- reduce duplicate logging

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-361