### PR TITLE
test(sui): allocate faucet port with freeport

### DIFF
--- a/chain/sui/provider/ctf_provider.go
+++ b/chain/sui/provider/ctf_provider.go
@@ -156,20 +156,23 @@ func (p *CTFChainProvider) startContainer(
 	}
 
 	result, err := retry.DoWithData(func() (containerResult, error) {
-		port := freeport.GetOne(p.t)
+		ports := freeport.GetN(p.t, 2)
+		port := ports[0]
+		faucetPort := ports[1]
 
 		input := &blockchain.Input{
-			Image:     "", // filled out by defaultSui function
-			Type:      blockchain.TypeSui,
-			ChainID:   chainID,
-			PublicKey: address,
-			Port:      strconv.Itoa(port),
+			Image:      "", // filled out by defaultSui function
+			Type:       blockchain.TypeSui,
+			ChainID:    chainID,
+			PublicKey:  address,
+			Port:       strconv.Itoa(port),
+			FaucetPort: strconv.Itoa(faucetPort),
 		}
 
 		output, rerr := blockchain.NewBlockchainNetwork(input)
 		if rerr != nil {
 			// Return the ports to freeport to avoid leaking them during retries
-			freeport.Return([]int{port})
+			freeport.Return([]int{port, faucetPort})
 			return containerResult{}, rerr
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250808121824-2c3544aab8f3
 	github.com/smartcontractkit/chainlink-protos/chainlink-catalog v0.0.2
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0
-	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.12
+	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.15
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335
 	github.com/smartcontractkit/freeport v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -671,8 +671,8 @@ github.com/smartcontractkit/chainlink-protos/chainlink-catalog v0.0.2 h1:Q4CSRUX
 github.com/smartcontractkit/chainlink-protos/chainlink-catalog v0.0.2/go.mod h1:BZ/xrJ6n/j5K4ptJyIk+L1dUup1eXXQpRKcgBYvugpE=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0 h1:/bhoALRzNXZkdzxBkNM505pMofNy0K0eW1nCzXw+AUI=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.12 h1:vITyX8uIoUjMGwJXbgE8Cl01oO+5QpbOAVut69Wi9Sc=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.12/go.mod h1:gdW2dlrvHcTawMCtAIXQYZcZ9Ggx16L55kA7wONvzJ4=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.15 h1:OyX2Z68z6VDY4aadqMXjwSTE/0misA5fk8Iq710nxkk=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.15/go.mod h1:gdW2dlrvHcTawMCtAIXQYZcZ9Ggx16L55kA7wONvzJ4=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6Be5//TyjPi1pS1uotnmcYq5vVkSyISIymSj8=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335 h1:7bxYNrPpygn8PUSBiEKn8riMd7CXMi/4bjTy0fHhcrY=


### PR DESCRIPTION
Previously the sui ctf test is flaky due to the faucet port being occupied by other process. This commit assigns a freeport to be used as the faucet port.