### PR TITLE
Tron Default Opts

### DIFF
--- a/chain/tron/provider/ctf_provider.go
+++ b/chain/tron/provider/ctf_provider.go
@@ -140,10 +140,10 @@ func (p *CTFChainProvider) Initialize(_ context.Context) (chain.BlockChain, erro
 		Address:  deployerAddr,     // Default "from" address for transactions
 		URL:      fullNodeURL,
 		// Helper for sending and confirming transactions
-		SendAndConfirm: func(ctx context.Context, tx *common.Transaction, opts ...tron.ConfirmRetryOptions) (*soliditynode.TransactionInfo, error) {
+		SendAndConfirm: func(ctx context.Context, tx *common.Transaction, opts *tron.ConfirmRetryOptions) (*soliditynode.TransactionInfo, error) {
 			options := tron.DefaultConfirmRetryOptions()
-			if len(opts) > 0 {
-				options = opts[0]
+			if opts != nil {
+				options = opts
 			}
 
 			// Send transaction and wait for confirmation
@@ -151,11 +151,11 @@ func (p *CTFChainProvider) Initialize(_ context.Context) (chain.BlockChain, erro
 		},
 		// Helper for deploying a contract and waiting for confirmation
 		DeployContractAndConfirm: func(
-			ctx context.Context, contractName string, abi string, bytecode string, params []interface{}, opts ...tron.DeployOptions,
+			ctx context.Context, contractName string, abi string, bytecode string, params []interface{}, opts *tron.DeployOptions,
 		) (address.Address, *soliditynode.TransactionInfo, error) {
 			options := tron.DefaultDeployOptions()
-			if len(opts) > 0 {
-				options = opts[0]
+			if opts != nil {
+				options = opts
 			}
 
 			// Create deploy contract transaction
@@ -187,11 +187,11 @@ func (p *CTFChainProvider) Initialize(_ context.Context) (chain.BlockChain, erro
 		},
 		// Helper for triggering a contract method and waiting for confirmation
 		TriggerContractAndConfirm: func(
-			ctx context.Context, contractAddr address.Address, functionName string, params []interface{}, opts ...tron.TriggerOptions,
+			ctx context.Context, contractAddr address.Address, functionName string, params []interface{}, opts *tron.TriggerOptions,
 		) (*soliditynode.TransactionInfo, error) {
 			options := tron.DefaultTriggerOptions()
-			if len(opts) > 0 {
-				options = opts[0]
+			if opts != nil {
+				options = opts
 			}
 
 			// Ensure contract is actually deployed on-chain

--- a/chain/tron/provider/rpc_provider.go
+++ b/chain/tron/provider/rpc_provider.go
@@ -106,10 +106,10 @@ func (p *RPCChainProvider) Initialize(ctx context.Context) (chain.BlockChain, er
 		Address:  deployerAddr,     // Default "from" address for transactions
 		URL:      p.config.FullNodeURL,
 		// Helper for sending and confirming transactions
-		SendAndConfirm: func(ctx context.Context, tx *common.Transaction, opts ...tron.ConfirmRetryOptions) (*soliditynode.TransactionInfo, error) {
+		SendAndConfirm: func(ctx context.Context, tx *common.Transaction, opts *tron.ConfirmRetryOptions) (*soliditynode.TransactionInfo, error) {
 			options := tron.DefaultConfirmRetryOptions()
-			if len(opts) > 0 {
-				options = opts[0]
+			if opts != nil {
+				options = opts
 			}
 
 			// Send transaction and wait for confirmation
@@ -117,11 +117,11 @@ func (p *RPCChainProvider) Initialize(ctx context.Context) (chain.BlockChain, er
 		},
 		// Helper for deploying a contract and waiting for confirmation
 		DeployContractAndConfirm: func(
-			ctx context.Context, contractName string, abi string, bytecode string, params []interface{}, opts ...tron.DeployOptions,
+			ctx context.Context, contractName string, abi string, bytecode string, params []interface{}, opts *tron.DeployOptions,
 		) (address.Address, *soliditynode.TransactionInfo, error) {
 			options := tron.DefaultDeployOptions()
-			if len(opts) > 0 {
-				options = opts[0]
+			if opts != nil {
+				options = opts
 			}
 
 			// Create deploy contract transaction
@@ -153,11 +153,11 @@ func (p *RPCChainProvider) Initialize(ctx context.Context) (chain.BlockChain, er
 		},
 		// Helper for triggering a contract method and waiting for confirmation
 		TriggerContractAndConfirm: func(
-			ctx context.Context, contractAddr address.Address, functionName string, params []interface{}, opts ...tron.TriggerOptions,
+			ctx context.Context, contractAddr address.Address, functionName string, params []interface{}, opts *tron.TriggerOptions,
 		) (*soliditynode.TransactionInfo, error) {
 			options := tron.DefaultTriggerOptions()
-			if len(opts) > 0 {
-				options = opts[0]
+			if opts != nil {
+				options = opts
 			}
 
 			// Ensure contract is actually deployed on-chain

--- a/chain/tron/provider/rpcclient/client.go
+++ b/chain/tron/provider/rpcclient/client.go
@@ -53,12 +53,12 @@ func New(client sdk.FullNodeClient, keystore *keystore.Keystore, account address
 func (c *Client) SendAndConfirmTx(
 	ctx context.Context,
 	tx *common.Transaction,
-	opts ...tron.ConfirmRetryOptions,
+	opts *tron.ConfirmRetryOptions,
 ) (*soliditynode.TransactionInfo, error) {
 	// Initialize the configuration with defaults or provided options.
 	option := tron.DefaultConfirmRetryOptions()
-	if len(opts) > 0 {
-		option = opts[0]
+	if opts != nil {
+		option = opts
 	}
 
 	// Decode the TxID from hex into bytes, required for signing
@@ -83,7 +83,7 @@ func (c *Client) SendAndConfirmTx(
 	}
 
 	// Confirm the transaction by polling for success/failure based on the TxID
-	return c.confirmTx(broadcastResponse.TxID, confirmRetryOpts(ctx, option)...)
+	return c.confirmTx(broadcastResponse.TxID, confirmRetryOpts(ctx, *option)...)
 }
 
 // confirmTx checks the transaction receipt by its ID, retrying until it is confirmed or fails.

--- a/chain/tron/provider/rpcclient/client_test.go
+++ b/chain/tron/provider/rpcclient/client_test.go
@@ -16,7 +16,7 @@ func TestConfirmRetryOpts_DefaultsAndOverrides(t *testing.T) {
 	ctx := context.Background()
 
 	// Test default options
-	opts := confirmRetryOpts(ctx, tron.DefaultConfirmRetryOptions())
+	opts := confirmRetryOpts(ctx, *tron.DefaultConfirmRetryOptions())
 	require.Len(t, opts, 4)
 
 	// Confirm context is set correctly

--- a/chain/tron/tron_chain.go
+++ b/chain/tron/tron_chain.go
@@ -24,17 +24,17 @@ type ConfirmRetryOptions struct {
 
 // DeployOptions defines optional parameters for deploying a smart contract.
 type DeployOptions struct {
-	OeLimit             int                 // Max energy the creator is willing to provide during execution.
-	CurPercent          int                 // Percentage of resource consumption charged to the contract caller (0–100).
-	FeeLimit            int                 // Max TRX to be used for deploying the contract (gas limit in Tron terms).
-	ConfirmRetryOptions ConfirmRetryOptions // Retry options for confirming the transaction.
+	OeLimit             int                  // Max energy the creator is willing to provide during execution.
+	CurPercent          int                  // Percentage of resource consumption charged to the contract caller (0–100).
+	FeeLimit            int                  // Max TRX to be used for deploying the contract (gas limit in Tron terms).
+	ConfirmRetryOptions *ConfirmRetryOptions // Retry options for confirming the transaction.
 }
 
 // TriggerOptions defines optional parameters for triggering (calling) a smart contract.
 type TriggerOptions struct {
-	FeeLimit            int32               // Max TRX to be used for this transaction call.
-	TAmount             int64               // Amount of TRX to transfer along with the contract call (like msg.value).
-	ConfirmRetryOptions ConfirmRetryOptions // Retry options for confirming the transaction.
+	FeeLimit            int32                // Max TRX to be used for this transaction call.
+	TAmount             int64                // Amount of TRX to transfer along with the contract call (like msg.value).
+	ConfirmRetryOptions *ConfirmRetryOptions // Retry options for confirming the transaction.
 }
 
 // Chain represents a Tron chain
@@ -47,23 +47,23 @@ type Chain struct {
 	DeployerSeed  string             // Optional: mnemonic or raw seed
 
 	// SendAndConfirm provides a utility function to send a transaction and waits for confirmation.
-	SendAndConfirm func(ctx context.Context, tx *common.Transaction, opts ...ConfirmRetryOptions) (*soliditynode.TransactionInfo, error)
+	SendAndConfirm func(ctx context.Context, tx *common.Transaction, opts *ConfirmRetryOptions) (*soliditynode.TransactionInfo, error)
 
 	// DeployContractAndConfirm provides a utility function to deploy a contract and waits for confirmation.
 	DeployContractAndConfirm func(
-		ctx context.Context, contractName string, abi string, bytecode string, params []interface{}, opts ...DeployOptions,
+		ctx context.Context, contractName string, abi string, bytecode string, params []interface{}, opts *DeployOptions,
 	) (address.Address, *soliditynode.TransactionInfo, error)
 
 	// TriggerContractAndConfim provides a utility function to send a contract transaction and waits for confirmation.
 	TriggerContractAndConfirm func(
-		ctx context.Context, contractAddr address.Address, functionName string, params []interface{}, opts ...TriggerOptions,
+		ctx context.Context, contractAddr address.Address, functionName string, params []interface{}, opts *TriggerOptions,
 	) (*soliditynode.TransactionInfo, error)
 }
 
 // DefaultConfirmRetryOptions returns standard retry options used across contract deployment and invocation.
 // Defaults to 180 retries with a 500ms delay between each attempt.
-func DefaultConfirmRetryOptions() ConfirmRetryOptions {
-	return ConfirmRetryOptions{
+func DefaultConfirmRetryOptions() *ConfirmRetryOptions {
+	return &ConfirmRetryOptions{
 		RetryAttempts: 180,
 		RetryDelay:    500 * time.Millisecond,
 	}
@@ -71,8 +71,8 @@ func DefaultConfirmRetryOptions() ConfirmRetryOptions {
 
 // DefaultDeployOptions returns default options used when deploying a contract.
 // It includes a high fee and energy limit suitable for development/testing, and standard retry behavior.
-func DefaultDeployOptions() DeployOptions {
-	return DeployOptions{
+func DefaultDeployOptions() *DeployOptions {
+	return &DeployOptions{
 		FeeLimit:            10_000_000, // Default fee limit (in SUN).
 		CurPercent:          100,        // Caller pays full cost.
 		OeLimit:             10_000_000, // Default energy limit.
@@ -82,8 +82,8 @@ func DefaultDeployOptions() DeployOptions {
 
 // DefaultTriggerOptions returns default options for calling smart contract methods.
 // These defaults ensure calls succeed on local/dev environments without TRX transfer.
-func DefaultTriggerOptions() TriggerOptions {
-	return TriggerOptions{
+func DefaultTriggerOptions() *TriggerOptions {
+	return &TriggerOptions{
 		FeeLimit:            10_000_000, // Default fee limit (in SUN).
 		TAmount:             0,          // No TRX transferred by default.
 		ConfirmRetryOptions: DefaultConfirmRetryOptions(),

--- a/chain/tron/tron_chain.go
+++ b/chain/tron/tron_chain.go
@@ -73,9 +73,9 @@ func DefaultConfirmRetryOptions() *ConfirmRetryOptions {
 // It includes a high fee and energy limit suitable for development/testing, and standard retry behavior.
 func DefaultDeployOptions() *DeployOptions {
 	return &DeployOptions{
-		FeeLimit:            10_000_000, // Default fee limit (in SUN).
-		CurPercent:          100,        // Caller pays full cost.
-		OeLimit:             10_000_000, // Default energy limit.
+		FeeLimit:            100_000_000, // Default fee limit (in SUN).
+		CurPercent:          100,         // Caller pays full cost.
+		OeLimit:             50_000_000,  // Default energy limit.
 		ConfirmRetryOptions: DefaultConfirmRetryOptions(),
 	}
 }


### PR DESCRIPTION
Use pointers for options to support nil initialization, and raise the default deployment parameters for better reliability.