### PR TITLE
feat: adds offchain/ocr package a method to generate BIP39 mnemonic phrases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/avast/retry-go/v4 v4.6.1
 	github.com/aws/aws-sdk-go v1.55.7
 	github.com/block-vision/sui-go-sdk v1.0.6
+	github.com/cosmos/go-bip39 v1.0.0
 	github.com/ethereum/go-ethereum v1.15.7
 	github.com/fbsobreira/gotron-sdk v0.0.0-20250403083053-2943ce8c759b
 	github.com/gagliardetto/solana-go v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -157,6 +157,8 @@ github.com/containerd/platforms v1.0.0-rc.1/go.mod h1:J71L7B+aiM5SdIEqmd9wp6THLV
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
+github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
@@ -712,6 +714,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
@@ -851,6 +854,7 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/offchain/ocr/ocr.go
+++ b/offchain/ocr/ocr.go
@@ -1,0 +1,20 @@
+package ocr
+
+import (
+	"github.com/cosmos/go-bip39"
+)
+
+// NewBIP39Mnemonic generates a new BIP39 mnemonic phrase with the specified entropy size.
+func NewBIP39Mnemonic(entropySize int) (string, error) {
+	entropy, err := bip39.NewEntropy(entropySize)
+	if err != nil {
+		return "", err
+	}
+
+	mnemonic, err := bip39.NewMnemonic(entropy)
+	if err != nil {
+		return "", err
+	}
+
+	return mnemonic, nil
+}

--- a/offchain/ocr/ocr_test.go
+++ b/offchain/ocr/ocr_test.go
@@ -1,0 +1,152 @@
+package ocr
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cosmos/go-bip39"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBIP39Mnemonic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		entropySize int
+		expectError bool
+	}{
+		{
+			name:        "valid entropy 128 bits",
+			entropySize: 128,
+			expectError: false,
+		},
+		{
+			name:        "valid entropy 160 bits",
+			entropySize: 160,
+			expectError: false,
+		},
+		{
+			name:        "valid entropy 192 bits",
+			entropySize: 192,
+			expectError: false,
+		},
+		{
+			name:        "valid entropy 224 bits",
+			entropySize: 224,
+			expectError: false,
+		},
+		{
+			name:        "valid entropy 256 bits",
+			entropySize: 256,
+			expectError: false,
+		},
+		{
+			name:        "invalid entropy size - too small",
+			entropySize: 127,
+			expectError: true,
+		},
+		{
+			name:        "invalid entropy size - too large",
+			entropySize: 257,
+			expectError: true,
+		},
+		{
+			name:        "invalid entropy size - not multiple of 32",
+			entropySize: 129,
+			expectError: true,
+		},
+		{
+			name:        "zero entropy size",
+			entropySize: 0,
+			expectError: true,
+		},
+		{
+			name:        "negative entropy size",
+			entropySize: -128,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mnemonic, err := NewBIP39Mnemonic(tt.entropySize)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Empty(t, mnemonic)
+			} else {
+				require.NoError(t, err)
+				assert.NotEmpty(t, mnemonic)
+
+				// Validate that the returned mnemonic is a valid BIP39 mnemonic
+				assert.True(t, bip39.IsMnemonicValid(mnemonic), "generated mnemonic should be valid")
+
+				// Check word count based on entropy size
+				words := strings.Fields(mnemonic)
+				expectedWordCount := (tt.entropySize + tt.entropySize/32) / 11
+				assert.Len(t, words, expectedWordCount, "word count should match expected for entropy size")
+
+				// Verify mnemonic can be converted back to bytes
+				_, err := bip39.MnemonicToByteArray(mnemonic)
+				require.NoError(t, err, "should be able to convert mnemonic to byte array")
+			}
+		})
+	}
+}
+
+func TestNewBIP39Mnemonic_Uniqueness(t *testing.T) {
+	t.Parallel()
+
+	const entropySize = 256
+	const numMnemonics = 100
+
+	mnemonics := make(map[string]bool)
+
+	for range numMnemonics {
+		mnemonic, err := NewBIP39Mnemonic(entropySize)
+		require.NoError(t, err)
+		require.NotEmpty(t, mnemonic)
+
+		// Ensure each generated mnemonic is unique
+		assert.False(t, mnemonics[mnemonic], "generated mnemonic should be unique")
+		mnemonics[mnemonic] = true
+
+		// Validate the mnemonic
+		assert.True(t, bip39.IsMnemonicValid(mnemonic))
+	}
+
+	assert.Len(t, mnemonics, numMnemonics, "should have generated exactly %d unique mnemonics", numMnemonics)
+}
+
+func TestNewBIP39Mnemonic_WordCount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		entropySize       int
+		expectedWordCount int
+	}{
+		{128, 12}, // 128 bits -> 12 words
+		{160, 15}, // 160 bits -> 15 words
+		{192, 18}, // 192 bits -> 18 words
+		{224, 21}, // 224 bits -> 21 words
+		{256, 24}, // 256 bits -> 24 words
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("entropy_%d_bits", tt.entropySize), func(t *testing.T) {
+			t.Parallel()
+
+			mnemonic, err := NewBIP39Mnemonic(tt.entropySize)
+			require.NoError(t, err)
+
+			words := strings.Fields(mnemonic)
+			assert.Len(t, words, tt.expectedWordCount,
+				"entropy size %d should generate %d words", tt.entropySize, tt.expectedWordCount)
+		})
+	}
+}


### PR DESCRIPTION
This change adds a method to generate BIP39 mnemonic phrases to the offchain/ocr package. These phrases are used for OCR Secrets.