### PR TITLE
feat: add a method to return the underlying backend of a SimClient

### DIFF
--- a/.changeset/afraid-chefs-eat.md
+++ b/.changeset/afraid-chefs-eat.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+Adds a `Backend` method to the `SimClient` to return the underlying simulated backend

--- a/chain/evm/provider/sim_client.go
+++ b/chain/evm/provider/sim_client.go
@@ -16,19 +16,19 @@ type SimClient struct {
 
 	// Embed the simulated.Client to provide access to its methods and adhere to the OnchainClient interface.
 	simulated.Client
-	// sim is the underlying simulated backend that this client wraps.
-	sim *simulated.Backend
+	// backend is the underlying simulated backend that this client wraps.
+	backend *simulated.Backend
 }
 
 // NewSimClient creates a new wrappedSimBackend instance from a simulated backend.
-func NewSimClient(t *testing.T, sim *simulated.Backend) *SimClient {
+func NewSimClient(t *testing.T, backend *simulated.Backend) *SimClient {
 	t.Helper()
 
-	require.NotNil(t, sim, "simulated backend must not be nil")
+	require.NotNil(t, backend, "simulated backend must not be nil")
 
 	return &SimClient{
-		sim:    sim,
-		Client: sim.Client(),
+		backend: backend,
+		Client:  backend.Client(),
 	}
 }
 
@@ -36,5 +36,9 @@ func (b *SimClient) Commit() common.Hash {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	return b.sim.Commit()
+	return b.backend.Commit()
+}
+
+func (b *SimClient) Backend() *simulated.Backend {
+	return b.backend
 }

--- a/chain/evm/provider/sim_client_test.go
+++ b/chain/evm/provider/sim_client_test.go
@@ -29,3 +29,16 @@ func Test_SimClient_Commit(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), blockNumber) // After commit, the block number should be 1
 }
+
+func Test_SimClient_Backend(t *testing.T) {
+	t.Parallel()
+
+	// Create a simulated backend
+	sim := simulated.NewBackend(types.GenesisAlloc{})
+
+	// Create a new SimClient instance
+	client := NewSimClient(t, sim)
+
+	// Ensure that the Backend method returns the correct backend
+	require.Equal(t, sim, client.Backend())
+}


### PR DESCRIPTION
This addds a `Backend` method to the `SimClient`, which returns the underlying backend. This is useful when you want to provide the underlying backend to other components that require the same backend.