### PR TITLE
Update Sui CTF provider configs to allow specifying image and platform

### DIFF
--- a/.changeset/witty-houses-post.md
+++ b/.changeset/witty-houses-post.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+Added optional configs for Sui CTF provider config to allow specifying image and platform.

--- a/chain/sui/provider/ctf_provider.go
+++ b/chain/sui/provider/ctf_provider.go
@@ -31,6 +31,14 @@ type CTFChainProviderConfig struct {
 	// Required: A sync.Once instance to ensure that the CTF framework only sets up the new
 	// DefaultNetwork once
 	Once *sync.Once
+
+	// Optional: A specification of the image to use for the CTF container.
+	// Default: mysten/sui-tools:devnet
+	Image *string
+
+	// Optional: A specification of the platform to use for the CTF container.
+	// Default: linux/amd64
+	Platform *string
 }
 
 // validate checks if the CTFChainProviderConfig is valid.
@@ -160,13 +168,19 @@ func (p *CTFChainProvider) startContainer(
 		port := ports[0]
 		faucetPort := ports[1]
 
+		image := ""
+		if p.config.Image != nil {
+			image = *p.config.Image
+		}
+
 		input := &blockchain.Input{
-			Image:      "", // filled out by defaultSui function
-			Type:       blockchain.TypeSui,
-			ChainID:    chainID,
-			PublicKey:  address,
-			Port:       strconv.Itoa(port),
-			FaucetPort: strconv.Itoa(faucetPort),
+			Image:         image,
+			ImagePlatform: p.config.Platform,
+			Type:          blockchain.TypeSui,
+			ChainID:       chainID,
+			PublicKey:     address,
+			Port:          strconv.Itoa(port),
+			FaucetPort:    strconv.Itoa(faucetPort),
 		}
 
 		output, rerr := blockchain.NewBlockchainNetwork(input)


### PR DESCRIPTION
We sometimes use an `arm64` image instead of the default `amd64` for Sui. This change edits the `CTFChainProviderConfig` for Sui CTF provider to allow passing that config into CTF. 