### PR TITLE
[CLD-388]: fix(multiclient): include chainsel & name in log message on health check

### DIFF
--- a/.changeset/true-moons-hug.md
+++ b/.changeset/true-moons-hug.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix: improve log message on multiclient healthcheck

--- a/deployment/multiclient.go
+++ b/deployment/multiclient.go
@@ -105,12 +105,12 @@ func NewMultiClient(lggr logger.Logger, rpcsCfg RPCConfig, opts ...func(client *
 	for i, rpc := range rpcsCfg.RPCs {
 		client, err := mc.dialWithRetry(rpc, lggr)
 		if err != nil {
-			lggr.Warnf("failed to dial client %d for RPC '%s' trying with the next one: %v", i, rpc.Name, err)
+			lggr.Warnf("failed to dial client %d for RPC '%s' - %s (%d), trying with the next one: %v", i, rpc.Name, chain.Name, chain.Selector, err)
 
 			continue
 		}
 		if err := mc.rpcHealthCheck(context.Background(), client); err != nil {
-			lggr.Warnf("health check failed for client %d for RPC '%s' trying with the next one: %v", i, rpc.Name, err)
+			lggr.Warnf("health check failed for client %d for RPC '%s' - %s (%d), trying with the next one: %v", i, rpc.Name, chain.Name, chain.Selector, err)
 			client.Close()
 
 			continue


### PR DESCRIPTION
As raised [here](https://chainlink-core.slack.com/archives/C08QE4ST1L2/p1750430667259899?thread_ts=1750427821.721129&cid=C08QE4ST1L2)by our user in support, to help with debugging, we want to include the chain selector and chain name as part of the log message.

```
logger.go:146: 23:47:25.703903000	WARN	health check failed for client 0 for RPC 'bad-rpc' - ethereum-testnet-sepolia (16015286601757825753), trying with the next one: health check failed: internal error	{"version": "(devel)@unset"}
```

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-388