### PR TITLE
Temporary export fields for refactor

### DIFF
--- a/.changeset/true-teams-stand.md
+++ b/.changeset/true-teams-stand.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+chore(domain): export SetupTestDomainsFS and rootPath for easier granular refactor

--- a/engine/cld/domain/artifacts_test.go
+++ b/engine/cld/domain/artifacts_test.go
@@ -134,7 +134,7 @@ func Test_Artifacts_ArchivedProposalDirPath(t *testing.T) {
 func Test_Artifacts_CreateMigrationDir(t *testing.T) {
 	t.Parallel()
 
-	fixture := setupTestDomainsFS(t)
+	fixture := SetupTestDomainsFS(t)
 
 	arts := fixture.artifactsDir
 
@@ -149,7 +149,7 @@ func Test_Artifacts_CreateMigrationDir(t *testing.T) {
 func Test_Artifacts_CreateProposalsDir(t *testing.T) {
 	t.Parallel()
 
-	fixture := setupTestDomainsFS(t)
+	fixture := SetupTestDomainsFS(t)
 
 	arts := fixture.artifactsDir
 
@@ -184,7 +184,7 @@ func Test_Artifacts_CreateProposalsDir(t *testing.T) {
 func Test_Artifacts_CreateArchivedProposalsDir(t *testing.T) {
 	t.Parallel()
 
-	fixture := setupTestDomainsFS(t)
+	fixture := SetupTestDomainsFS(t)
 
 	arts := fixture.artifactsDir
 
@@ -216,7 +216,7 @@ func Test_Artifacts_CreateArchivedProposalsDir(t *testing.T) {
 func Test_Artifacts_CreateOperationsReportsDir(t *testing.T) {
 	t.Parallel()
 
-	fixture := setupTestDomainsFS(t)
+	fixture := SetupTestDomainsFS(t)
 
 	arts := fixture.artifactsDir
 
@@ -248,7 +248,7 @@ func Test_Artifacts_CreateOperationsReportsDir(t *testing.T) {
 func Test_Artifacts_RemoveMigrationDir(t *testing.T) {
 	t.Parallel()
 
-	fixture := setupTestDomainsFS(t)
+	fixture := SetupTestDomainsFS(t)
 	arts := fixture.artifactsDir
 
 	err := arts.CreateMigrationDir("0001_initial")
@@ -311,7 +311,7 @@ func Test_Artifacts_MigrationDirExists(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			fixture := setupTestDomainsFS(t)
+			fixture := SetupTestDomainsFS(t)
 			artsDir := fixture.artifactsDir
 
 			if tt.beforeFunc != nil {
@@ -372,7 +372,7 @@ func Test_Artifacts_OperationsReportsDirExists(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			fixture := setupTestDomainsFS(t)
+			fixture := SetupTestDomainsFS(t)
 			artsDir := fixture.artifactsDir
 
 			if tt.beforeFunc != nil {
@@ -435,7 +435,7 @@ func Test_Artifacts_MigrationOperationsReportsFileExists(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			fixture := setupTestDomainsFS(t)
+			fixture := SetupTestDomainsFS(t)
 			artsDir := fixture.artifactsDir
 
 			if tt.beforeFunc != nil {
@@ -691,7 +691,7 @@ func Test_Artifacts_SaveChangesetOutput_LoadChangesetOutput(t *testing.T) {
 		t.Run("migrations "+tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			fixture := setupTestDomainsFS(t)
+			fixture := SetupTestDomainsFS(t)
 
 			artsDir := fixture.artifactsDir
 
@@ -704,7 +704,7 @@ func Test_Artifacts_SaveChangesetOutput_LoadChangesetOutput(t *testing.T) {
 		t.Run("durable pipelines "+tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			fixture := setupTestDomainsFS(t)
+			fixture := SetupTestDomainsFS(t)
 
 			artsDir := fixture.artifactsDir
 
@@ -808,7 +808,7 @@ func Test_Artifacts_LoadAddressBookByMigrationKey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			fixture := setupTestDomainsFS(t)
+			fixture := SetupTestDomainsFS(t)
 			artsDir := fixture.artifactsDir
 
 			if tt.beforeFunc != nil {
@@ -898,7 +898,7 @@ func Test_Artifacts_LoadDataStoreByMigrationKey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			fixture := setupTestDomainsFS(t)
+			fixture := SetupTestDomainsFS(t)
 			artsDir := fixture.artifactsDir
 
 			if tt.beforeFunc != nil {
@@ -978,7 +978,7 @@ func Test_Artifacts_SaveAndLoadOperationsReport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			fixture := setupTestDomainsFS(t)
+			fixture := SetupTestDomainsFS(t)
 			artsDir := fixture.artifactsDir
 
 			if tt.beforeFunc != nil {
@@ -1020,7 +1020,7 @@ func Test_Artifacts_SaveAndLoadOperationsReport(t *testing.T) {
 func Test_Artifacts_SaveAndLoadMultipleProposals(t *testing.T) {
 	t.Parallel()
 
-	fixture := setupTestDomainsFS(t)
+	fixture := SetupTestDomainsFS(t)
 	migrationKey := "0001_initial"
 	artsDir := fixture.artifactsDir
 
@@ -1167,7 +1167,7 @@ func Test_Artifacts_SetDurablePipelinesTimestamp(t *testing.T) {
 func Test_Artifacts_SaveAddressBookInSortedOrder(t *testing.T) {
 	t.Parallel()
 
-	fixture := setupTestDomainsFS(t)
+	fixture := SetupTestDomainsFS(t)
 	artsDir := fixture.artifactsDir
 
 	// Set timestamp for durable pipelines directory structure
@@ -1279,7 +1279,7 @@ func Test_getOperationsReportsFilePath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			fixture := setupTestDomainsFS(t)
+			fixture := SetupTestDomainsFS(t)
 			artsDir := fixture.artifactsDir
 
 			if tt.isDurablePipelines {

--- a/engine/cld/domain/domain.go
+++ b/engine/cld/domain/domain.go
@@ -55,6 +55,9 @@ func NewDomain(rootPath, key string) Domain {
 	}
 }
 
+// RootPath returns the root path of domains filesystem.
+func (d Domain) RootPath() string { return d.rootPath }
+
 // DirPath returns the path to the domain directory.
 func (d Domain) DirPath() string {
 	return filepath.Join(d.rootPath, d.key)

--- a/engine/cld/domain/domain_test.go
+++ b/engine/cld/domain/domain_test.go
@@ -173,7 +173,7 @@ func Test_Domain_EnvDir(t *testing.T) {
 
 func Test_Domain_AddressBookByEnv(t *testing.T) {
 	t.Parallel()
-	fixture := setupTestDomainsFS(t)
+	fixture := SetupTestDomainsFS(t)
 	d := NewDomain(fixture.rootDirPath, "ccip")
 	got, err := d.AddressBookByEnv("staging")
 	require.NoError(t, err)
@@ -183,7 +183,7 @@ func Test_Domain_AddressBookByEnv(t *testing.T) {
 
 func Test_Domain_DataStoreByEnv(t *testing.T) {
 	t.Parallel()
-	fixture := setupTestDomainsFS(t)
+	fixture := SetupTestDomainsFS(t)
 	d := NewDomain(fixture.rootDirPath, "ccip")
 	got, err := d.DataStoreByEnv("staging")
 	require.NoError(t, err)
@@ -193,7 +193,7 @@ func Test_Domain_DataStoreByEnv(t *testing.T) {
 
 func Test_Domain_ArtifactsByEnv(t *testing.T) {
 	t.Parallel()
-	fixture := setupTestDomainsFS(t)
+	fixture := SetupTestDomainsFS(t)
 	d := NewDomain(fixture.rootDirPath, "ccip")
 	got := d.ArtifactsDirByEnv("staging")
 	assert.Equal(t, fixture.artifactsDir, got)
@@ -210,7 +210,7 @@ func Test_Domain_CmdDirPath(t *testing.T) {
 // 	t.Parallel()
 //
 // 	var (
-// 		fixture = setupTestDomainsFS(t)
+// 		fixture = SetupTestDomainsFS(t)
 // 		envdir  = fixture.envDir
 // 		reg     = NewMigrationsRegistry()
 // 	)
@@ -266,7 +266,7 @@ func Test_Domain_CmdDirPath(t *testing.T) {
 // 		t.Run(tt.name, func(t *testing.T) {
 // 			t.Parallel()
 //
-// 			fixture := setupTestDomainsFS(t)
+// 			fixture := SetupTestDomainsFS(t)
 //
 // 			err := fixture.envDir.SaveViewState(tt.giveState)
 //

--- a/engine/cld/domain/envdir.go
+++ b/engine/cld/domain/envdir.go
@@ -18,6 +18,7 @@ import (
 type EnvDir struct {
 	// rootPath is absolute path of the domains filesystem. e.g. if the domain directory is in the
 	// project root directory, this would be the project root directory.
+	// TODO: unexport after scaffolding logic moved to cld
 	rootPath string
 
 	// The key of the domain that the environment belongs to. e.g. "ccip", "keystone"
@@ -45,6 +46,9 @@ func (d EnvDir) String() string {
 func (d EnvDir) DirPath() string {
 	return filepath.Join(d.rootPath, d.domainKey, d.key)
 }
+
+// RootPath returns the root path of the environment directory.
+func (d EnvDir) RootPath() string { return d.rootPath }
 
 // DomainKey returns the domain key that the environment belongs to.
 func (d EnvDir) DomainKey() string {

--- a/engine/cld/domain/envdir_test.go
+++ b/engine/cld/domain/envdir_test.go
@@ -103,7 +103,7 @@ func Test_EnvDir_RemoveMigrationAddressBook(t *testing.T) {
 			t.Parallel()
 
 			var (
-				fixture = setupTestDomainsFS(t)
+				fixture = SetupTestDomainsFS(t)
 				envDir  = fixture.envDir
 			)
 
@@ -234,7 +234,7 @@ func Test_EnvDir_MigrateAddressBook(t *testing.T) {
 			t.Parallel()
 
 			var (
-				fixture = setupTestDomainsFS(t)
+				fixture = SetupTestDomainsFS(t)
 				envDir  = fixture.envDir
 			)
 
@@ -410,7 +410,7 @@ func Test_EnvDir_MutableDataStore(t *testing.T) {
 
 			require.NotNil(t, tt.give)
 
-			fixture := setupTestDomainsFS(t)
+			fixture := SetupTestDomainsFS(t)
 			envdir := tt.give(t, fixture)
 
 			got, err := envdir.MutableDataStore()
@@ -429,7 +429,7 @@ func Test_EnvDir_MutableDataStore(t *testing.T) {
 func Test_EnvDir_Artifacts(t *testing.T) {
 	t.Parallel()
 
-	fixture := setupTestDomainsFS(t)
+	fixture := SetupTestDomainsFS(t)
 
 	got := fixture.envDir.ArtifactsDir()
 
@@ -589,7 +589,7 @@ func Test_EnvDir_MergeMigrationAddressBook(t *testing.T) {
 			t.Parallel()
 
 			var (
-				fixture = setupTestDomainsFS(t)
+				fixture = SetupTestDomainsFS(t)
 				envDir  = fixture.envDir
 			)
 
@@ -741,7 +741,7 @@ func Test_EnvDir_MergeMigrationDataStore(t *testing.T) {
 			t.Parallel()
 
 			var (
-				fixture = setupTestDomainsFS(t)
+				fixture = SetupTestDomainsFS(t)
 				envDir  = fixture.envDir
 			)
 
@@ -793,7 +793,7 @@ func Test_EnvDir_DurablePipelinesInputsDirPath(t *testing.T) {
 func Test_EnvDir_CreateDurablePipelinesDir(t *testing.T) {
 	t.Parallel()
 
-	fixture := setupTestDomainsFS(t)
+	fixture := SetupTestDomainsFS(t)
 	envdir := fixture.envDir
 
 	err := envdir.CreateDurablePipelinesDir()
@@ -962,7 +962,7 @@ func Test_EnvDir_AddressBook(t *testing.T) {
 
 			require.NotNil(t, tt.give)
 
-			fixture := setupTestDomainsFS(t)
+			fixture := SetupTestDomainsFS(t)
 			envdir := tt.give(t, fixture)
 
 			got, err := envdir.AddressBook()
@@ -1125,7 +1125,7 @@ func Test_EnvDir_DataStore(t *testing.T) {
 
 			require.NotNil(t, tt.give)
 
-			fixture := setupTestDomainsFS(t)
+			fixture := SetupTestDomainsFS(t)
 			envdir := tt.give(t, fixture)
 
 			got, err := envdir.DataStore()
@@ -1204,7 +1204,7 @@ func Test_EnvDir_LoadNodes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			fixture := setupTestDomainsFS(t)
+			fixture := SetupTestDomainsFS(t)
 
 			if tt.beforeFunc != nil {
 				tt.beforeFunc(t, fixture)
@@ -1307,7 +1307,7 @@ func Test_EnvDir_SaveFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			fixture := setupTestDomainsFS(t)
+			fixture := SetupTestDomainsFS(t)
 
 			if tt.beforeFunc != nil {
 				tt.beforeFunc(t, fixture)

--- a/engine/cld/domain/fixture_test.go
+++ b/engine/cld/domain/fixture_test.go
@@ -25,8 +25,9 @@ type testDomainFS struct {
 	artifactsDir *ArtifactsDir
 }
 
+// TODO: unexport after migrations/archive.go is extracted from cldf
 // setupDomainFS creates the domain directory structure for testing.
-func setupTestDomainsFS(t *testing.T) testDomainFS {
+func SetupTestDomainsFS(t *testing.T) testDomainFS {
 	t.Helper()
 
 	// Setup the root directory.


### PR DESCRIPTION
This pull request focuses on improving testability and modularity in the domains package by exporting key test setup utilities and root path accessors. The main changes are the export of `SetupTestDomainsFS` and `rootPath` for easier and more granular refactoring, along with updates to related test code to use the newly exported functions.

**Test utilities and refactoring:**

* Exported the `SetupTestDomainsFS` function (previously `setupTestDomainsFS`) in `engine/cld/domain/fixture_test.go` to make the test domain filesystem setup reusable and easier to refactor across tests. All usages in test files have been updated accordingly. [[1]](diffhunk://#diff-55c7e69d0b6d5531daad779f18991076dd8a8825a1a2c6098af4e795e8ce2478R28-R30) [[2]](diffhunk://#diff-d47fb8fcc003feba450ca1697258b49fdda81b40a7866dd19f4018b47339b3aaR1-R5)
* Updated all references to `setupTestDomainsFS` in test files (`engine/cld/domain/artifacts_test.go`, `engine/cld/domain/domain_test.go`, `engine/cld/domain/envdir_test.go`) to use the exported `SetupTestDomainsFS` function. [[1]](diffhunk://#diff-98ec913d7a6392cf2d72317c9ea85d46b2568afa0ae3a943d13bedbb502e82b1L137-R137) [[2]](diffhunk://#diff-6bcb191e62e1f4b4535496fc95ec2fff83237aef5375b935ae19bf217f2698c5L176-R176) [[3]](diffhunk://#diff-0860700083b19a6be234624ffd83c9c0f5ce7843fd18a9a352fc71124e05e7ecL106-R106) etc.)

**Domain and environment directory accessors:**

* Added and exported `RootPath()` methods to both the `Domain` and `EnvDir` structs, allowing tests and other code to access the root path of the domain and environment directories directly. [[1]](diffhunk://#diff-d7656e075ccd98ef59a865b5fd025754207b767a67dc9edd6df71ffcd2ed714cR58-R60) [[2]](diffhunk://#diff-c9a586fd6c58ae8bd299b4b572b1870f3429898e2efc9afce345a816beab4adbR50-R52)
* Added comments and TODOs indicating that certain fields and methods are temporarily exported for scaffolding and refactoring purposes, with plans to unexport them after related logic is moved. [[1]](diffhunk://#diff-c9a586fd6c58ae8bd299b4b572b1870f3429898e2efc9afce345a816beab4adbR21) [[2]](diffhunk://#diff-55c7e69d0b6d5531daad779f18991076dd8a8825a1a2c6098af4e795e8ce2478R28-R30)

These changes collectively make the test infrastructure more flexible and prepare the codebase for future modularization and refactoring.