### PR TITLE
[CLD-480]: feat: added JD client and provider

### DIFF
--- a/.changeset/salty-books-kick.md
+++ b/.changeset/salty-books-kick.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat: new JD client and offchain provider for JD

--- a/go.mod
+++ b/go.mod
@@ -20,14 +20,12 @@ require (
 	github.com/gagliardetto/solana-go v1.12.0
 	github.com/google/uuid v1.6.0
 	github.com/pelletier/go-toml/v2 v2.2.4
-	github.com/rs/zerolog v1.33.0
 	github.com/smartcontractkit/chain-selectors v1.0.60
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250520123946-6aaf88e0848a
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250425195105-d9eabb4a4519
 	github.com/smartcontractkit/chainlink-evm v0.0.0-20250424162751-35c5921b8597
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.9
-	github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.1
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250422175525-b7575d96bd4d
 	github.com/smartcontractkit/freeport v0.1.1
@@ -38,6 +36,7 @@ require (
 	github.com/zksync-sdk/zksync2-go v1.1.1-0.20250620124214-2c742ee399c6
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0
+	golang.org/x/oauth2 v0.26.0
 	google.golang.org/grpc v1.71.0
 	google.golang.org/protobuf v1.36.6
 )
@@ -210,6 +209,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/rs/cors v1.11.1 // indirect
+	github.com/rs/zerolog v1.33.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
 	github.com/scylladb/go-reflectx v1.0.1 // indirect
@@ -260,6 +260,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.3.1 // indirect
 	golang.org/x/crypto v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -666,8 +666,6 @@ github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0 h1:/bhoALRz
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.9 h1:0IJFn61lpb3XE+n9q80Q2JuEXc8HI1FfXc9sZUJ8qBg=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.9/go.mod h1:47sm4C5wBxR8VBAZoDRGSt5wJwDJN3vVeE36l5vQs1g=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.1 h1:3KiRoOPda+ZB4GtdXY15e+ykCWLGBF9zSXVlIrWrBgw=
-github.com/smartcontractkit/chainlink-testing-framework/lib v1.54.1/go.mod h1:orWoMb61wz6RwW++jIOXVmCoVuLIAoowtgrCvLGNBLQ=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6Be5//TyjPi1pS1uotnmcYq5vVkSyISIymSj8=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250422175525-b7575d96bd4d h1:Yc1iLWCbgYHJAVrnMfNEVwSspk+dG/yxYmGbz0jeXw8=
@@ -895,6 +893,8 @@ golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
 golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.26.0 h1:afQXWNNaeC4nvZ0Ed9XvCCzXM6UHJG7iCg0W4fPqSBE=
+golang.org/x/oauth2 v0.26.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/offchain/jd/client.go
+++ b/offchain/jd/client.go
@@ -1,0 +1,99 @@
+package jd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	csav1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/csa"
+	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
+	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// JDConfig is the configuration for the Job Distributor client.
+type JDConfig struct {
+	GRPC  string
+	WSRPC string
+	Creds credentials.TransportCredentials
+	Auth  oauth2.TokenSource
+}
+
+// JobDistributor is the client for the Job Distributor service.
+type JobDistributor struct {
+	WSRPC string
+	nodev1.NodeServiceClient
+	jobv1.JobServiceClient
+	csav1.CSAServiceClient
+}
+
+// NewJDClient creates a new Job Distributor client
+func NewJDClient(cfg JDConfig) (*JobDistributor, error) {
+	conn, err := newJDConnection(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect Job Distributor service. Err: %w", err)
+	}
+	jd := &JobDistributor{
+		WSRPC:             cfg.WSRPC,
+		NodeServiceClient: nodev1.NewNodeServiceClient(conn),
+		JobServiceClient:  jobv1.NewJobServiceClient(conn),
+		CSAServiceClient:  csav1.NewCSAServiceClient(conn),
+	}
+
+	return jd, err
+}
+
+// GetCSAPublicKey returns the public key for the CSA service
+func (jd *JobDistributor) GetCSAPublicKey(ctx context.Context) (string, error) {
+	keypairs, err := jd.ListKeypairs(ctx, &csav1.ListKeypairsRequest{})
+	if err != nil {
+		return "", err
+	}
+	if keypairs == nil || len(keypairs.Keypairs) == 0 {
+		return "", errors.New("no keypairs found")
+	}
+	csakey := keypairs.Keypairs[0].PublicKey
+
+	return csakey, nil
+}
+
+// ProposeJob proposes jobs through the jobService and accepts the proposed job on selected node based on ProposeJobRequest.NodeId
+func (jd *JobDistributor) ProposeJob(ctx context.Context, in *jobv1.ProposeJobRequest, opts ...grpc.CallOption) (*jobv1.ProposeJobResponse, error) {
+	res, err := jd.JobServiceClient.ProposeJob(ctx, in, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to propose job. err: %w", err)
+	}
+	if res.Proposal == nil {
+		return nil, errors.New("failed to propose job. err: proposal is nil")
+	}
+
+	return res, nil
+}
+
+func newJDConnection(cfg JDConfig) (*grpc.ClientConn, error) {
+	opts := []grpc.DialOption{}
+	interceptors := []grpc.UnaryClientInterceptor{}
+
+	if cfg.Creds != nil {
+		opts = append(opts, grpc.WithTransportCredentials(cfg.Creds))
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+	if cfg.Auth != nil {
+		interceptors = append(interceptors, authTokenInterceptor(cfg.Auth))
+	}
+
+	if len(interceptors) > 0 {
+		opts = append(opts, grpc.WithChainUnaryInterceptor(interceptors...))
+	}
+
+	conn, err := grpc.NewClient(cfg.GRPC, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect Job Distributor service. Err: %w", err)
+	}
+
+	return conn, nil
+}

--- a/offchain/jd/client_test.go
+++ b/offchain/jd/client_test.go
@@ -1,0 +1,81 @@
+package jd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestNewJDClient_ConfigurationScenarios(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		config      JDConfig
+		description string
+	}{
+		{
+			name: "basic config with credentials",
+			config: JDConfig{
+				GRPC:  "localhost:9090",
+				Creds: insecure.NewCredentials(),
+			},
+			description: "Basic configuration with insecure credentials",
+		},
+		{
+			name: "config with WSRPC",
+			config: JDConfig{
+				GRPC:  "localhost:9090",
+				WSRPC: "ws://localhost:9091",
+				Creds: insecure.NewCredentials(),
+			},
+			description: "Configuration with WebSocket RPC endpoint",
+		},
+		{
+			name: "config with OAuth2 auth",
+			config: JDConfig{
+				GRPC:  "localhost:9090",
+				Creds: insecure.NewCredentials(),
+				Auth:  oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+			},
+			description: "Configuration with OAuth2 authentication",
+		},
+
+		{
+			name: "complete config",
+			config: JDConfig{
+				GRPC:  "localhost:9090",
+				WSRPC: "ws://localhost:9091",
+				Creds: insecure.NewCredentials(),
+				Auth:  oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}),
+			},
+			description: "Complete configuration with all options",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client, err := NewJDClient(tt.config)
+
+			// gRPC connection creation typically succeeds even without server
+			// The actual connection failure happens on first RPC call
+			if err != nil {
+				t.Logf("Connection failed for %s: %v", tt.description, err)
+				assert.Contains(t, err.Error(), "failed to connect Job Distributor service")
+			} else {
+				require.NotNil(t, client, "Client should not be nil for %s", tt.description)
+
+				// Verify fields are set correctly
+				assert.Equal(t, tt.config.WSRPC, client.WSRPC)
+				assert.NotNil(t, client.NodeServiceClient)
+				assert.NotNil(t, client.JobServiceClient)
+				assert.NotNil(t, client.CSAServiceClient)
+			}
+		})
+	}
+}

