### PR TITLE
tests: disable zksync intialize test

### DIFF
--- a/chain/evm/provider/zksync_ctf_provider_test.go
+++ b/chain/evm/provider/zksync_ctf_provider_test.go
@@ -52,6 +52,8 @@ func Test_ZkSyncCTFChainProviderConfig_validate(t *testing.T) {
 }
 
 func Test_CTFChainProvider_Initialize(t *testing.T) {
+	t.Skip("Skipping test for CTF chain provider initialization, too flaky when starting container," +
+		" enable once the issue is resolved")
 	t.Parallel()
 
 	var chainSelector = chain_selectors.TEST_1000.Selector


### PR DESCRIPTION
Super flaky even failing with the 10 retries that we added.