### PR TITLE
[CLD-429]: test: enable skipped test and improve readiness check

### DIFF
--- a/chain/aptos/provider/ctf_provider.go
+++ b/chain/aptos/provider/ctf_provider.go
@@ -159,7 +159,7 @@ func (p *CTFChainProvider) startContainer(
 
 		input := &blockchain.Input{
 			Image:     "", // filled out by defaultAptos function
-			Type:      "aptos",
+			Type:      blockchain.TypeAptos,
 			ChainID:   chainID,
 			PublicKey: account.Address.String(),
 			CustomPorts: []string{

--- a/chain/evm/provider/zksync_ctf_provider_test.go
+++ b/chain/evm/provider/zksync_ctf_provider_test.go
@@ -52,8 +52,6 @@ func Test_ZkSyncCTFChainProviderConfig_validate(t *testing.T) {
 }
 
 func Test_CTFChainProvider_Initialize(t *testing.T) {
-	t.Skip("Skipping test for CTF chain provider initialization, too flaky when starting container," +
-		" enable once the issue is resolved")
 	t.Parallel()
 
 	var chainSelector = chain_selectors.TEST_1000.Selector
@@ -130,8 +128,6 @@ func Test_ZkSyncCTFChainProvider_BlockChain(t *testing.T) {
 }
 
 func Test_ZkSyncCTFChainProvider_SignHash(t *testing.T) {
-	t.Skip("Skipping test, too flaky when starting container," +
-		" enable once the issue is resolved")
 	t.Parallel()
 
 	var chainSelector = chain_selectors.TEST_1000.Selector

--- a/chain/solana/provider/ctf_provider.go
+++ b/chain/solana/provider/ctf_provider.go
@@ -216,7 +216,7 @@ func (p *CTFChainProvider) startContainer(
 
 		input := &blockchain.Input{
 			Image:          image,
-			Type:           "solana",
+			Type:           blockchain.TypeSolana,
 			ChainID:        chainID,
 			PublicKey:      adminPubKey.String(),
 			Port:           strconv.Itoa(ports[0]),

--- a/chain/solana/provider/rpcclient/client_test.go
+++ b/chain/solana/provider/rpcclient/client_test.go
@@ -90,7 +90,7 @@ func startSolanaContainer(
 
 	bcInput := &blockchain.Input{
 		Image:     image,
-		Type:      "solana",
+		Type:      blockchain.TypeSolana,
 		ChainID:   chainID,
 		PublicKey: publicKey.String(),
 		Port:      strconv.Itoa(ports[0]),


### PR DESCRIPTION
Earlier some test that starts docker container were skipped due to flakiness. I have been running them again the CI many times, and it doesnt seem to be flaky anymore, I will enable the tests again and monitor them.

Also updated the string for chain type to use the enum from CTF

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-429