### PR TITLE
feat: add more domain paths for the config dirs and files

### DIFF
--- a/.changeset/crazy-moose-warn.md
+++ b/.changeset/crazy-moose-warn.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+Adds additional config related file path getter methods to Domains

--- a/engine/cld/domain/domain.go
+++ b/engine/cld/domain/domain.go
@@ -110,3 +110,28 @@ func (d Domain) InternalDirPath() string {
 func (d Domain) CmdDirPath() string {
 	return filepath.Join(d.DirPath(), CmdDirName)
 }
+
+// ConfigDirPath returns the path to the domain config directory within the domain.
+func (d Domain) ConfigDirPath() string {
+	return filepath.Join(d.DirPath(), DomainConfigDirName)
+}
+
+// ConfigLocalDirPath returns the path where local execution config files are stored.
+func (d Domain) ConfigLocalDirPath() string {
+	return filepath.Join(d.ConfigDirPath(), DomainConfigLocalDirName)
+}
+
+// ConfigLocalFileName returns the path to a domain environment's local execution config file.
+func (d Domain) ConfigLocalFileName(env string) string {
+	return filepath.Join(d.ConfigLocalDirPath(), "config."+env+".yaml")
+}
+
+// ConfigNetworksFilePath returns the path where the domain's networks config files are stored.
+func (d Domain) ConfigNetworksFilePath() string {
+	return filepath.Join(d.ConfigDirPath(), DomainConfigNetworksDirName)
+}
+
+// ConfigCIDirPath returns the path where the domain's CI .env files are stored.
+func (d Domain) ConfigCIDirPath() string {
+	return filepath.Join(d.ConfigDirPath(), DomainConfigCIDirName)
+}

--- a/engine/cld/domain/domain_test.go
+++ b/engine/cld/domain/domain_test.go
@@ -205,6 +205,36 @@ func Test_Domain_CmdDirPath(t *testing.T) {
 	assert.Equal(t, "domains/ccip/cmd", d.CmdDirPath())
 }
 
+func Test_Domain_ConfigDirPath(t *testing.T) {
+	t.Parallel()
+	d := NewDomain("domains", "ccip")
+	assert.Equal(t, "domains/ccip/.config", d.ConfigDirPath())
+}
+
+func Test_Domain_ConfigLocalDirPath(t *testing.T) {
+	t.Parallel()
+	d := NewDomain("domains", "ccip")
+	assert.Equal(t, "domains/ccip/.config/local", d.ConfigLocalDirPath())
+}
+
+func Test_Domain_ConfigLocalFileName(t *testing.T) {
+	t.Parallel()
+	d := NewDomain("domains", "ccip")
+	assert.Equal(t, "domains/ccip/.config/local/config.staging.yaml", d.ConfigLocalFileName("staging"))
+}
+
+func Test_Domain_ConfigNetworksFilePath(t *testing.T) {
+	t.Parallel()
+	d := NewDomain("domains", "ccip")
+	assert.Equal(t, "domains/ccip/.config/networks", d.ConfigNetworksFilePath())
+}
+
+func Test_Domain_ConfigCIDirPath(t *testing.T) {
+	t.Parallel()
+	d := NewDomain("domains", "ccip")
+	assert.Equal(t, "domains/ccip/.config/ci", d.ConfigCIDirPath())
+}
+
 // todo: uncomment after moving migration registry over to cldf
 // func Test_EnvDir_LatestExecutedMigration(t *testing.T) {
 // 	t.Parallel()
@@ -236,50 +266,4 @@ func Test_Domain_CmdDirPath(t *testing.T) {
 // 	got, err = envdir.LatestExecutedMigration(reg)
 // 	require.NoError(t, err)
 // 	require.Equal(t, "0002_second", got)
-// }
-
-// todo: uncomment after moving view state over to cldf
-// func Test_EnvDir_SaveViewState(t *testing.T) {
-// 	t.Parallel()
-//
-// 	tests := []struct {
-// 		name      string
-// 		giveState json.Marshaler
-// 		want      string
-// 		wantErr   string
-// 	}{
-// 		{
-// 			name: "success",
-// 			giveState: &testMarshaler{
-// 				Name: "test",
-// 			},
-// 			want: `{"Name":"test"}`,
-// 		},
-// 		{
-// 			name:      "save error",
-// 			giveState: &failedMarshaler{},
-// 			wantErr:   "unable to marshal state",
-// 		},
-// 	}
-//
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			t.Parallel()
-//
-// 			fixture := setupTestDomainsFS(t)
-//
-// 			err := fixture.envDir.SaveViewState(tt.giveState)
-//
-// 			if tt.wantErr != "" {
-// 				require.Error(t, err)
-// 				assert.ErrorContains(t, err, tt.wantErr)
-// 			} else {
-// 				require.NoError(t, err)
-// 				b, err := os.ReadFile(fixture.envDir.ViewStateFilePath())
-// 				require.NoError(t, err)
-//
-// 				assert.JSONEq(t, tt.want, string(b))
-// 			}
-// 		})
-// 	}
 // }

--- a/engine/cld/domain/paths.go
+++ b/engine/cld/domain/paths.go
@@ -1,54 +1,90 @@
 package domain
 
 const (
-	// LibDirName is the standard name of the directory containing the domain's lib directory.
+	// LibDirName is the name of the directory containing the domain's lib directory.
 	LibDirName = "lib"
-	// InternalDirName is the standard name of the directory containing the domain's internal directory.
+
+	// InternalDirName is the name of the directory containing the domain's internal directory.
 	InternalDirName = "internal"
-	// CmdDirName is the standard name of the directory containing the domain's cmd directory.
+
+	// CmdDirName is the name of the directory containing the domain's cmd directory.
 	CmdDirName = "cmd"
-	// AddressBookFileName is the standard name of the file containing the address book.
+
+	// AddressBookFileName is the name of the file containing the address book.
 	AddressBookFileName = "addresses.json"
-	// ArchivedProposalsDirName is the standard name of the directory containing archived proposals.
+
+	// ArchivedProposalsDirName is the name of the directory containing archived proposals.
 	ArchivedProposalsDirName = "archived_proposals"
-	// ArtifactsDirName is the standard name of the directory containing migration artifacts.
+
+	// ArtifactsDirName is the name of the directory containing migration artifacts.
 	ArtifactsDirName = "artifacts"
-	// DarastoreDirName is the standard name of the directory containing the datastore files.
+
+	// DarastoreDirName is the name of the directory containing the datastore files.
 	DatastoreDirName = "datastore"
-	// DataStoreFileName is the standard name of the file containing the datastore.
+
+	// DataStoreFileName is the name of the file containing the datastore.
 	DataStoreFileName = "datastore.json"
-	// AddressRefsFileName is the standard name of the file containing the address refs.
+
+	// AddressRefsFileName is the name of the file containing the address refs.
 	AddressRefsFileName = "address_refs.json"
-	// ChainMetadataFileName is the standard name of the file containing the chain metadata.
+
+	// ChainMetadataFileName is the name of the file containing the chain metadata.
 	ChainMetadataFileName = "chain_metadata.json"
-	// ContractMetadataFileName is the standard name of the file containing the contract metadata.
+
+	// ContractMetadataFileName is the name of the file containing the contract metadata.
 	ContractMetadataFileName = "contract_metadata.json"
-	// EnvMetadataFileName is the standard name of the file containing the environment metadata.
+
+	// DomainConfigDirName is the name of the directory containing the domain's config directory.
+	DomainConfigDirName = ".config"
+
+	// DomainConfigLocalDirName is the name of the directory containing the local domain config.
+	DomainConfigLocalDirName = "local"
+
+	// DomainConfigLocalFileName is the name of the file containing the local domain config.
+	DomainConfigLocalFileName = "config.yml"
+
+	// DomainConfigNetworksDirName is the name of the directory containing the domain networks config.
+	DomainConfigNetworksDirName = "networks"
+
+	// DomainConfigCIDirName is the name of the directory containing the domain CI config.
+	DomainConfigCIDirName = "ci"
+
+	// EnvMetadataFileName is the name of the file containing the environment metadata.
 	EnvMetadataFileName = "env_metadata.json"
-	// NodesFileName is the standard name of the file containing node information in the
+
+	// NodesFileName is the name of the file containing node information in the
 	// environment directory.
 	NodesFileName = "nodes.json"
-	// ProposalsDirName is the standard name of the directory containing proposals.
+
+	// ProposalsDirName is the name of the directory containing proposals.
 	ProposalsDirName = "proposals"
-	// DecodedProposalsDirName is the standard name of the directory containing decoded proposals.
+
+	// DecodedProposalsDirName is the name of the directory containing decoded proposals.
 	DecodedProposalsDirName = "decoded_proposals"
-	// DurablePipelinesFileName is the standard name of the file containing the durable pipelines for
+
+	// DurablePipelinesFileName is the name of the file containing the durable pipelines for
 	// the environment.
 	DurablePipelinesFileName = "durable_pipelines.go"
-	// OperationsReportsDirName is the standard name of the directory containing operations reports.[
+
+	// OperationsReportsDirName is the name of the directory containing operations reports.[
 	OperationsReportsDirName = "operations_reports"
-	// ViewStateFileName is the standard name of the file containing the view state of the
+
+	// ViewStateFileName is the name of the file containing the view state of the
 	// environment.
 	ViewStateFileName = "state.json"
-	// MigrationsFileName is the standard name of the file containing the migrations for the
+
+	// MigrationsFileName is the name of the file containing the migrations for the
 	// environment.
 	MigrationsFileName = "migrations.go"
-	// MigrationsArchiveFileName is the standard name of the file containing the archived
+
+	// MigrationsArchiveFileName is the name of the file containing the archived
 	// migrations for the environment.
 	MigrationsArchiveFileName = "migrations_archive.go"
-	// DurablePipelineDirName is the standard name of the directory containing durable pipelines.
+
+	// DurablePipelineDirName is the name of the directory containing durable pipelines.
 	DurablePipelineDirName = "durable_pipelines"
-	// DurablePipelineInputsDirName is the standard name of the directory containing the inputs
+
+	// DurablePipelineInputsDirName is the name of the directory containing the inputs
 	// for the durable pipelines.
 	DurablePipelineInputsDirName = "inputs"
 )


### PR DESCRIPTION
This change adds more paths for the domain config dirs and files so they can be called on the domain struct. This aims to provide a way to access the expected paths for the domain config dirs and files.