### PR TITLE
refactor: refactor network url transformer

### DIFF
--- a/.changeset/cute-tigers-smell.md
+++ b/.changeset/cute-tigers-smell.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+[BREAKING] The Load function of Network Config has been changed to simplify the URL transformation option


### PR DESCRIPTION
This refactor changes the URL Transform Load Option to accept a simple transform function, and moves the logic of which URLs to transform to the config itself.

This simplifies the caller's API and avoids exposing the internal config structure to the caller.