### PR TITLE
fix: fixes legacy env vars in env config

### DIFF
--- a/.changeset/tough-streets-hug.md
+++ b/.changeset/tough-streets-hug.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+Fixes legacy env vars fallback for certain fields on the env.Config

--- a/engine/cld/config/env/config.go
+++ b/engine/cld/config/env/config.go
@@ -198,15 +198,16 @@ var (
 	// When loading, Viper will check each listed environment variable in order and use the first one
 	// that is set.
 	envBindings = map[string][]string{
-		"onchain.kms.key_id":                                      {"ONCHAIN_KMS_KEY_ID", "KMS_KEY_ID"},
-		"onchain.kms.key_region":                                  {"ONCHAIN_KMS_KEY_REGION", "KMS_KEY_REGION"},
-		"onchain.evm.deployer_key":                                {"ONCHAIN_EVM_DEPLOYER_KEY", "EVM_DEPLOYER_KEY"},
+		"onchain.kms.key_id":                                      {"ONCHAIN_KMS_KEY_ID", "KMS_DEPLOYER_KEY_ID"},
+		"onchain.kms.key_region":                                  {"ONCHAIN_KMS_KEY_REGION", "KMS_DEPLOYER_KEY_REGION"},
+		"onchain.evm.deployer_key":                                {"ONCHAIN_EVM_DEPLOYER_KEY", "TEST_WALLET_KEY"},
 		"onchain.evm.seth.config_file_path":                       {"ONCHAIN_EVM_SETH_CONFIG_FILE_PATH", "SETH_CONFIG_FILE"},
 		"onchain.evm.seth.geth_wrapper_dirs":                      {"ONCHAIN_EVM_SETH_GETH_WRAPPER_DIRS", "GETH_WRAPPERS_DIRS"},
 		"onchain.solana.wallet_key":                               {"ONCHAIN_SOLANA_WALLET_KEY", "SOLANA_WALLET_KEY"},
 		"onchain.solana.programs_dir_path":                        {"ONCHAIN_SOLANA_PROGRAMS_DIR_PATH", "SOLANA_PROGRAM_PATH"},
 		"onchain.aptos.deployer_key":                              {"ONCHAIN_APTOS_DEPLOYER_KEY", "APTOS_DEPLOYER_KEY"},
 		"onchain.tron.deployer_key":                               {"ONCHAIN_TRON_DEPLOYER_KEY", "TRON_DEPLOYER_KEY"},
+		"onchain.sui.deployer_key":                                {"ONCHAIN_SUI_DEPLOYER_KEY"},
 		"offchain.job_distributor.auth.cognito_app_client_id":     {"OFFCHAIN_JD_AUTH_COGNITO_APP_CLIENT_ID", "JD_AUTH_COGNITO_APP_CLIENT_ID"},
 		"offchain.job_distributor.auth.cognito_app_client_secret": {"OFFCHAIN_JD_AUTH_COGNITO_APP_CLIENT_SECRET", "JD_AUTH_COGNITO_APP_CLIENT_SECRET"},
 		"offchain.job_distributor.auth.aws_region":                {"OFFCHAIN_JD_AUTH_AWS_REGION", "JD_AUTH_AWS_REGION"},
@@ -216,7 +217,7 @@ var (
 		"offchain.job_distributor.endpoints.grpc":                 {"OFFCHAIN_JD_ENDPOINTS_GRPC", "JD_GRPC"},
 		"offchain.ocr.x_signers":                                  {"OFFCHAIN_OCR_X_SIGNERS", "OCR_X_SIGNERS"},
 		"offchain.ocr.x_proposers":                                {"OFFCHAIN_OCR_X_PROPOSERS", "OCR_X_PROPOSERS"},
-		"catalog.grpc":                                            {"CATALOG_GRPC"},
+		"catalog.grpc":                                            {"CATALOG_GRPC", "CATALOG_SERVICE_GRPC"},
 	}
 )
 

--- a/engine/cld/config/env/config_test.go
+++ b/engine/cld/config/env/config_test.go
@@ -64,6 +64,7 @@ var (
 		"ONCHAIN_SOLANA_PROGRAMS_DIR_PATH":           "/tmp",
 		"ONCHAIN_APTOS_DEPLOYER_KEY":                 "0x123",
 		"ONCHAIN_TRON_DEPLOYER_KEY":                  "0x123",
+		"ONCHAIN_SUI_DEPLOYER_KEY":                   "0x123",
 		"OFFCHAIN_JD_AUTH_COGNITO_APP_CLIENT_ID":     "123",
 		"OFFCHAIN_JD_AUTH_COGNITO_APP_CLIENT_SECRET": "123",
 		"OFFCHAIN_JD_AUTH_AWS_REGION":                "us-east-1",
@@ -74,6 +75,30 @@ var (
 		"OFFCHAIN_OCR_X_SIGNERS":                     "awkward bat",
 		"OFFCHAIN_OCR_X_PROPOSERS":                   "caring deer",
 		"CATALOG_GRPC":                               "http://localhost:8080",
+	}
+
+	legacyEnvVars = map[string]string{
+		"KMS_DEPLOYER_KEY_ID":               "123",
+		"KMS_DEPLOYER_KEY_REGION":           "us-east-1",
+		"TEST_WALLET_KEY":                   "0x123",
+		"SETH_CONFIG_FILE":                  "config.json",
+		"GETH_WRAPPERS_DIRS":                "./a,./b",
+		"SOLANA_WALLET_KEY":                 "0x123",
+		"SOLANA_PROGRAM_PATH":               "/tmp",
+		"APTOS_DEPLOYER_KEY":                "0x123",
+		"TRON_DEPLOYER_KEY":                 "0x123",
+		"JD_AUTH_COGNITO_APP_CLIENT_ID":     "123",
+		"JD_AUTH_COGNITO_APP_CLIENT_SECRET": "123",
+		"JD_AUTH_AWS_REGION":                "us-east-1",
+		"JD_AUTH_USERNAME":                  "123",
+		"JD_AUTH_PASSWORD":                  "123",
+		"JD_WS_RPC":                         "WSRPC2",
+		"JD_GRPC":                           "GRPC2",
+		"OCR_X_SIGNERS":                     "awkward bat",
+		"OCR_X_PROPOSERS":                   "caring deer",
+		"CATALOG_SERVICE_GRPC":              "http://localhost:8080",
+		// These values do not have a legacy equivalent
+		"ONCHAIN_SUI_DEPLOYER_KEY": "0x123",
 	}
 
 	// envCfg is the config that is loaded from the environment variables.
@@ -98,6 +123,9 @@ var (
 				DeployerKey: "0x123",
 			},
 			Tron: TronConfig{
+				DeployerKey: "0x123",
+			},
+			Sui: SuiConfig{
 				DeployerKey: "0x123",
 			},
 		},
@@ -167,7 +195,7 @@ func Test_Load(t *testing.T) { //nolint:paralleltest // see comment in setupTest
 			beforeFunc: func(t *testing.T) {
 				t.Helper()
 
-				setupTestEnvVars(t)
+				setupEnvVars(t, envVars)
 			},
 			givePath: "./testdata/config.yml",
 			want:     envCfg,
@@ -177,7 +205,7 @@ func Test_Load(t *testing.T) { //nolint:paralleltest // see comment in setupTest
 			beforeFunc: func(t *testing.T) {
 				t.Helper()
 
-				setupTestEnvVars(t)
+				setupEnvVars(t, envVars)
 			},
 			givePath: "./testdata/invalid.yml",
 			want:     envCfg,
@@ -240,8 +268,17 @@ func Test_LoadFile(t *testing.T) {
 	}
 }
 
-func Test_LoadEnv(t *testing.T) { //nolint:paralleltest // see comment in setupTestEnvVars
-	setupTestEnvVars(t)
+func Test_LoadEnv(t *testing.T) { //nolint:paralleltest // see comment in setupEnvVars
+	setupEnvVars(t, envVars)
+
+	got, err := LoadEnv()
+	require.NoError(t, err)
+
+	assert.Equal(t, envCfg, got)
+}
+
+func Test_LoadEnv_Legacy(t *testing.T) { //nolint:paralleltest // see comment in setupEnvVars
+	setupEnvVars(t, legacyEnvVars)
 
 	got, err := LoadEnv()
 	require.NoError(t, err)
@@ -253,7 +290,7 @@ func Test_LoadEnv(t *testing.T) { //nolint:paralleltest // see comment in setupT
 //
 // CAUTION: Because this function uses t.Setenv which affects the entire process, tests which call
 // this function cannot be run in parallel.
-func setupTestEnvVars(t *testing.T) {
+func setupEnvVars(t *testing.T, envVars map[string]string) {
 	t.Helper()
 
 	for key, value := range envVars {


### PR DESCRIPTION
This change fixes the keys of legacy env vars in the env config. It also adds support for binding env vars for Sui chains.