--- a/offchain/jd/doc.go
+++ b/offchain/jd/doc.go
@@ -1,0 +1,142 @@
+/*
+Package jd provides a comprehensive framework for interacting with Job Distributor (JD) services
+in the Chainlink Deployments Framework ecosystem.
+
+# Overview
+
+The JD package enables seamless integration with
+Job Distributor services through gRPC communication. It supports multiple authentication
+mechanisms and provides a unified interface for job management operations.
+
+# Architecture
+
+The package consists of two main components:
+
+1. **JD Client** (`client.go`) - Core gRPC client implementation
+2. **Provider Interface** (`provider/`) - A wrapper around the JD client that provides a standarized interface
+
+# Basic Usage
+
+## Simple Connection
+
+For basic connectivity without authentication:
+
+	import (
+		"context"
+		"google.golang.org/grpc/credentials/insecure"
+		"github.com/smartcontractkit/chainlink-deployments-framework/offchain/jd"
+	)
+
+	config := jd.JDConfig{
+		GRPC:  "localhost:9090",
+		WSRPC: "ws://localhost:9091"
+	}
+
+	client, err := jd.NewJDClient(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Use client for operations
+	pubKey, err := client.GetCSAPublicKey(ctx)
+
+## Provider Interface
+
+	import (
+		"github.com/smartcontractkit/chainlink-deployments-framework/offchain/jd/provider"
+	)
+
+	providerConfig := provider.ClientOffchainProviderConfig{
+		GRPC:  "localhost:9090",
+		WSRPC: "ws://localhost:9091",
+		Creds: insecure.NewCredentials(),
+	}
+
+	prov, err := provider.NewClientOffchainProvider(providerConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Initialize with environment
+	err = prov.Initialize(env)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Get client
+	client, err := prov.OffchainClient()
+
+	// client is compatible with the Offchain field in the Environment struct
+
+# Authentication
+
+The package supports three authentication mechanisms:
+
+## 1. No Authentication
+
+For development or internal networks:
+
+	config := jd.JDConfig{
+		GRPC:  "localhost:9090",
+		Creds: insecure.NewCredentials(),
+	}
+
+## 2. OAuth2 Authentication
+
+For services requiring OAuth2 Bearer tokens:
+
+	import "golang.org/x/oauth2"
+
+	tokenSource := oauth2.StaticTokenSource(&oauth2.Token{
+		AccessToken: "your-access-token",
+		TokenType:   "Bearer",
+	})
+
+	config := jd.JDConfig{
+		GRPC:        "secure.jobdistributor.com:443",
+		WSRPC:       "wss://secure.jobdistributor.com:443/ws",
+		OAuth2:      tokenSource,
+		Creds:       credentials.NewTLS(&tls.Config{}),
+	}
+
+# Client Operations
+
+The JD client supports various operations:
+
+## CSA Key Management
+
+	// Get CSA public key
+	pubKey, err := client.GetCSAPublicKey(ctx)
+	if err != nil {
+		log.Printf("Failed to get CSA key: %v", err)
+	}
+
+## Job Management
+
+	import "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
+
+	jobSpec := &job.ProposeJobRequest{
+		NodeIds: []string{"node-1", "node-2"},
+		Spec:    "job specification here",
+	}
+
+	response, err := client.ProposeJob(ctx, jobSpec)
+	if err != nil {
+		log.Printf("Failed to propose job: %v", err)
+	}
+
+# Configuration Validation
+
+The provider automatically validates configurations:
+
+	config := provider.ClientOffchainProviderConfig{
+		GRPC: "", // Invalid - will cause validation error
+	}
+
+	prov, err := provider.NewClientOffchainProvider(config)
+	if err != nil {
+		// Handle validation error
+		log.Printf("Invalid configuration: %v", err)
+	}
+*/
+package jd

