### PR TITLE
[CLD-486]: feat: new CTF Provider for JD

### DIFF
--- a/.changeset/smart-parts-camp.md
+++ b/.changeset/smart-parts-camp.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat: new CTF provider for JD

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -8,24 +8,17 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	csav1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/csa"
-	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
-	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
-// OffchainClient interacts with the job-distributor
-// which is a family agnostic interface for performing
-// DON operations.
-type OffchainClient interface {
-	jobv1.JobServiceClient
-	nodev1.NodeServiceClient
-	csav1.CSAServiceClient
-}
+// OffchainClient is an alias for the offchain.Client type for now until we migrate all reference over to the new offchain package.
+// Then we will remove this alias.
+type OffchainClient = offchain.Client
 
 func MaybeDataErr(err error) error {
 	//revive:disable

--- a/offchain/jd/provider/client_provider.go
+++ b/offchain/jd/provider/client_provider.go
@@ -8,7 +8,6 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc/credentials"
 
-	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/offchain/jd"
 )
@@ -39,7 +38,7 @@ var _ offchain.Provider = (*ClientOffchainProvider)(nil)
 // ClientOffchainProvider is a JD provider that connects to a Job Distributor service via gRPC.
 type ClientOffchainProvider struct {
 	config ClientOffchainProviderConfig
-	client deployment.OffchainClient
+	client offchain.Client
 }
 
 // NewClientOffchainProvider creates a new ClientOffchainProvider with the given configuration.
@@ -50,8 +49,8 @@ func NewClientOffchainProvider(config ClientOffchainProviderConfig) *ClientOffch
 }
 
 // Initialize initializes the ClientOffchainProvider, setting up the JD client with the provided
