### PR TITLE
[CLD-493]: fix(tron): remove lazy loading for kms & test cleanup

### DIFF
--- a/.changeset/free-foxes-melt.md
+++ b/.changeset/free-foxes-melt.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+fix(tron): signer generator no longer lazy loads

--- a/chain/tron/provider/ctf_provider_test.go
+++ b/chain/tron/provider/ctf_provider_test.go
@@ -29,17 +29,27 @@ func TestCTFChainProviderConfig_validate(t *testing.T) {
 		},
 		{
 			name: "missing sync.Once",
-			config: CTFChainProviderConfig{
-				DeployerSignerGen: SignerGenCTFDefault(),
-			},
+			config: func() CTFChainProviderConfig {
+				signerGen, err := SignerGenCTFDefault()
+				require.NoError(t, err)
+
+				return CTFChainProviderConfig{
+					DeployerSignerGen: signerGen,
+				}
+			}(),
 			expectedErr: "sync.Once instance is required",
 		},
 		{
 			name: "valid config",
-			config: CTFChainProviderConfig{
-				DeployerSignerGen: SignerGenCTFDefault(),
-				Once:              &sync.Once{},
-			},
+			config: func() CTFChainProviderConfig {
+				signerGen, err := SignerGenCTFDefault()
+				require.NoError(t, err)
+
+				return CTFChainProviderConfig{
+					DeployerSignerGen: signerGen,
+					Once:              &sync.Once{},
+				}
+			}(),
 			expectedErr: "",
 		},
 	}
