### PR TITLE
[CLD-487]: fix: remove OffchainClient alias

### DIFF
--- a/.changeset/cuddly-crabs-serve.md
+++ b/.changeset/cuddly-crabs-serve.md
@@ -1,0 +1,12 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+BREAKING: remove deployment.OffchainClient. Use offchain.Client instead
+
+Migration Guide:
+
+```
+cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment" -> cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
+cldf.OffchainClient -> offchain.Client
+```

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -16,10 +16,6 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
-// OffchainClient is an alias for the offchain.Client type for now until we migrate all reference over to the new offchain package.
-// Then we will remove this alias.
-type OffchainClient = offchain.Client
-
 func MaybeDataErr(err error) error {
 	//revive:disable
 	var d rpc.DataError
@@ -57,7 +53,7 @@ type Environment struct {
 	Catalog datastore.CatalogStore
 
 	NodeIDs    []string
-	Offchain   OffchainClient
+	Offchain   offchain.Client
 	GetContext func() context.Context
 	OCRSecrets OCRSecrets
 	// OperationsBundle contains dependencies required by the operations API.
@@ -83,7 +79,7 @@ func NewEnvironment(
 	existingAddrs AddressBook,
 	dataStore datastore.DataStore,
 	nodeIDs []string,
-	offchain OffchainClient,
+	offchain offchain.Client,
 	ctx func() context.Context,
 	secrets OCRSecrets,
 	blockChains chain.BlockChains,


### PR DESCRIPTION
Should use offchain.Client going forward

- CLD has already been updated
- Chainlink has this [pending PR](https://github.com/smartcontractkit/chainlink/pull/18866)

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-487