### PR TITLE
[CLD-418]: fix: handle empty data - parseErrorFromABI

### DIFF
--- a/.changeset/purple-pens-itch.md
+++ b/.changeset/purple-pens-itch.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix: handle empty data on parseErrorFromABI

--- a/deployment/helpers.go
+++ b/deployment/helpers.go
@@ -46,7 +46,7 @@ func parseErrorFromABI(errorString string, contractABI string) (string, error) {
 	}
 
 	for errorName, abiError := range parsedAbi.Errors {
-		if bytes.Equal(data[:4], abiError.ID.Bytes()[:4]) {
+		if len(data) >= 4 && bytes.Equal(data[:4], abiError.ID.Bytes()[:4]) {
 			// Found a matching error
 			v, err3 := abiError.Unpack(data)
 			if err3 != nil {

--- a/deployment/helpers_test.go
+++ b/deployment/helpers_test.go
@@ -15,6 +15,7 @@ func TestParseErrorFromABI(t *testing.T) {
 		RevertReason       string
 		ABI                string
 		ParsedRevertReason string
+		ExpectError        bool
 	}{
 		{
 			Name:               "Generic error with string msg",
@@ -28,14 +29,25 @@ func TestParseErrorFromABI(t *testing.T) {
 			ABI:                sampleABI,
 			ParsedRevertReason: "error -`InvalidConfig` args [4294967297]",
 		},
+		{
+			Name:               "Empty error string",
+			RevertReason:       "",
+			ABI:                sampleABI,
+			ParsedRevertReason: "",
+			ExpectError:        true,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 			revertReason, err := parseErrorFromABI(tc.RevertReason, tc.ABI)
-			require.NoError(t, err)
-			require.Equal(t, tc.ParsedRevertReason, revertReason)
+			if tc.ExpectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.ParsedRevertReason, revertReason)
+			}
 		})
 	}
 }


### PR DESCRIPTION
As reported [here](https://chainlink-core.slack.com/archives/C08QF1BEW4T/p1751056343734999), if the data is null or empty, there will be a runtime error when we perform data[:4], we should handle this safer by performing a length check

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-418