### PR TITLE
feat(ton): new ctf provider

### DIFF
--- a/.changeset/ready-coins-go.md
+++ b/.changeset/ready-coins-go.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat(ton): new ctf provider

--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Build and test
         uses: smartcontractkit/.github/actions/ci-test-go@eeb76b5870e3c17856d5a60fd064a053c023b5f5 # ci-test-go@1.0.0
         with:
-          go-test-cmd: go test -race -coverprofile=coverage.txt $(go list ./...)
+          # disable the checkptr runtime check due a false positive in github.com/xssnick/tonutils-go
+          # causing tests in ci to fail "fatal error: checkptr: pointer arithmetic result points to invalid allocation"
+          # https://github.com/xssnick/tonutils-go/issues/310
+          go-test-cmd: go test -race -gcflags=all=-d=checkptr=0 -coverprofile=coverage.txt $(go list ./...)
           use-go-cache: true
 
   sonarqube:

--- a/.github/workflows/schedule-main.yml
+++ b/.github/workflows/schedule-main.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Build and test
         uses: smartcontractkit/.github/actions/ci-test-go@eeb76b5870e3c17856d5a60fd064a053c023b5f5 # ci-test-go@1.0.0
         with:
-          go-test-cmd: go test -race -coverprofile=coverage.txt $(go list ./...)
+          # disable the checkptr runtime check due a false positive in github.com/xssnick/tonutils-go
+          # causing tests in ci to fail "fatal error: checkptr: pointer arithmetic result points to invalid allocation"
+          # https://github.com/xssnick/tonutils-go/issues/310
+          go-test-cmd: go test -race -gcflags=all=-d=checkptr=0 -coverprofile=coverage.txt $(go list ./...)
           use-go-cache: true
 
   sonarqube:

