### PR TITLE
test(TON): use dev image for ton CTF provider

### DIFF
--- a/.changeset/curly-olives-write.md
+++ b/.changeset/curly-olives-write.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+use dev tagged image for TON CTF Provider

--- a/chain/ton/provider/ctf_provider.go
+++ b/chain/ton/provider/ctf_provider.go
@@ -121,6 +121,7 @@ func (p *CTFChainProvider) startContainer(chainID string) (string, *ton.APIClien
 			Type:    blockchain.TypeTon,
 			ChainID: chainID,
 			Port:    strconv.Itoa(port),
+			Image:   "ghcr.io/neodix42/mylocalton-docker:dev", // as of 11th Aug 2025, the tag 'latest' image used by default fails to startup. Override it with the 'dev' image
 		})
 		if rerr != nil {
 			// Return the ports to freeport to avoid leaking them during retries


### PR DESCRIPTION
The initialize test for TON [started failing today](https://github.com/smartcontractkit/chainlink-deployments-framework/actions/runs/16870505111/job/47784398103?pr=253) even in main branch when it was previously passing, i did some investigation and looks like there was a new "latest" tag image published just recently - https://github.com/neodix42/mylocalton-docker/pkgs/container/mylocalton-docker, this image stops the container from starting up, opted to use `dev` image since that is working.

This unblocks all PRs due to the failing test