--- a/offchain/jd/interceptor.go
+++ b/offchain/jd/interceptor.go
@@ -1,0 +1,30 @@
+package jd
+
+import (
+	"context"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func authTokenInterceptor(source oauth2.TokenSource) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		token, err := source.Token()
+		if err != nil {
+			return err
+		}
+
+		return invoker(
+			metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token.AccessToken),
+			method, req, reply, cc, opts...,
+		)
+	}
+}

--- a/offchain/jd/interceptor_test.go
+++ b/offchain/jd/interceptor_test.go
@@ -1,0 +1,135 @@
+package jd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// Mock TokenSource for testing OAuth2 functionality
+type MockTokenSource struct {
+	mock.Mock
+}
+
+func (m *MockTokenSource) Token() (*oauth2.Token, error) {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+
+	return args.Get(0).(*oauth2.Token), args.Error(1)
+}
+
+// Mock UnaryInvoker for testing interceptor behavior
+type MockUnaryInvoker struct {
+	mock.Mock
+	capturedCtx context.Context //nolint:containedctx // Needed to capture modified context in tests
+}
+
+func (m *MockUnaryInvoker) Invoke(
+	ctx context.Context,
+	method string,
+	req, reply any,
+	cc *grpc.ClientConn,
+	opts ...grpc.CallOption,
+) error {
+	m.capturedCtx = ctx // Capture the context to verify metadata
+	args := m.Called(ctx, method, req, reply, cc, opts)
+
+	return args.Error(0)
+}
+
+func TestAuthTokenInterceptor_Success(t *testing.T) {
+	t.Parallel()
+
+	// Setup
+	mockTokenSource := &MockTokenSource{}
+	expectedToken := &oauth2.Token{
+		AccessToken: "test-access-token-123",
+		TokenType:   "Bearer",
+		Expiry:      time.Now().Add(time.Hour),
+	}
+	mockTokenSource.On("Token").Return(expectedToken, nil)
+
+	mockInvoker := &MockUnaryInvoker{}
+	mockInvoker.On("Invoke", mock.Anything, "test.method", "request", "reply", (*grpc.ClientConn)(nil), []grpc.CallOption(nil)).Return(nil)
+
+	// Create interceptor
+	interceptor := authTokenInterceptor(mockTokenSource)
+
+	// Execute
+	ctx := context.Background()
+	err := interceptor(ctx, "test.method", "request", "reply", nil, mockInvoker.Invoke)
+
+	// Verify
+	require.NoError(t, err)
+	mockTokenSource.AssertExpectations(t)
+	mockInvoker.AssertExpectations(t)
+
+	// Verify that the authorization header was added to the context
+	md, exists := metadata.FromOutgoingContext(mockInvoker.capturedCtx)
+	require.True(t, exists)
+	authHeaders := md.Get("authorization")
+	require.Len(t, authHeaders, 1)
+	assert.Equal(t, "Bearer test-access-token-123", authHeaders[0])
+}
+
+func TestAuthTokenInterceptor_TokenError(t *testing.T) {
+	t.Parallel()
+
+	// Setup
+	mockTokenSource := &MockTokenSource{}
+	expectedError := errors.New("token retrieval failed")
+	mockTokenSource.On("Token").Return(nil, expectedError)
+
+	mockInvoker := &MockUnaryInvoker{} // Should not be called
+
+	// Create interceptor
+	interceptor := authTokenInterceptor(mockTokenSource)
+
+	// Execute
+	ctx := context.Background()
+	err := interceptor(ctx, "test.method", "request", "reply", nil, mockInvoker.Invoke)
+
+	// Verify
+	require.Error(t, err)
+	assert.Equal(t, expectedError, err)
+	mockTokenSource.AssertExpectations(t)
+	mockInvoker.AssertNotCalled(t, "Invoke")
+}
+
+func TestInterceptors_CallOptionsPreservation(t *testing.T) {
+	t.Parallel()
+
+	// Test that call options are properly passed through interceptors
+	t.Run("authTokenInterceptor", func(t *testing.T) {
+		t.Parallel()
+
+		// Setup
+		mockTokenSource := &MockTokenSource{}
+		mockTokenSource.On("Token").Return(&oauth2.Token{AccessToken: "test"}, nil)
+
+		mockInvoker := &MockUnaryInvoker{}
+		expectedOpts := []grpc.CallOption{grpc.WaitForReady(true)}
+		mockInvoker.On("Invoke", mock.Anything, "test.method", "request", "reply", (*grpc.ClientConn)(nil), expectedOpts).Return(nil)
+
+		interceptor := authTokenInterceptor(mockTokenSource)
+
+		// Execute
+		ctx := context.Background()
+		err := interceptor(ctx, "test.method", "request", "reply", nil, mockInvoker.Invoke, expectedOpts...)
+
+		// Verify
+		require.NoError(t, err)
+		mockInvoker.AssertExpectations(t)
+		mockTokenSource.AssertExpectations(t)
+	})
+}