--- a/chain/ton/provider/ctf_provider.go
+++ b/chain/ton/provider/ctf_provider.go
@@ -1,0 +1,235 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
+	"github.com/smartcontractkit/freeport"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/xssnick/tonutils-go/address"
+	"github.com/xssnick/tonutils-go/liteclient"
+	"github.com/xssnick/tonutils-go/tlb"
+	"github.com/xssnick/tonutils-go/ton"
+	"github.com/xssnick/tonutils-go/ton/wallet"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_ton "github.com/smartcontractkit/chainlink-deployments-framework/chain/ton"
+)
+
+// CTFChainProviderConfig holds the configuration to initialize the CTFChainProvider.
+type CTFChainProviderConfig struct {
+	// Required: A sync.Once instance to ensure that the CTF framework only sets up the new
+	// DefaultNetwork once
+	Once *sync.Once
+}
+
+// validate checks if the CTFChainProviderConfig is valid.
+func (c CTFChainProviderConfig) validate() error {
+	if c.Once == nil {
+		return errors.New("sync.Once instance is required")
+	}
+
+	return nil
+}
+
+var _ chain.Provider = (*CTFChainProvider)(nil)
+
+// CTFChainProvider manages a Ton chain instance running inside a Chainlink Testing Framework (CTF) Docker container.
+//
+// This provider requires Docker to be installed and operational. Spinning up a new container can be slow,
+// so it is recommended to initialize the provider only once per test suite or parent test to optimize performance.
+type CTFChainProvider struct {
+	t        *testing.T
+	selector uint64
+	config   CTFChainProviderConfig
+
+	chain *cldf_ton.Chain
+}
+
+// NewCTFChainProvider creates a new CTFChainProvider with the given selector and configuration.
+func NewCTFChainProvider(
+	t *testing.T, selector uint64, config CTFChainProviderConfig,
+) *CTFChainProvider {
+	t.Helper()
+
+	p := &CTFChainProvider{
+		t:        t,
+		selector: selector,
+		config:   config,
+	}
+
+	return p
+}
+
+// Initialize sets up the Ton chain by validating the configuration, starting a CTF container,
+// generating a deployer signer account, and constructing the chain instance.
+func (p *CTFChainProvider) Initialize(_ context.Context) (chain.BlockChain, error) {
+	if p.chain != nil {
+		return *p.chain, nil // Already initialized
+	}
+
+	if err := p.config.validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate provider config: %w", err)
+	}
+
+	// Get the Chain ID
+	chainID, err := chain_selectors.GetChainIDFromSelector(p.selector)
+	require.NoError(p.t, err, "failed to get chain ID from selector")
+
+	url, nodeClient := p.startContainer(chainID)
+	tonWallet := createTonWallet(p.t, nodeClient, wallet.V3R2, wallet.WithWorkchain(0))
+	// airdrop the deployer wallet
+	fundTonWallets(p.t, nodeClient, []*address.Address{tonWallet.Address()}, []tlb.Coins{tlb.MustFromTON("1000")})
+	p.chain = &cldf_ton.Chain{
+		ChainMetadata: cldf_ton.ChainMetadata{Selector: p.selector},
+		Client:        nodeClient,
+		Wallet:        tonWallet,
+		WalletAddress: tonWallet.Address(),
+		URL:           url,
+	}
+
+	return *p.chain, nil
+}
+
+func (p *CTFChainProvider) startContainer(chainID string) (string, *ton.APIClient) {
+	var (
+		attempts = uint(10)
+		url      string
+	)
+
+	// initialize the docker network used by CTF
+	err := framework.DefaultNetwork(p.config.Once)
+	require.NoError(p.t, err)
+
+	url, err = retry.DoWithData(func() (string, error) {
+		// Initialize a port for the container
+		port := freeport.GetOne(p.t)
+
+		// spin up mylocalton with CTFv2
+		output, rerr := blockchain.NewBlockchainNetwork(&blockchain.Input{
+			Type:    blockchain.TypeTon,
+			ChainID: chainID,
+			Port:    strconv.Itoa(port),
+		})
+		if rerr != nil {
+			// Return the ports to freeport to avoid leaking them during retries
+			freeport.Return([]int{port})
+
+			return "", rerr
+		}
+
+		testcontainers.CleanupContainer(p.t, output.Container)
+
+		return output.Nodes[0].ExternalHTTPUrl, nil
+	},
+		retry.Context(p.t.Context()),
+		retry.Attempts(attempts),
+		retry.Delay(1*time.Second),
+		retry.DelayType(retry.FixedDelay),
+		retry.OnRetry(func(attempt uint, err error) {
+			p.t.Logf("Attempt %d/%d: Failed to start CTF Ton container: %v", attempt+1, attempts, err)
+		}),
+	)
+	require.NoError(p.t, err, "Failed to start CTF Ton container after %d attempts", attempts)
+
+	// get local config from simple http server in genesis node
+	cfg, err := liteclient.GetConfigFromUrl(p.t.Context(), fmt.Sprintf("http://%s/localhost.global.config.json", url))
+	require.NoError(p.t, err)
+
+	// establish connection to the TON node
+	connectionPool := liteclient.NewConnectionPool()
+	err = connectionPool.AddConnectionsFromConfig(p.t.Context(), cfg)
+	require.NoError(p.t, err)
+	client := ton.NewAPIClient(connectionPool, ton.ProofCheckPolicyFast)
+	client.SetTrustedBlockFromConfig(cfg)
+
+	// check connection, CTFv2 handles the readiness
+	checkConnection(p.t, client)
+
+	return url, client
+}
+
+// Note: this utility functions can be replaced once we have in the chainlink-ton utils package
+func createTonWallet(t *testing.T, client ton.APIClientWrapped, version wallet.Version, option wallet.Option) *wallet.Wallet {
+	t.Helper()
+	//
+	seed := wallet.NewSeed()
+	rw, err := wallet.FromSeed(client, seed, version)
+	require.NoError(t, err)
+	pw, perr := wallet.FromPrivateKeyWithOptions(client, rw.PrivateKey(), version, option)
+	require.NoError(t, perr)
+
+	return pw
+}
+
+func fundTonWallets(t *testing.T, client ton.APIClientWrapped, recipients []*address.Address, amounts []tlb.Coins) {
+	t.Helper()
+
+	require.Len(t, amounts, len(recipients), "recipients and amounts must have the same length")
+	// initialize the prefunded wallet(Highload-V2), for other wallets, see https://github.com/neodix42/mylocalton-docker#pre-installed-wallets
+	version := wallet.HighloadV2Verified //nolint:staticcheck // SA1019: only available option in mylocalton-docker
+	rawHlWallet, err := wallet.FromSeed(client, strings.Fields(blockchain.DefaultTonHlWalletMnemonic), version)
+	require.NoError(t, err)
+
+	mcFunderWallet, err := wallet.FromPrivateKeyWithOptions(client, rawHlWallet.PrivateKey(), version, wallet.WithWorkchain(-1))
+	require.NoError(t, err)
+
+	funder, err := mcFunderWallet.GetSubwallet(uint32(42))
+	require.NoError(t, err)
+	// double check funder address
+	require.Equal(t, blockchain.DefaultTonHlWalletAddress, funder.Address().StringRaw(), "funder address mismatch")
+	// create transfer messages for each recipient
+	messages := make([]*wallet.Message, len(recipients))
+	for i, addr := range recipients {
+		transfer, terr := funder.BuildTransfer(addr, amounts[i], false, "")
+		require.NoError(t, terr)
+		messages[i] = transfer
+	}
+	_, _, txerr := funder.SendManyWaitTransaction(t.Context(), messages)
+	require.NoError(t, txerr, "airdrop transaction failed")
+	// we don't wait for the transaction to be confirmed here, as it may take some time
+}
+
+func checkConnection(t *testing.T, client *ton.APIClient) {
+	t.Helper()
+
+	err := retry.Do(func() error {
+		// check connection, CTFv2 handles the readiness
+		_, err := client.GetMasterchainInfo(t.Context())
+		return err
+	},
+		retry.Context(t.Context()),
+		retry.Attempts(30),
+		retry.Delay(1*time.Second),
+		retry.DelayType(retry.FixedDelay),
+	)
+
+	require.NoError(t, err, "TON network not ready")
+}
+
+// Name returns the name of the CTFChainProvider.
+func (*CTFChainProvider) Name() string {
+	return "Ton CTF Chain Provider"
+}
+
+// ChainSelector returns the chain selector of the Aptos chain managed by this provider.
+func (p *CTFChainProvider) ChainSelector() uint64 {
+	return p.selector
+}
+
+// BlockChain returns the Ton chain instance managed by this provider. You must call Initialize
+// before using this method to ensure the chain is properly set up.
+func (p *CTFChainProvider) BlockChain() chain.BlockChain {
+	return *p.chain
+}