@@ -61,8 +71,11 @@ func TestCTFChainProviderConfig_validate(t *testing.T) {
 func TestNewCTFChainProvider(t *testing.T) {
 	t.Parallel()
 
+	signerGen, err := SignerGenCTFDefault()
+	require.NoError(t, err)
+
 	config := CTFChainProviderConfig{
-		DeployerSignerGen: SignerGenCTFDefault(),
+		DeployerSignerGen: signerGen,
 		Once:              &sync.Once{},
 	}
 
@@ -86,10 +99,15 @@ func TestCTFChainProvider_Initialize(t *testing.T) {
 		{
 			name:         "valid initialization",
 			giveSelector: chain_selectors.TRON_TESTNET_NILE.Selector,
-			giveConfig: CTFChainProviderConfig{
-				DeployerSignerGen: SignerGenCTFDefault(),
-				Once:              &sync.Once{},
-			},
+			giveConfig: func() CTFChainProviderConfig {
+				signerGen, err := SignerGenCTFDefault()
+				require.NoError(t, err)
+
+				return CTFChainProviderConfig{
+					DeployerSignerGen: signerGen,
+					Once:              &sync.Once{},
+				}
+			}(),
 		},
 		{
 			name:         "fails config validation",
@@ -102,18 +120,28 @@ func TestCTFChainProvider_Initialize(t *testing.T) {
 		{
 			name:         "missing sync.Once",
 			giveSelector: chain_selectors.TRON_TESTNET_NILE.Selector,
-			giveConfig: CTFChainProviderConfig{
-				DeployerSignerGen: SignerGenCTFDefault(),
-			},
+			giveConfig: func() CTFChainProviderConfig {
+				signerGen, err := SignerGenCTFDefault()
+				require.NoError(t, err)
+
+				return CTFChainProviderConfig{
+					DeployerSignerGen: signerGen,
+				}
+			}(),
 			wantErr: "sync.Once instance is required",
 		},
 		{
 			name:         "chain id not found for selector",
 			giveSelector: 999999, // Invalid selector
-			giveConfig: CTFChainProviderConfig{
-				DeployerSignerGen: SignerGenCTFDefault(),
-				Once:              &sync.Once{},
-			},
+			giveConfig: func() CTFChainProviderConfig {
+				signerGen, err := SignerGenCTFDefault()
+				require.NoError(t, err)
+
+				return CTFChainProviderConfig{
+					DeployerSignerGen: signerGen,
+					Once:              &sync.Once{},
+				}
+			}(),
 			wantErr: "failed to get chain ID from selector 999999",
 		},
 	}
@@ -149,8 +177,12 @@ func TestCTFChainProvider_Initialize(t *testing.T) {
 
 func TestCTFChainProvider_ContainerStartup(t *testing.T) {
 	t.Parallel()
+
+	signerGen, err := SignerGenCTFDefault()
+	require.NoError(t, err)
+
 	config := CTFChainProviderConfig{
-		DeployerSignerGen: SignerGenCTFDefault(),
+		DeployerSignerGen: signerGen,
 		Once:              &sync.Once{},
 	}
 
@@ -168,8 +200,11 @@ func TestCTFChainProvider_ContainerStartup(t *testing.T) {
 func TestCTFProvider_SendAndConfirmTx_And_CheckContractDeployed(t *testing.T) {
 	t.Parallel()
 
+	signerGen, err := SignerGenCTFDefault()
+	require.NoError(t, err)
+
 	config := CTFChainProviderConfig{
-		DeployerSignerGen: SignerGenCTFDefault(),
+		DeployerSignerGen: signerGen,
 		Once:              &sync.Once{},
 	}
 

--- a/chain/tron/provider/kms_signer_test.go
+++ b/chain/tron/provider/kms_signer_test.go
@@ -6,29 +6,16 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	kmslib "github.com/aws/aws-sdk-go/service/kms"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/fbsobreira/gotron-sdk/pkg/address"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/kms"
+	kmsmocks "github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/kms/mocks"
 )
-
-// MockKMSClient is a mock implementation of kms.Client for testing
-type MockKMSClient struct {
-	mock.Mock
-}
-
-func (m *MockKMSClient) GetPublicKey(input *kmslib.GetPublicKeyInput) (*kmslib.GetPublicKeyOutput, error) {
-	args := m.Called(input)
-	return args.Get(0).(*kmslib.GetPublicKeyOutput), args.Error(1)
-}
-
-func (m *MockKMSClient) Sign(input *kmslib.SignInput) (*kmslib.SignOutput, error) {
-	args := m.Called(input)
-	return args.Get(0).(*kmslib.SignOutput), args.Error(1)
-}
 
 func TestNewKMSSigner(t *testing.T) {
 	t.Parallel()
@@ -68,13 +55,10 @@ func TestNewKMSSigner(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, signer)
-				assert.Equal(t, tt.keyID, signer.KeyID)
-				assert.Equal(t, tt.keyRegion, signer.KeyRegion)
-				assert.Equal(t, tt.awsProfile, signer.AWSProfile)
 
 				// Verify initialization fields are properly set
 				assert.NotNil(t, signer.client)
-				assert.NotEmpty(t, signer.kmsKeyID)
+				assert.Equal(t, tt.keyID, signer.kmsKeyID)
 				assert.NotNil(t, signer.ecdsaPublicKey)
 				assert.NotEmpty(t, signer.address)
 			}
@@ -82,49 +66,208 @@ func TestNewKMSSigner(t *testing.T) {
 	}
 }
 
-func TestKMSSigner_SignatureConversion(t *testing.T) {
+func TestNewKMSSignerWithClient_Constructor(t *testing.T) {
 	t.Parallel()
 
-	// Generate a test private key
+	// Generate a test private key and derive public key
 	privateKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	t.Run("signature conversion with real signature", func(t *testing.T) {
-		// Create a real signature for testing
-		hash := crypto.Keccak256([]byte("test message"))
-		realSig, err := crypto.Sign(hash, privateKey)
-		require.NoError(t, err)
+	// Marshal the public key to DER format (as KMS would return it)
+	pubKeyBytes := crypto.FromECDSAPub(&privateKey.PublicKey)
 
-		// Extract r and s from the real signature
-		r := new(big.Int).SetBytes(realSig[:32])
-		s := new(big.Int).SetBytes(realSig[32:64])
+	tests := []struct {
+		name        string
+		keyID       string
+		setupMock   func(*kmsmocks.MockClient)
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:  "successful initialization with mock client",
+			keyID: "test-key-id",
+			setupMock: func(mockClient *kmsmocks.MockClient) {
+				mockClient.EXPECT().GetPublicKey(&kmslib.GetPublicKeyInput{
+					KeyId: aws.String("test-key-id"),
+				}).Return(&kmslib.GetPublicKeyOutput{
+					PublicKey: pubKeyBytes,
+				}, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:  "KMS GetPublicKey fails",
+			keyID: "test-key-id",
+			setupMock: func(mockClient *kmsmocks.MockClient) {
+				mockClient.EXPECT().GetPublicKey(&kmslib.GetPublicKeyInput{
+					KeyId: aws.String("test-key-id"),
+				}).Return(nil, assert.AnError)
+			},
+			wantErr:     true,
+			errContains: "failed to get public key from KMS",
+		},
+		{
+			name:  "invalid public key format",
+			keyID: "test-key-id",
+			setupMock: func(mockClient *kmsmocks.MockClient) {
+				mockClient.EXPECT().GetPublicKey(&kmslib.GetPublicKeyInput{
+					KeyId: aws.String("test-key-id"),
+				}).Return(&kmslib.GetPublicKeyOutput{
+					PublicKey: []byte("invalid-public-key"),
+				}, nil)
+			},
+			wantErr:     true,
+			errContains: "failed to parse ECDSA public key",
+		},
+	}
 
-		// Create KMS signature structure
-		ecdsaSig := kms.ECDSASig{
-			R: asn1.RawValue{Bytes: r.Bytes()},
-			S: asn1.RawValue{Bytes: s.Bytes()},
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		kmsSignature, err := asn1.Marshal(ecdsaSig)
-		require.NoError(t, err)
+			mockClient := kmsmocks.NewMockClient(t)
+			tt.setupMock(mockClient)
 
-		// Test signature conversion
-		tronSig, err := kmsToTronSig(kmsSignature, &privateKey.PublicKey, hash)
+			signer, err := newKMSSignerWithClient(tt.keyID, mockClient)
 
-		// The conversion should succeed with a real signature
-		require.NoError(t, err)
-		require.Len(t, tronSig, 65) // 32 bytes r + 32 bytes s + 1 byte v
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, signer)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, signer)
+				assert.Equal(t, mockClient, signer.client)
+				assert.Equal(t, tt.keyID, signer.kmsKeyID)
+				assert.NotNil(t, signer.ecdsaPublicKey)
+				assert.NotEmpty(t, signer.address)
 
-		// Verify the r and s components
-		rResult := tronSig[:32]
-		sResult := tronSig[32:64]
-		recoveryID := tronSig[64]
+				// Verify the address is properly derived
+				expectedAddress := address.PubkeyToAddress(privateKey.PublicKey)
+				assert.Equal(t, expectedAddress, signer.address)
+			}
+		})
+	}
+}
 
-		// Check that r and s are properly padded to 32 bytes
-		assert.Len(t, rResult, 32)
-		assert.Len(t, sResult, 32)
-		assert.LessOrEqual(t, recoveryID, byte(1)) // Recovery ID should be 0 or 1
-	})
+func TestKMSSignerWithClient_Sign(t *testing.T) {
+	t.Parallel()
+
+	// Generate a test private key and derive public key
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	// Marshal the public key to DER format (as KMS would return it)
+	pubKeyBytes := crypto.FromECDSAPub(&privateKey.PublicKey)
+
+	// Create test hash to sign
+	testHash := crypto.Keccak256([]byte("test message"))
+
+	// Create a real signature to use as mock KMS response
+	realSig, err := crypto.Sign(testHash, privateKey)
+	require.NoError(t, err)
+
+	// Extract r and s from the real signature to create mock KMS signature
+	r := new(big.Int).SetBytes(realSig[:32])
+	s := new(big.Int).SetBytes(realSig[32:64])
+
+	ecdsaSig := kms.ECDSASig{
+		R: asn1.RawValue{Bytes: r.Bytes()},
+		S: asn1.RawValue{Bytes: s.Bytes()},
+	}
+
+	mockKMSSignature, err := asn1.Marshal(ecdsaSig)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		keyID       string
+		setupMock   func(*kmsmocks.MockClient)
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:  "successful signing",
+			keyID: "test-key-id",
+			setupMock: func(mockClient *kmsmocks.MockClient) {
+				// Mock GetPublicKey for initialization
+				mockClient.EXPECT().GetPublicKey(&kmslib.GetPublicKeyInput{
+					KeyId: aws.String("test-key-id"),
+				}).Return(&kmslib.GetPublicKeyOutput{
+					PublicKey: pubKeyBytes,
+				}, nil)
+
+				// Mock Sign operation
+				mockClient.EXPECT().Sign(&kmslib.SignInput{
+					KeyId:            aws.String("test-key-id"),
+					Message:          testHash,
+					MessageType:      aws.String(kmslib.MessageTypeDigest),
+					SigningAlgorithm: aws.String(kmslib.SigningAlgorithmSpecEcdsaSha256),
+				}).Return(&kmslib.SignOutput{
+					Signature: mockKMSSignature,
+				}, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:  "KMS Sign fails",
+			keyID: "test-key-id",
+			setupMock: func(mockClient *kmsmocks.MockClient) {
+				// Mock GetPublicKey for initialization
+				mockClient.EXPECT().GetPublicKey(&kmslib.GetPublicKeyInput{
+					KeyId: aws.String("test-key-id"),
+				}).Return(&kmslib.GetPublicKeyOutput{
+					PublicKey: pubKeyBytes,
+				}, nil)
+
+				// Mock Sign operation failure
+				mockClient.EXPECT().Sign(&kmslib.SignInput{
+					KeyId:            aws.String("test-key-id"),
+					Message:          testHash,
+					MessageType:      aws.String(kmslib.MessageTypeDigest),
+					SigningAlgorithm: aws.String(kmslib.SigningAlgorithmSpecEcdsaSha256),
+				}).Return(nil, assert.AnError)
+			},
+			wantErr:     true,
+			errContains: "failed to sign transaction hash with KMS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockClient := kmsmocks.NewMockClient(t)
+			tt.setupMock(mockClient)
+
+			signer, err := newKMSSignerWithClient(tt.keyID, mockClient)
+			require.NoError(t, err)
+			require.NotNil(t, signer)
+
+			signature, err := signer.Sign(testHash)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, signature)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, signature)
+				assert.Len(t, signature, 65) // 32 bytes r + 32 bytes s + 1 byte recovery ID
+
+				// Verify signature format
+				recoveryID := signature[64]
+				assert.LessOrEqual(t, recoveryID, byte(1))
+
+				// Verify the signature can recover to the correct public key
+				assert.True(t, isValidRecovery(signature, testHash, &privateKey.PublicKey))
+			}
+		})
+	}
 }
 
 func TestKMSToTronSig(t *testing.T) {
@@ -266,48 +409,4 @@ func TestIsValidRecovery(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
-}
-
-func TestKMSSigner_ErrorScenarios(t *testing.T) {
-	t.Parallel()
-
-	t.Run("invalid asn1 signature", func(t *testing.T) {
-		t.Parallel()
-
-		privateKey, err := crypto.GenerateKey()
-		require.NoError(t, err)
-
-		hash := crypto.Keccak256([]byte("test message"))
-		invalidKMSSignature := []byte("invalid asn1 data")
-
-		_, err = kmsToTronSig(invalidKMSSignature, &privateKey.PublicKey, hash)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to unmarshal KMS signature")
-	})
-
-	t.Run("no valid recovery id found", func(t *testing.T) {
-		t.Parallel()
-
-		// This test is tricky because we need to create a signature that doesn't
-		// recover to the expected public key with either recovery ID
-		// For now, we'll test with zero values which should fail
-		zero := big.NewInt(0)
-
-		ecdsaSig := kms.ECDSASig{
-			R: asn1.RawValue{Bytes: zero.Bytes()},
-			S: asn1.RawValue{Bytes: zero.Bytes()},
-		}
-
-		kmsSignature, err := asn1.Marshal(ecdsaSig)
-		require.NoError(t, err)
-
-		privateKey, err := crypto.GenerateKey()
-		require.NoError(t, err)
-
-		hash := crypto.Keccak256([]byte("test message"))
-
-		_, err = kmsToTronSig(kmsSignature, &privateKey.PublicKey, hash)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to find valid recovery ID for TRON signature")
-	})
 }

--- a/chain/tron/provider/rpc_provider_test.go
+++ b/chain/tron/provider/rpc_provider_test.go
@@ -121,29 +121,18 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 			wantErr: "invalid Tron RPC config",
 		},
 		{
-			name:         "initialization with invalid private key",
+			name:         "initialization with nil signer generator",
 			giveSelector: chainSelector,
 			giveConfigFunc: func(t *testing.T) RPCChainProviderConfig {
 				t.Helper()
 
-				signerGen, err := SignerGenPrivateKey("") // Invalid private key
-				if err != nil {
-					// Return a config with nil signer to trigger validation error
-					return RPCChainProviderConfig{
-						FullNodeURL:       "http://localhost:8090",
-						SolidityNodeURL:   "http://localhost:8091",
-						DeployerSignerGen: nil,
-					}
-				}
-
 				return RPCChainProviderConfig{
 					FullNodeURL:       "http://localhost:8090",
 					SolidityNodeURL:   "http://localhost:8091",
-					DeployerSignerGen: signerGen,
+					DeployerSignerGen: nil,
 				}
 			},
-			// Now returns error during config validation
-			wantErr: "failed to get deployer address",
+			wantErr: "deployer signer generator is required",
 		},
 	}
 


### PR DESCRIPTION
- Instead of initializing the kms client on signing, we perform it on construction for early detection of error. Constructor now returns error.
- allow kms client to be injected for testing
- update testing with mock and cleaned up some duplicate test

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-493