### PR TITLE
fix: make the wsurl for Solana Provider optional

### DIFF
--- a/.changeset/thin-carpets-punch.md
+++ b/.changeset/thin-carpets-punch.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+The websocket url in the Solana Chain Provider is now optional

--- a/chain/solana/provider/rpc_provider.go
+++ b/chain/solana/provider/rpc_provider.go
@@ -20,7 +20,7 @@ import (
 type RPCChainProviderConfig struct {
 	// Required: The HTTP RPC URL to connect to the Solana node.
 	HTTPURL string
-	// Required: The WebSocket URL to connect to the Solana node.
+	// Optional: The WebSocket URL to connect to the Solana node.
 	WSURL string
 	// Required: A generator for the deployer key. Use PrivateKeyFromRaw to create a deployer
 	// key from a private key.
@@ -36,9 +36,6 @@ type RPCChainProviderConfig struct {
 func (c RPCChainProviderConfig) validate() error {
 	if c.HTTPURL == "" {
 		return errors.New("http url is required")
-	}
-	if c.WSURL == "" {
-		return errors.New("ws url is required")
 	}
 	if c.DeployerKeyGen == nil {
 		return errors.New("deployer key generator is required")

--- a/chain/solana/provider/rpc_provider_test.go
+++ b/chain/solana/provider/rpc_provider_test.go
@@ -29,11 +29,6 @@ func Test_RPCChainProviderConfig_validate(t *testing.T) {
 			wantErr:        "http url is required",
 		},
 		{
-			name:           "missing ws url",
-			giveConfigFunc: func(c *RPCChainProviderConfig) { c.WSURL = "" },
-			wantErr:        "ws url is required",
-		},
-		{
 			name:           "missing deployer key generator",
 			giveConfigFunc: func(c *RPCChainProviderConfig) { c.DeployerKeyGen = nil },
 			wantErr:        "deployer key generator is required",


### PR DESCRIPTION
This commit makes the `wsurl` field in the Solana Provider optional, as existing implementations do not require a WebSocket URL.