### PR TITLE
feat: Replace WithRPCURLTransformer with targeted transformers

### DIFF
--- a/.changeset/angry-pugs-wish.md
+++ b/.changeset/angry-pugs-wish.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+[BREAKING] Removes `WithRPCURLTransformer` load option with 2 separated options targeting HTTP and WS separately (`WithHTTPURLTransformer` and `WithWSURLTransformer`).

--- a/engine/cld/config/network/config_test.go
+++ b/engine/cld/config/network/config_test.go
@@ -677,7 +677,7 @@ networks:
 	}
 }
 
-func Test_Load_WithURLTransformer(t *testing.T) {
+func Test_Load_WithTransforms(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -741,7 +741,10 @@ networks:
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := Load([]string{tt.givePath}, WithRPCURLTransformer(tt.giveURLTransformer))
+			got, err := Load([]string{tt.givePath},
+				WithHTTPURLTransformer(tt.giveURLTransformer),
+				WithWSURLTransformer(tt.giveURLTransformer),
+			)
 			require.NoError(t, err)
 
 			if tt.wantErr != "" {


### PR DESCRIPTION
The previous `WithRPCURLTransformer` load option was a single function that transformed both HTTP and WS URLs. This is too general and makes the assumption that the caller wants to transform all the URLs with the same function.

This PR introduces 2 new load options: `WithHTTPURLTransformer` and `WithWSURLTransformer` which are more specific and allow the caller to transform only or both the HTTP or WS URLs, with different functions.