--- a/offchain/jd/provider/client_provider.go
+++ b/offchain/jd/provider/client_provider.go
@@ -1,0 +1,92 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/offchain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/offchain/jd"
+)
+
+// ClientOffchainProviderConfig holds the configuration to initialize the ClientOffchainProvider.
+type ClientOffchainProviderConfig struct {
+	// Required: The gRPC URL to connect to the Job Distributor service.
+	GRPC string
+	// Optional: The WebSocket RPC URL for the Job Distributor service.
+	WSRPC string
+	// Optional: Transport credentials for secure gRPC connections. Defaults to insecure.NewCredentials()
+	Creds credentials.TransportCredentials
+	// Optional: OAuth2 token source for authentication.
+	Auth oauth2.TokenSource
+}
+
+// validate checks if the ClientOffchainProviderConfig is valid.
+func (c ClientOffchainProviderConfig) validate() error {
+	if c.GRPC == "" {
+		return errors.New("gRPC URL is required")
+	}
+
+	return nil
+}
+
+var _ offchain.Provider = (*ClientOffchainProvider)(nil)
+
+// ClientOffchainProvider is a JD provider that connects to a Job Distributor service via gRPC.
+type ClientOffchainProvider struct {
+	config ClientOffchainProviderConfig
+	client deployment.OffchainClient
+}
+
+// NewClientOffchainProvider creates a new ClientOffchainProvider with the given configuration.
+func NewClientOffchainProvider(config ClientOffchainProviderConfig) *ClientOffchainProvider {
+	return &ClientOffchainProvider{
+		config: config,
+	}
+}
+
+// Initialize initializes the ClientOffchainProvider, setting up the JD client with the provided
+// configuration. It returns the initialized deployment.OffchainClient or an error if initialization fails.
+func (p *ClientOffchainProvider) Initialize(ctx context.Context) (deployment.OffchainClient, error) {
+	if p.client != nil {
+		return p.client, nil // Already initialized
+	}
+
+	// Validate the provider configuration
+	if err := p.config.validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate provider config: %w", err)
+	}
+
+	// Create JD configuration from provider config
+	jdConfig := jd.JDConfig{
+		GRPC:  p.config.GRPC,
+		WSRPC: p.config.WSRPC,
+		Creds: p.config.Creds,
+		Auth:  p.config.Auth,
+	}
+
+	// Create the JD client
+	client, err := jd.NewJDClient(jdConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JD client: %w", err)
+	}
+
+	p.client = client
+
+	return client, nil
+}
+
+// Name returns the name of the ClientOffchainProvider.
+func (*ClientOffchainProvider) Name() string {
+	return "Job Distributor Client Offchain Provider"
+}
+
+// OffchainClient returns the JD client instance managed by this provider.
+// You must call Initialize before using this method to ensure the client is properly set up.
+func (p *ClientOffchainProvider) OffchainClient() deployment.OffchainClient {
+	return p.client
+}

