### PR TITLE
refactor(engine): move networks from cld with config injection

### DIFF
--- a/engine/cld/environment/names.go
+++ b/engine/cld/environment/names.go
@@ -1,0 +1,22 @@
+package environment
+
+// Environment names which correspond to the directory
+// structure in each product. For example:
+// keystone/staging
+// keystone/mainnet
+// ccip/mainnet
+// etc.
+const (
+	Local          = "local"
+	StagingTestnet = "staging_testnet"
+	StagingMainnet = "staging_mainnet"
+	Staging        = "staging" // Note this is currently the equivalent of staging_testnet.
+	ProdMainnet    = "prod_mainnet"
+	ProdTestnet    = "prod_testnet"
+	Prod           = "prod"
+
+	// Legacy environments to be cleaned up once the migration to the above environments is completed.
+	Testnet    = "testnet"
+	Mainnet    = "mainnet"
+	SolStaging = "solana-staging" // Note this is testnet staging for Solana.
+)

--- a/engine/cld/network/network.go
+++ b/engine/cld/network/network.go
@@ -1,0 +1,153 @@
+package network
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/domain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/environment"
+
+	cldf_config_network "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/config/network"
+)
+
+// Config holds knobs that must stay private (hosts/ports, and whether to enable GAP transforms).
+// In the public repo, you can accept a *Config from the private caller. If nil, no GAP transform.
+type Config struct {
+	// RPCsHost is the original host to be replaced when routing via GAP
+	RPCsHost string
+	// GapProxyHost is the GAP V2 proxy host
+	GapProxyHost string
+	// GapWSPort is the GAP V2 proxy WebSocket port
+	GapWSPort string
+	// GapHTTPPort is the GAP V2 proxy HTTP port
+	GapHTTPPort string
+	// UseGAP toggles URL transformation. Set this in the private repo
+	UseGAP bool
+}
+
+// LoadNetworks retrieves the network configuration for the given domain and filters the networks
+// according to the specified environment. The GAP/host settings are injected via cfg (may be nil).
+func LoadNetworks(
+	env string, d domain.Domain, lggr logger.Logger, cfg *Config,
+) (*cldf_config_network.Config, error) {
+	netCfg, err := loadNetworkConfig(d, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load network config: %w", err)
+	}
+
+	var (
+		typesAll     = []cldf_config_network.NetworkType{cldf_config_network.NetworkTypeTestnet, cldf_config_network.NetworkTypeMainnet}
+		typesTestnet = []cldf_config_network.NetworkType{cldf_config_network.NetworkTypeTestnet}
+		typesMainnet = []cldf_config_network.NetworkType{cldf_config_network.NetworkTypeMainnet}
+	)
+
+	// Filter networks based on the environment
+	var networkTypes []cldf_config_network.NetworkType
+	switch env {
+	case environment.Local, environment.StagingTestnet, environment.ProdTestnet:
+		networkTypes = typesTestnet
+	case environment.StagingMainnet, environment.ProdMainnet:
+		networkTypes = typesMainnet
+	case environment.Prod:
+		networkTypes = typesAll
+	// Legacy environments supporting domains not yet migrated to the new structure.
+	case environment.Testnet, environment.SolStaging:
+		networkTypes = typesTestnet
+	case environment.Staging:
+		if d.Key() == "data-streams" {
+			networkTypes = typesAll
+		} else {
+			networkTypes = typesTestnet
+		}
+	case environment.Mainnet:
+		networkTypes = typesMainnet
+	default:
+		lggr.Errorf("Unknown environment: %s", env)
+		return nil, fmt.Errorf("unknown env: %s", env)
+	}
+
+	lggr.Infof("Loaded %s Networks for %s/%s", networkTypes, d.Key(), env)
+	return netCfg.FilterWith(cldf_config_network.TypesFilter(networkTypes...)), nil
+}
+
+// loadNetworkConfig loads the network config from the .config directory in the given domain.
+// GAP/host behavior is fully controlled by the injected cfg (nil => no GAP transforms).
+func loadNetworkConfig(d domain.Domain, cfg *Config) (*cldf_config_network.Config, error) {
+	// Check if the .config directory exists in the domain
+	configDir := filepath.Join(d.DirPath(), ".config")
+	if _, err := os.Stat(configDir); err != nil {
+		return nil, fmt.Errorf("cannot find config directory: %w", err)
+	}
+
+	// Find all yaml/yml config files in the .config directory and any subdirectories
+	var configFiles []string
+
+	yamlFiles, err := filepath.Glob(filepath.Join(configDir, "**", "*.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find config files: %w", err)
+	}
+	configFiles = append(configFiles, yamlFiles...)
+
+	ymlFiles, err := filepath.Glob(filepath.Join(configDir, "**", "*.yml"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find config files: %w", err)
+	}
+	configFiles = append(configFiles, ymlFiles...)
+
+	if len(configFiles) == 0 {
+		return nil, fmt.Errorf("no config files found in %s", configDir)
+	}
+
+	// Decide on URL transformers based on injected cfg.
+	var loadOpts []cldf_config_network.LoadOption
+	if cfg != nil && cfg.UseGAP {
+		// We transform both HTTP and WS URLs by replacing the original RPC host with GAP host:port.
+		loadOpts = append(loadOpts,
+			cldf_config_network.WithHTTPURLTransformer(gapURLTransformer(cfg.RPCsHost, cfg.GapProxyHost, cfg.GapHTTPPort)),
+			cldf_config_network.WithWSURLTransformer(gapURLTransformer(cfg.RPCsHost, cfg.GapProxyHost, cfg.GapWSPort)),
+		)
+	}
+
+	// Load the config
+	netCfg, err := cldf_config_network.Load(configFiles, loadOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config files: %w", err)
+	}
+
+	return netCfg, nil
+}
+
+// gapURLTransformer returns a URLTransformer which replaces the RPC host in a URI string
+// with the GAP V2 proxy address (host:port).
+func gapURLTransformer(originalHost, proxyHost, port string) func(string) string {
+	return func(uri string) string {
+		return strings.Replace(uri, originalHost, fmt.Sprintf("%s:%s", proxyHost, port), 1)
+	}
+}
+
+/*
+USAGE:
+
+const (
+	rpcsHost      = "host.sh"
+	gapProxyHost  = "gap.sh"
+	gapWSPort     = "9333"
+	gapHTTPPort   = "4444"
+)
+
+cfg := &environment.Config{
+	RPCsHost:     rpcsHost,
+	GapProxyHost: gapProxyHost,
+	GapWSPort:    gapWSPort,
+	GapHTTPPort:  gapHTTPPort,
+	UseGAP:       true,
+}
+
+netCfg, err := environment.LoadNetworks(env, dom, lggr, cfg)
+
+In local dev, pass nil or a Config with UseGAP=false to avoid any transformation.
+*/

--- a/engine/cld/network/networks_test.go
+++ b/engine/cld/network/networks_test.go
@@ -1,0 +1,407 @@
+package network
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	cldf_domain "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/domain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/environment"
+
+	cldf_config_network "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/config/network"
+)
+
+var (
+	dummyDomain = cldf_domain.NewDomain(cldf_domain.DomainsRoot, "dummy")
+)
+
+func Test_LoadNetworks(t *testing.T) {
+	t.Parallel()
+
+	var (
+		networks = []cldf_config_network.Network{
+			{
+				Type:          cldf_config_network.NetworkTypeMainnet,
+				ChainSelector: 1,
+				RPCs: []cldf_config_network.RPC{
+					{
+						RPCName:            "test_rpc",
+						PreferredURLScheme: "http",
+						HTTPURL:            "https://test.rpc",
+						WSURL:              "wss://test.rpc",
+					},
+				},
+			},
+			{
+				Type:          cldf_config_network.NetworkTypeTestnet,
+				ChainSelector: 2,
+				RPCs: []cldf_config_network.RPC{
+					{
+						RPCName:            "test_rpc",
+						PreferredURLScheme: "http",
+						HTTPURL:            "https://test.rpc",
+						WSURL:              "wss://test.rpc",
+					},
+				},
+			},
+		}
+
+		cfg        = cldf_config_network.NewConfig(networks)
+		mainnetCfg = cldf_config_network.NewConfig([]cldf_config_network.Network{networks[0]})
+		testnetCfg = cldf_config_network.NewConfig([]cldf_config_network.Network{networks[1]})
+	)
+
+	fixture, err := yaml.Marshal(cfg)
+	require.NoError(t, err)
+
+	// Prepare a temp domain with network config files
+	var (
+		rootDir   = t.TempDir()
+		domainDir = filepath.Join(rootDir, "dummy")
+		configDir = filepath.Join(domainDir, ".config", "networks")
+	)
+
+	// Create the domain and config directory
+	err = os.MkdirAll(configDir, 0755)
+	require.NoError(t, err)
+
+	// Create the network config file
+	err = os.WriteFile(
+		filepath.Join(configDir, "networks.yaml"), fixture, 0644,
+	)
+	require.NoError(t, err)
+
+	// Temporary domain for testing the Data Streams domain exception
+	var (
+		streamsDomainDir = filepath.Join(rootDir, "data-streams")
+		streamsConfigDir = filepath.Join(streamsDomainDir, ".config", "networks")
+	)
+
+	err = os.MkdirAll(streamsConfigDir, 0755)
+	require.NoError(t, err)
+
+	err = os.WriteFile(
+		filepath.Join(streamsConfigDir, "networks.yaml"), fixture, 0644,
+	)
+	require.NoError(t, err)
+
+	domain := cldf_domain.NewDomain(rootDir, "dummy")
+
+	tests := []struct {
+		name       string
+		giveEnv    string
+		giveDomain cldf_domain.Domain
+		want       *cldf_config_network.Config
+		wantErr    string
+	}{
+		{
+			name:       "Local",
+			giveEnv:    environment.Testnet,
+			giveDomain: domain,
+			want:       testnetCfg,
+		},
+		{
+			name:       "Staging Testnet",
+			giveEnv:    environment.StagingTestnet,
+			giveDomain: domain,
+			want:       testnetCfg,
+		},
+		{
+			name:       "Prod Testnet",
+			giveEnv:    environment.ProdTestnet,
+			giveDomain: domain,
+			want:       testnetCfg,
+		},
+		{
+			name:       "Staging Mainnet",
+			giveEnv:    environment.StagingMainnet,
+			giveDomain: domain,
+			want:       mainnetCfg,
+		},
+		{
+			name:       "Prod Mainnet",
+			giveEnv:    environment.ProdMainnet,
+			giveDomain: domain,
+			want:       mainnetCfg,
+		},
+		{
+			name:       "Prod",
+			giveEnv:    environment.Prod,
+			giveDomain: domain,
+			want:       cfg,
+		},
+		{
+			name:       "Testnet",
+			giveEnv:    environment.Testnet,
+			giveDomain: domain,
+			want:       testnetCfg,
+		},
+		{
+			name:       "Sol Staging",
+			giveEnv:    environment.SolStaging,
+			giveDomain: domain,
+			want:       testnetCfg,
+		},
+		{
+			name:       "Staging",
+			giveEnv:    environment.Staging,
+			giveDomain: domain,
+			want:       testnetCfg,
+		},
+		{
+			name:       "Staging (data-streams exception)",
+			giveEnv:    environment.Staging,
+			giveDomain: cldf_domain.NewDomain(rootDir, "data-streams"),
+			want:       cfg,
+		},
+		{
+			name:       "Mainnet",
+			giveEnv:    environment.Mainnet,
+			giveDomain: domain,
+			want:       mainnetCfg,
+		},
+		{
+			name:       "Unknown Environment",
+			giveEnv:    "unknown",
+			giveDomain: domain,
+			wantErr:    "unknown env: unknown",
+		},
+		{
+			name:       "failed to load network config",
+			giveEnv:    environment.StagingTestnet,
+			giveDomain: cldf_domain.NewDomain("nonexistent", "dummy"),
+			wantErr:    "failed to load network config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// For filtering behavior we don't need GAP transforms; pass nil Config.
+			got, err := LoadNetworks(tt.giveEnv, tt.giveDomain, logger.Test(t), nil)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_loadNetworkConfig(t *testing.T) {
+	t.Parallel()
+
+	yamlFile1 := `
+  networks:
+    - type: "mainnet"
+      chain_selector: 1
+      block_explorer:
+        type: "Etherscan"
+        api_key: "test_key"
+        url: "https://etherscan.io"
+      rpcs:
+      - rpc_name: "test_rpc"
+        preferred_url_scheme: "http"
+        http_url: "https://rpcs.cldev.sh/ethereum-mainnet"
+        ws_url: "wss://rpcs.cldev.sh/ethereum-mainnet"
+      - rpc_name: "test_rpc2"
+        preferred_url_scheme: "http"
+        http_url: "https://test2.rpc"
+        ws_url: "wss://test2.rpc"
+    `
+
+	yamlFile2 := `
+  networks:
+    - type: "testnet"
+      chain_selector: 2
+      rpcs:
+      - rpc_name: "test_rpc"
+        preferred_url_scheme: "http"
+        http_url: "https://test.rpc"
+        ws_url: "wss://test.rpc"
+  `
+
+	// Yaml with error
+	yamlFile3 := `
+    - type: "testnet"
+      chain_selector: "2
+  `
+
+	network1 := cldf_config_network.Network{
+		Type:          "mainnet",
+		ChainSelector: 1,
+		BlockExplorer: cldf_config_network.BlockExplorer{
+			Type:   "Etherscan",
+			APIKey: "test_key",
+			URL:    "https://etherscan.io",
+		},
+		RPCs: []cldf_config_network.RPC{
+			{
+				RPCName:            "test_rpc",
+				PreferredURLScheme: "http",
+				HTTPURL:            "https://gap-rpc-proxy.public.main.prod.cldev.sh:4443/ethereum-mainnet",
+				WSURL:              "wss://gap-rpc-proxy.public.main.prod.cldev.sh:9443/ethereum-mainnet",
+			},
+			{
+				RPCName:            "test_rpc2",
+				PreferredURLScheme: "http",
+				HTTPURL:            "https://test2.rpc",
+				WSURL:              "wss://test2.rpc",
+			},
+		},
+	}
+
+	network2 := cldf_config_network.Network{
+		Type:          "testnet",
+		ChainSelector: 2,
+		RPCs: []cldf_config_network.RPC{
+			{
+				RPCName:            "test_rpc",
+				PreferredURLScheme: "http",
+				HTTPURL:            "https://test.rpc",
+				WSURL:              "wss://test.rpc",
+			},
+		},
+	}
+
+	// Private-only values injected via Config for transformation expectations above.
+	injected := &Config{
+		RPCsHost:     "rpcs.cldev.sh",
+		GapProxyHost: "gap-rpc-proxy.public.main.prod.cldev.sh",
+		GapWSPort:    "9443",
+		GapHTTPPort:  "4443",
+		UseGAP:       true,
+	}
+
+	tests := []struct {
+		name         string
+		domain       cldf_domain.Domain
+		filetoCreate []string
+		want         *cldf_config_network.Config
+		wantErr      bool
+	}{
+		{
+			name:         "Loading single file",
+			domain:       dummyDomain,
+			filetoCreate: []string{yamlFile1},
+			wantErr:      false,
+			want:         cldf_config_network.NewConfig([]cldf_config_network.Network{network1}),
+		},
+		{
+			name:         "Loading multiple files",
+			domain:       dummyDomain,
+			filetoCreate: []string{yamlFile1, yamlFile2},
+			wantErr:      false,
+			want:         cldf_config_network.NewConfig([]cldf_config_network.Network{network1, network2}),
+		},
+		{
+			name:         "No config files found",
+			domain:       dummyDomain,
+			filetoCreate: []string{},
+			wantErr:      true,
+			want:         nil,
+		},
+		{
+			name:         "Error loading YAML file",
+			domain:       dummyDomain,
+			filetoCreate: []string{yamlFile3},
+			wantErr:      true,
+			want:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Prepare a temp project root with both testnet and mainnet RPC files in YAML format
+			var (
+				rootDir   = t.TempDir()
+				domainDir = filepath.Join(rootDir, "dummy")
+				configDir = filepath.Join(domainDir, ".config", "networks")
+			)
+
+			// Create the domain and config directory
+			err := os.MkdirAll(configDir, 0755)
+			require.NoError(t, err)
+
+			// Create the YAML files specific to the test case
+			for i, file := range tt.filetoCreate {
+				// Alternate between .yaml and .yml extensions for testing
+				fileExt := "yaml"
+				if i%2 == 0 {
+					fileExt = "yml"
+				}
+				err = os.WriteFile(
+					filepath.Join(configDir, fmt.Sprintf("file-%d.%s", i, fileExt)),
+					[]byte(file), 0644,
+				)
+				require.NoError(t, err)
+			}
+
+			domain := cldf_domain.NewDomain(rootDir, "dummy")
+
+			got, err := loadNetworkConfig(domain, injected)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotEmpty(t, got)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func Test_gapURLTransform(t *testing.T) {
+	t.Parallel()
+
+	const (
+		originalHost = "rpcs.cldev.sh"
+		proxyHost    = "gap-rpc-proxy.public.main.prod.cldev.sh"
+	)
+
+	tests := []struct {
+		name string
+		give string
+		port string
+		want string
+	}{
+		{
+			name: "replaces the http uri host with the GAP V2 proxy address",
+			give: "https://rpcs.cldev.sh/ethereum-mainnet",
+			port: "4443",
+			want: "https://gap-rpc-proxy.public.main.prod.cldev.sh:4443/ethereum-mainnet",
+		},
+		{
+			name: "replaces the websocket uri host with the GAP V2 proxy address",
+			give: "wss://rpcs.cldev.sh/ethereum-mainnet",
+			port: "9443",
+			want: "wss://gap-rpc-proxy.public.main.prod.cldev.sh:9443/ethereum-mainnet",
+		},
+		{
+			name: "leaves uris with non-rpcs.cl-dev.sh URLs unchanged",
+			give: "https://test.rpc",
+			port: "4443",
+			want: "https://test.rpc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			transformFunc := gapURLTransformer(originalHost, proxyHost, tt.port)
+			assert.Equal(t, tt.want, transformFunc(tt.give))
+		})
+	}
+}


### PR DESCRIPTION
Moves pkg/environment/networks.go to cld with added config injection.