-// configuration. It returns the initialized deployment.OffchainClient or an error if initialization fails.
-func (p *ClientOffchainProvider) Initialize(ctx context.Context) (deployment.OffchainClient, error) {
+// configuration. It returns the initialized offchain.Client or an error if initialization fails.
+func (p *ClientOffchainProvider) Initialize(ctx context.Context) (offchain.Client, error) {
 	if p.client != nil {
 		return p.client, nil // Already initialized
 	}
@@ -87,6 +86,6 @@ func (*ClientOffchainProvider) Name() string {
 
 // OffchainClient returns the JD client instance managed by this provider.
 // You must call Initialize before using this method to ensure the client is properly set up.
-func (p *ClientOffchainProvider) OffchainClient() deployment.OffchainClient {
+func (p *ClientOffchainProvider) OffchainClient() offchain.Client {
 	return p.client
 }

--- a/offchain/jd/provider/ctf_integration_test.go
+++ b/offchain/jd/provider/ctf_integration_test.go
@@ -1,0 +1,92 @@
+package provider_test
+
+import (
+	"testing"
+
+	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
+	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/offchain/jd/provider"
+)
+
+// TestCTFOffchainProvider_WithLocalImage demonstrates how to use the CTF provider
+// with a JD Docker image from AWS ECR.
+
+// To authenticate with ECR before running:
+// 1. AWS CLI configured with access to ECR: use aws sso login to AWS Account which has the ECR repository containing the JD image.
+// 2. aws ecr get-login-password --region <region> | docker login --username AWS --password-stdin <ECR_REPO_URL>
+//
+// Alternatively, you can build the JD image locally and use it directly.
+// Run this test with: go test -v -run TestCTFOffchainProvider_WithLocalImage
+func TestCTFOffchainProvider_WithLocalImage(t *testing.T) {
+	t.Parallel()
+
+	// Skip by default - uncomment the next line to run integration tests
+	t.Skip("Integration test with ECR Docker image - enable manually")
+
+	config := provider.CTFOffchainProviderConfig{
+		// Use ECR image from private AWS account
+		Image: "<IMAGE_TAG>", // UPDATE THIS
+
+		// Use default ports (optional to specify)
+		GRPCPort:  "14231",
+		WSRPCPort: "8080",
+
+		// Valid 64-character hex CSA encryption key
+		CSAEncryptionKey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+
+		// Optional: Custom database configuration
+		// DBInput: &postgres.Input{
+		//     Image: "postgres:16",
+		//     Port:  15432, // Use different port to avoid conflicts
+		//     Name:  "jd-test-db",
+		// },
+	}
+
+	// Create the CTF provider
+	jdProvider := provider.NewCTFOffchainProvider(t, config)
+
+	// Initialize the provider (this starts Docker containers)
+	t.Log("Initializing JD CTF provider with ECR image...")
+	jdClient, err := jdProvider.Initialize(t.Context())
+	require.NoError(t, err, "Failed to initialize JD CTF provider")
+	require.NotNil(t, jdClient, "JD client should not be nil")
+
+	t.Log("JD CTF provider initialized successfully - health check passed")
+
+	// Test 1: Node Service - List nodes
+	t.Run("Node_ListNodes", func(t *testing.T) {
+		t.Parallel()
+
+		nodes, err := jdClient.ListNodes(t.Context(), &nodev1.ListNodesRequest{})
+		require.NoError(t, err, "Failed to list nodes")
+		require.NotNil(t, nodes, "Nodes response should not be nil")
+
+		t.Logf("Found %d nodes", len(nodes.Nodes))
+
+		// Log node information if any exist
+		for i, node := range nodes.Nodes {
+			t.Logf("Node %d: ID=%s", i, node.Id)
+		}
+	})
+
+	// Test 2: Job Service - List jobs
+	t.Run("Job_ListJobs", func(t *testing.T) {
+		t.Parallel()
+
+		jobs, err := jdClient.ListJobs(t.Context(), &jobv1.ListJobsRequest{})
+		require.NoError(t, err, "Failed to list jobs")
+		require.NotNil(t, jobs, "Jobs response should not be nil")
+
+		t.Logf("Found %d jobs", len(jobs.Jobs))
+
+		// Log job information if any exist
+		for i, job := range jobs.Jobs {
+			t.Logf("Job %d: ID=%s", i, job.Id)
+		}
+	})
+
+	t.Log("All JD integration tests completed successfully")
+}

--- a/offchain/jd/provider/ctf_provider.go
+++ b/offchain/jd/provider/ctf_provider.go
@@ -1,0 +1,183 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	csav1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/csa"
+	ctf_jd "github.com/smartcontractkit/chainlink-testing-framework/framework/components/jd"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/postgres"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/offchain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/offchain/jd"
+)
+
+const (
+	// DefaultCSAEncryptionKey is the default CSA encryption key used when none is provided
+	DefaultCSAEncryptionKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+)
+
+// CTFOffchainProviderConfig holds the configuration to initialize the CTFOffchainProvider.
+type CTFOffchainProviderConfig struct {
+	// Optional: Docker image for the JD service. If not provided, will use environment variable CTF_JD_IMAGE.
+	Image string
+	// Optional: GRPC port for the JD service. Defaults to 14231.
+	GRPCPort string
+	// Optional: WebSocket RPC port for the JD service. Defaults to 8080.
+	WSRPCPort string
+	// Optional: CSA encryption key. Defaults to a 64-character hex string.
+	CSAEncryptionKey string
+	// Optional: Docker file path for building JD image locally.
+	DockerFilePath string
+	// Optional: Docker context for building JD image locally.
+	DockerContext string
+	// Optional: SQL dump path for JD database initialization.
+	JDSQLDumpPath string
+	// Optional: PostgreSQL database configuration. If not provided, will use default.
+	DBInput *postgres.Input
+}
+
+// validate checks if the CTFOffchainProviderConfig is valid.
+func (c CTFOffchainProviderConfig) validate() error {
+	// Check if either Image is provided or CTF_JD_IMAGE environment variable is set
+	if c.Image == "" {
+		ctfJDImage := os.Getenv("CTF_JD_IMAGE")
+		if ctfJDImage == "" {
+			return errors.New("either Image must be provided in config or CTF_JD_IMAGE environment variable must be set")
+		}
+	}
+
+	return nil
+}
+
+var _ offchain.Provider = (*CTFOffchainProvider)(nil)
+
+// CTFOffchainProvider manages a Job Distributor (JD) instance running inside a Chainlink Testing Framework
+// (CTF) Docker container.
+//
+// This provider requires Docker to be installed and operational. Spinning up a new container
+// can be slow, so it is recommended to initialize the provider only once per test suite or parent
+// test to optimize performance.
+type CTFOffchainProvider struct {
+	t      *testing.T
+	config CTFOffchainProviderConfig
+
+	client offchain.Client
+}
+
+// NewCTFOffchainProvider creates a new CTFOffchainProvider with the given configuration.
+func NewCTFOffchainProvider(
+	t *testing.T, config CTFOffchainProviderConfig,
+) *CTFOffchainProvider {
+	t.Helper()
+
+	p := &CTFOffchainProvider{
+		t:      t,
+		config: config,
+	}
+
+	return p
+}
+
+// Initialize sets up the Job Distributor by validating the configuration, starting a CTF container,
+// and constructing the JD client instance.
+func (p *CTFOffchainProvider) Initialize(ctx context.Context) (offchain.Client, error) {
+	if p.client != nil {
+		return p.client, nil // Already initialized
+	}
+
+	// Validate the provider configuration
+	if err := p.config.validate(); err != nil {
+		return nil, err
+	}
+
+	// Set default CSA encryption key if not provided
+	csaEncryptionKey := p.config.CSAEncryptionKey
+	if csaEncryptionKey == "" {
+		csaEncryptionKey = DefaultCSAEncryptionKey
+	}
+
+	// Create JD input configuration from provider config
+	jdInput := &ctf_jd.Input{
+		Image:            p.config.Image,
+		GRPCPort:         p.config.GRPCPort,
+		WSRPCPort:        p.config.WSRPCPort,
+		CSAEncryptionKey: csaEncryptionKey,
+		DockerFilePath:   p.config.DockerFilePath,
+		DockerContext:    p.config.DockerContext,
+		JDSQLDumpPath:    p.config.JDSQLDumpPath,
+		DBInput:          p.config.DBInput,
+	}
+
+	// Create the JD container using CTF
+	jdOutput, err := ctf_jd.NewJD(jdInput)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create JD configuration from the CTF output
+	jdConfig := jd.JDConfig{
+		GRPC:  jdOutput.ExternalGRPCUrl,
+		WSRPC: jdOutput.ExternalWSRPCUrl,
+		// Note: Using insecure credentials for testing
+		Creds: nil,
+		Auth:  nil,
+	}
+
+	// Create the JD client
+	client, err := jd.NewJDClient(jdConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	p.client = client
+
+	// Perform health check to ensure JD service is ready
+	if err := p.healthCheck(ctx, client); err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+// healthCheck verifies that the JD service is ready by calling GetKeypair with retry logic.
+func (p *CTFOffchainProvider) healthCheck(ctx context.Context, client offchain.Client) error {
+	p.t.Helper()
+
+	err := retry.Do(func() error {
+		// Try to Get CSA keypair as a health check
+		_, err := client.GetKeypair(ctx, &csav1.GetKeypairRequest{})
+		return err
+	},
+		retry.Context(ctx),
+		retry.Attempts(10),
+		retry.Delay(2*time.Second),
+		retry.DelayType(retry.FixedDelay),
+		retry.OnRetry(func(attempt uint, err error) {
+			p.t.Logf("JD health check attempt %d/10: %v", attempt+1, err)
+		}),
+	)
+
+	if err != nil {
+		return errors.New("JD service health check failed: service is not ready after retries")
+	}
+
+	p.t.Log("JD service health check passed: service is ready")
+
+	return nil
+}
+
+// Name returns the name of the CTFOffchainProvider.
+func (*CTFOffchainProvider) Name() string {
+	return "Job Distributor CTF Offchain Provider"
+}
+
+// OffchainClient returns the JD client instance managed by this provider.
+// You must call Initialize before using this method to ensure the client is properly set up.
+func (p *CTFOffchainProvider) OffchainClient() offchain.Client {
+	return p.client
+}

--- a/offchain/jd/provider/ctf_provider_test.go
+++ b/offchain/jd/provider/ctf_provider_test.go
@@ -1,0 +1,161 @@
+package provider
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCTFOffchainProviderConfig_validate(t *testing.T) { //nolint:paralleltest // Cannot run in parallel due to global env var manipulation
+	// Save original env var and restore at the end
+	originalEnv := os.Getenv("CTF_JD_IMAGE")
+	defer func() {
+		if originalEnv != "" {
+			os.Setenv("CTF_JD_IMAGE", originalEnv)
+		} else {
+			os.Unsetenv("CTF_JD_IMAGE")
+		}
+	}()
+
+	tests := []struct {
+		name    string
+		config  CTFOffchainProviderConfig
+		envVar  string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid config with Image provided",
+			config: CTFOffchainProviderConfig{
+				Image: "my-jd-image:latest",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "valid config with CTF_JD_IMAGE env var",
+			config:  CTFOffchainProviderConfig{},
+			envVar:  "env-jd-image:latest",
+			wantErr: false,
+		},
+		{
+			name:    "missing both Image and CTF_JD_IMAGE",
+			config:  CTFOffchainProviderConfig{},
+			wantErr: true,
+			errMsg:  "either Image must be provided in config or CTF_JD_IMAGE environment variable must be set",
+		},
+		{
+			name: "both Image and CTF_JD_IMAGE provided (should prefer config)",
+			config: CTFOffchainProviderConfig{
+				Image: "config-jd-image:latest",
+			},
+			envVar:  "env-jd-image:latest",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests { //nolint:paralleltest // Cannot run subtests in parallel due to global env var manipulation
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variable if provided
+			if tt.envVar != "" {
+				os.Setenv("CTF_JD_IMAGE", tt.envVar)
+			} else {
+				os.Unsetenv("CTF_JD_IMAGE")
+			}
+
+			err := tt.config.validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewCTFOffchainProvider(t *testing.T) {
+	t.Parallel()
+
+	config := CTFOffchainProviderConfig{
+		Image: "test-jd-image:latest",
+	}
+
+	provider := NewCTFOffchainProvider(t, config)
+
+	assert.NotNil(t, provider)
+	assert.Equal(t, config, provider.config)
+	assert.Equal(t, t, provider.t)
+	assert.Nil(t, provider.client) // Should be nil until initialized
+}
+
+func TestCTFOffchainProvider_Name(t *testing.T) {
+	t.Parallel()
+
+	config := CTFOffchainProviderConfig{
+		Image: "test-jd-image:latest",
+	}
+	provider := NewCTFOffchainProvider(t, config)
+
+	expectedName := "Job Distributor CTF Offchain Provider"
+	assert.Equal(t, expectedName, provider.Name())
+}
+
+func TestCTFOffchainProvider_OffchainClient_BeforeInitialize(t *testing.T) {
+	t.Parallel()
+
+	config := CTFOffchainProviderConfig{
+		Image: "test-jd-image:latest",
+	}
+	provider := NewCTFOffchainProvider(t, config)
+
+	// Should return nil before initialization
+	assert.Nil(t, provider.OffchainClient())
+}
+
+func TestCTFOffchainProvider_Initialize_ValidationError(t *testing.T) {
+	t.Parallel()
+
+	// Test that Initialize properly validates configuration
+	// Clear any existing CTF_JD_IMAGE environment variable
+	os.Unsetenv("CTF_JD_IMAGE")
+
+	config := CTFOffchainProviderConfig{
+		// Missing both Image field and CTF_JD_IMAGE env var
+	}
+	provider := NewCTFOffchainProvider(t, config)
+
+	ctx := context.Background()
+	client, err := provider.Initialize(ctx)
+
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Contains(t, err.Error(), "either Image must be provided in config or CTF_JD_IMAGE environment variable must be set")
+}
+
+// TestCTFOffchainProvider_CustomConfiguration tests that custom configuration is properly handled
+func TestCTFOffchainProvider_CustomConfiguration(t *testing.T) {
+	t.Parallel()
+
+	config := CTFOffchainProviderConfig{
+		Image:            "custom-jd-image:latest",
+		GRPCPort:         "15000",
+		WSRPCPort:        "9000",
+		CSAEncryptionKey: "custom-key-123",
+		DockerFilePath:   "./custom/Dockerfile",
+		DockerContext:    "./custom/context",
+		JDSQLDumpPath:    "./custom/dump.sql",
+	}
+
+	provider := NewCTFOffchainProvider(t, config)
+
+	assert.Equal(t, "custom-jd-image:latest", provider.config.Image)
+	assert.Equal(t, "15000", provider.config.GRPCPort)
+	assert.Equal(t, "9000", provider.config.WSRPCPort)
+	assert.Equal(t, "custom-key-123", provider.config.CSAEncryptionKey)
+	assert.Equal(t, "./custom/Dockerfile", provider.config.DockerFilePath)
+	assert.Equal(t, "./custom/context", provider.config.DockerContext)
+	assert.Equal(t, "./custom/dump.sql", provider.config.JDSQLDumpPath)
+}

--- a/offchain/offchain.go
+++ b/offchain/offchain.go
@@ -1,6 +1,15 @@
 package offchain
 
-import "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+import (
+	csav1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/csa"
+	jobv1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job"
+	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
+)
 
-// OffchainClient is an alias for the deployment.OffchainClient type for now until we migrate all reference over to the new offchain package.
-type OffchainClient = deployment.OffchainClient
+// Client is an offchain interface which interacts with job-distributor for performing
+// DON operations.
+type Client interface {
+	jobv1.JobServiceClient
+	nodev1.NodeServiceClient
+	csav1.CSAServiceClient
+}

--- a/offchain/provider.go
+++ b/offchain/provider.go
@@ -5,10 +5,10 @@ import "context"
 // Provider interface for offchain client providers.
 type Provider interface {
 	// Initialize sets up the offchain client and returns the instance.
-	Initialize(ctx context.Context) (OffchainClient, error)
+	Initialize(ctx context.Context) (Client, error)
 	// Name returns a human-readable name for this provider.
 	Name() string
 	// OffchainClient returns the initialized offchain client instance.
 	// You must call Initialize before using this method.
-	OffchainClient() OffchainClient
+	OffchainClient() Client
 }


### PR DESCRIPTION
Introduce new CTF provider for JD which provides a ready for testing JD docker container.

Because JD docker image is not available publicly, we need to use ECR auth to gain access to the docker image, the ctf_integration_test.go which spins up the JD containers and execute requests on it is currently skipped because of it.  Or just build it locally. 

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-486