### PR TITLE
fix: Job Distributor config is optional and should be nil if not set

### DIFF
--- a/.changeset/lemon-knives-unite.md
+++ b/.changeset/lemon-knives-unite.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+[BREAKING] JobDistributorConfig.Auth is now a pointer to indicate that it is an optional field

--- a/engine/cld/config/env/config.go
+++ b/engine/cld/config/env/config.go
@@ -64,7 +64,7 @@ type TronConfig struct {
 // configuration.
 type JobDistributorConfig struct {
 	Endpoints JobDistributorEndpoints `mapstructure:"endpoints"` // The URL endpoints for the Job Distributor
-	Auth      JobDistributorAuth      `mapstructure:"auth"`      // Secret: The authentication configuration for the Job Distributor
+	Auth      *JobDistributorAuth     `mapstructure:"auth"`      // Secret: The authentication configuration for the Job Distributor
 }
 
 // JobDistributorAuth is the configuration for authenticating to the Job Distributor via Cognito.

--- a/engine/cld/config/env/config_test.go
+++ b/engine/cld/config/env/config_test.go
@@ -35,7 +35,7 @@ var (
 		},
 		Offchain: OffchainConfig{
 			JobDistributor: JobDistributorConfig{
-				Auth: JobDistributorAuth{
+				Auth: &JobDistributorAuth{
 					CognitoAppClientID:     "af1a2b3c",
 					CognitoAppClientSecret: "11111111",
 					AWSRegion:              "us-west-1",
@@ -103,7 +103,7 @@ var (
 		},
 		Offchain: OffchainConfig{
 			JobDistributor: JobDistributorConfig{
-				Auth: JobDistributorAuth{
+				Auth: &JobDistributorAuth{
 					CognitoAppClientID:     "123",
 					CognitoAppClientSecret: "123",
 					AWSRegion:              "us-east-1",
@@ -138,6 +138,29 @@ func Test_Load(t *testing.T) { //nolint:paralleltest // see comment in setupTest
 			name:     "load from file",
 			givePath: "./testdata/config.yml",
 			want:     fileCfg,
+		},
+		{
+			name:     "load from empty file and env vars",
+			givePath: "./testdata/empty.yml",
+			want: &Config{
+				Onchain: OnchainConfig{
+					KMS: KMSConfig{},
+					EVM: EVMConfig{
+						Seth: nil, // Testing optional pointer fields
+					},
+					Solana: SolanaConfig{},
+					Aptos:  AptosConfig{},
+					Tron:   TronConfig{},
+				},
+				Offchain: OffchainConfig{
+					JobDistributor: JobDistributorConfig{
+						Auth:      nil, // Testing optional pointer fields
+						Endpoints: JobDistributorEndpoints{},
+					},
+					OCR: OCRConfig{},
+				},
+				Catalog: CatalogConfig{},
+			},
 		},
 		{
 			name: "override with env",

--- a/engine/cld/config/env/testdata/empty.yml
+++ b/engine/cld/config/env/testdata/empty.yml
@@ -1,0 +1,2 @@
+# This file is used to test the loading of an empty config file.
+# It should return an empty config object.


### PR DESCRIPTION
This is a breaking change because it changes the type of the JobDistributorConfig.Auth field from JobDistributorAuth to *JobDistributorAuth.

This is required because JobDistributor Auth details are optional and can be omitted to skip JD loading.