--- a/chain/ton/provider/ctf_provider_test.go
+++ b/chain/ton/provider/ctf_provider_test.go
@@ -1,0 +1,122 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/testutils"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/ton"
+)
+
+func Test_CTFChainProviderConfig_validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  CTFChainProviderConfig
+		wantErr string
+	}{
+		{
+			name: "valid config",
+			config: CTFChainProviderConfig{
+				Once: testutils.DefaultNetworkOnce,
+			},
+			wantErr: "",
+		},
+		{
+			name: "missing sync.Once instance",
+			config: CTFChainProviderConfig{
+				Once: nil,
+			},
+			wantErr: "sync.Once instance is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.config.validate()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_CTFChainProvider_Initialize(t *testing.T) {
+	t.Parallel()
+
+	var chainSelector = chain_selectors.TEST_1000.Selector
+
+	tests := []struct {
+		name         string
+		giveSelector uint64
+		giveConfig   CTFChainProviderConfig
+		wantErr      string
+	}{
+		{
+			name:         "valid initialization",
+			giveSelector: chainSelector,
+			giveConfig: CTFChainProviderConfig{
+				Once: testutils.DefaultNetworkOnce,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := NewCTFChainProvider(t, tt.giveSelector, tt.giveConfig)
+
+			got, err := p.Initialize(t.Context())
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, p.chain)
+
+				// Check that the chain is of type ton.Chain and has the expected fields
+				gotChain, ok := got.(ton.Chain)
+				require.True(t, ok, "expected got to be of type ton.Chain")
+				assert.Equal(t, tt.giveSelector, gotChain.Selector)
+				assert.NotEmpty(t, gotChain.Client)
+				assert.NotEmpty(t, gotChain.Wallet)
+				assert.NotEmpty(t, gotChain.WalletAddress)
+			}
+		})
+	}
+}
+
+func Test_CTFChainProvider_Name(t *testing.T) {
+	t.Parallel()
+
+	p := &CTFChainProvider{}
+	assert.Equal(t, "Ton CTF Chain Provider", p.Name())
+}
+
+func Test_CTFChainProvider_ChainSelector(t *testing.T) {
+	t.Parallel()
+
+	p := &CTFChainProvider{selector: chain_selectors.TEST_1000.Selector}
+	assert.Equal(t, chain_selectors.TEST_1000.Selector, p.ChainSelector())
+}
+
+func Test_CTFChainProvider_BlockChain(t *testing.T) {
+	t.Parallel()
+
+	chain := &ton.Chain{}
+
+	p := &CTFChainProvider{
+		chain: chain,
+	}
+
+	assert.Equal(t, *chain, p.BlockChain())
+}


### PR DESCRIPTION
Create new CTF provider for ton chain. Migrated the code from Chainlink [here](https://github.com/smartcontractkit/chainlink/blob/1d22b7e8f9f52d4e1725bffaf9eb49d1132152d2/deployment/environment/memory/ton_chains.go#L71-L71), adjusted it to fit the design and added some testing.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-424