### PR TITLE
Adding an optional interface for the aptos faucet

### DIFF
--- a/chain/aptos/aptos_chain.go
+++ b/chain/aptos/aptos_chain.go
@@ -11,6 +11,7 @@ type Chain struct {
 	Selector uint64
 
 	Client         aptoslib.AptosRpcClient
+	FaucetClient   aptoslib.AptosFaucetClient
 	DeployerSigner aptoslib.TransactionSigner
 	URL            string
 

--- a/chain/aptos/provider/rpc_provider.go
+++ b/chain/aptos/provider/rpc_provider.go
@@ -16,7 +16,8 @@ import (
 // RPCChainProviderConfig holds the configuration to initialize the RPCChainProvider.
 type RPCChainProviderConfig struct {
 	// Required: The RPC URL to connect to the Aptos node
-	RPCURL       string
+	RPCURL string
+	// Optional: The RPC URL to connect to the Aptos node faucet
 	RPCFaucetURL string
 	// Required: A generator for the deployer signer account. Use AccountGenPrivateKey to
 	// create a deployer signer from a private key.

--- a/chain/aptos/provider/rpc_provider_test.go
+++ b/chain/aptos/provider/rpc_provider_test.go
@@ -22,6 +22,7 @@ func Test_RPCChainProviderConfig_validate(t *testing.T) {
 			name: "valid config",
 			config: RPCChainProviderConfig{
 				RPCURL:            "http://localhost:8080",
+				RPCFaucetURL:      "http://localhost:8081",
 				DeployerSignerGen: AccountGenCTFDefault(),
 			},
 			wantErr: "",
@@ -37,6 +38,7 @@ func Test_RPCChainProviderConfig_validate(t *testing.T) {
 			name: "missing deployer signer generator",
 			config: RPCChainProviderConfig{
 				RPCURL:            "http://localhost:8080",
+				RPCFaucetURL:      "http://localhost:8081",
 				DeployerSignerGen: nil,
 			},
 			wantErr: "deployer signer generator is required",
@@ -71,6 +73,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 			giveSelector: chain_selectors.APTOS_LOCALNET.Selector,
 			giveConfig: RPCChainProviderConfig{
 				RPCURL:            "http://localhost:8080",
+				RPCFaucetURL:      "http://localhost:8081",
 				DeployerSignerGen: AccountGenPrivateKey(testPrivateKey),
 			},
 		},
@@ -88,6 +91,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 			giveSelector: chain_selectors.APTOS_LOCALNET.Selector,
 			giveConfig: RPCChainProviderConfig{
 				RPCURL:            "http://localhost:8080",
+				RPCFaucetURL:      "http://localhost:8081",
 				DeployerSignerGen: AccountGenPrivateKey("invalid_private_key"),
 			},
 			wantErr: "failed to generate deployer account",
@@ -97,6 +101,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 			giveSelector: 999999, // Invalid selector
 			giveConfig: RPCChainProviderConfig{
 				RPCURL:            "http://localhost:8080",
+				RPCFaucetURL:      "http://localhost:8081",
 				DeployerSignerGen: AccountGenPrivateKey(testPrivateKey),
 			},
 			wantErr: "failed to get chain ID from selector 999999",
@@ -120,6 +125,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 				require.True(t, ok, "expected got to be of type aptos.Chain")
 				assert.Equal(t, tt.giveSelector, gotChain.Selector)
 				assert.NotEmpty(t, gotChain.Client)
+				assert.NotEmpty(t, gotChain.FaucetClient)
 				assert.NotEmpty(t, gotChain.DeployerSigner)
 				assert.Equal(t, tt.giveConfig.RPCURL, gotChain.URL)
 				assert.NotEmpty(t, gotChain.Confirm)


### PR DESCRIPTION
The Aptos SDK does offer an option to set up the Faucet Client when calling [New Client](https://github.com/aptos-labs/aptos-go-sdk/blob/2973385bd2bc3bf53c103518b3597ee7d381eddb/client.go#L525), however this exposes the underlying methods and not the FaucetClient natively, so to avoid introducing breaking changes in the `Chain.Client` interface we can add an optional `FaucetClient` interface which can handle funding directly.

This would speed up funding in places like the load test where we create new test accounts on each run, so we don't have to keep funding a deployer key each time or hardcoding it.


e.g

```golang
ac, err := aptos.NewClient(aptos.NetworkConfig{
	Name:      chainCfg.ChainName,
	NodeUrl:   chainCfg.HTTPRPCs[0].External,
	FaucetUrl: chainCfg.HTTPRPCs[1].External,
	ChainId:   uint8(cId),
})

fac, err := aptos.NewFaucetClient(nodeClient, chainCfg.HTTPRPCs[1].External)
cldf_aptos.Chain{
	Selector:       chainDetails.ChainSelector,
	Client:         ac,
        FaucetClient    fac,
	DeployerSigner: signerKey,
	URL:            chainCfg.HTTPRPCs[0].External,
	Confirm: func(txHash string, opts ...any) error {
		tx, err := ac.WaitForTransaction(txHash, opts...)
		if err != nil {
			return err
		}

		if !tx.Success {
			return fmt.Errorf("transaction failed: %s", tx.VmStatus)
		}

		return nil
	},
}
```