--- a/offchain/jd/provider/client_provider_test.go
+++ b/offchain/jd/provider/client_provider_test.go
@@ -1,0 +1,117 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientOffchainProviderConfig_validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  ClientOffchainProviderConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid config with minimal fields",
+			config: ClientOffchainProviderConfig{
+				GRPC: "localhost:9090",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config with all fields",
+			config: ClientOffchainProviderConfig{
+				GRPC:  "localhost:9090",
+				WSRPC: "ws://localhost:9091",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid config - missing GRPC",
+			config:  ClientOffchainProviderConfig{},
+			wantErr: true,
+			errMsg:  "gRPC URL is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.config.validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewClientOffchainProvider(t *testing.T) {
+	t.Parallel()
+
+	config := ClientOffchainProviderConfig{
+		GRPC: "localhost:9090",
+	}
+
+	provider := NewClientOffchainProvider(config)
+
+	require.NotNil(t, provider)
+	assert.Equal(t, config, provider.config)
+	assert.Nil(t, provider.client) // Should be nil until initialized
+}
+
+func TestClientOffchainProvider_Name(t *testing.T) {
+	t.Parallel()
+
+	provider := NewClientOffchainProvider(ClientOffchainProviderConfig{
+		GRPC: "localhost:9090",
+	})
+
+	assert.Equal(t, "Job Distributor Client Offchain Provider", provider.Name())
+}
+
+func TestClientOffchainProvider_Initialize_ValidationError(t *testing.T) {
+	t.Parallel()
+
+	// Test with invalid config
+	provider := NewClientOffchainProvider(ClientOffchainProviderConfig{})
+
+	client, err := provider.Initialize(context.Background())
+
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "failed to validate provider config")
+}
+
+func TestClientOffchainProvider_OffchainClient_BeforeInitialize(t *testing.T) {
+	t.Parallel()
+
+	provider := NewClientOffchainProvider(ClientOffchainProviderConfig{
+		GRPC: "localhost:9090",
+	})
+
+	client := provider.OffchainClient()
+	assert.Nil(t, client) // Should be nil before initialization
+}
+
+func TestInitializeProvider(t *testing.T) {
+	t.Parallel()
+
+	// Test with invalid provider
+	provider := NewClientOffchainProvider(ClientOffchainProviderConfig{})
+
+	client, err := provider.Initialize(context.Background())
+
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "failed to validate provider config")
+}

--- a/offchain/offchain.go
+++ b/offchain/offchain.go
@@ -1,0 +1,6 @@
+package offchain
+
+import "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
+// OffchainClient is an alias for the deployment.OffchainClient type for now until we migrate all reference over to the new offchain package.
+type OffchainClient = deployment.OffchainClient

--- a/offchain/provider.go
+++ b/offchain/provider.go
@@ -1,0 +1,14 @@
+package offchain
+
+import "context"
+
+// Provider interface for offchain client providers.
+type Provider interface {
+	// Initialize sets up the offchain client and returns the instance.
+	Initialize(ctx context.Context) (OffchainClient, error)
+	// Name returns a human-readable name for this provider.
+	Name() string
+	// OffchainClient returns the initialized offchain client instance.
+	// You must call Initialize before using this method.
+	OffchainClient() OffchainClient
+}


### PR DESCRIPTION
Migrated the JD client and introduced a offchain provider for JD.

Note this JD client is missing the DON capability compared to the JD client in Chainlink repo. This is because DON capability involves bringing over a huge amount of code (including generated code) from the Chainlink repo which is currently not used in CLD.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-480