### PR TITLE
feat: add gas limit option to raw transactor

### DIFF
--- a/.changeset/young-colts-chew.md
+++ b/.changeset/young-colts-chew.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+Add support for gas limit option on raw signer generator

--- a/chain/evm/provider/signer_generator.go
+++ b/chain/evm/provider/signer_generator.go
@@ -24,16 +24,40 @@ var (
 	_ SignerGenerator = (*transactorFromKMSSigner)(nil)
 )
 
+// GeneratorOptions contains configuration options for the SignerGenerator.
+type GeneratorOptions struct {
+	gasLimit uint64
+}
+
+// GeneratorOption is a function that modifies GeneratorOptions.
+type GeneratorOption func(*GeneratorOptions)
+
+func WithGasLimit(gasLimit uint64) GeneratorOption {
+	return func(opts *GeneratorOptions) {
+		opts.gasLimit = gasLimit
+	}
+}
+
 // TransactorFromRaw returns a generator which creates a transactor from a raw private key.
-func TransactorFromRaw(privKey string) SignerGenerator {
+func TransactorFromRaw(privKey string, opts ...GeneratorOption) SignerGenerator {
+	// load default options
+	defaultOpts := &GeneratorOptions{
+		gasLimit: 0,
+	}
+	// apply provided options
+	for _, opt := range opts {
+		opt(defaultOpts)
+	}
 	return &transactorFromRaw{
-		privKey: privKey,
+		privKey:  privKey,
+		gasLimit: defaultOpts.gasLimit,
 	}
 }
 
 // transactorFromRaw is a SignerGenerator that creates a transactor from a private key.
 type transactorFromRaw struct {
-	privKey string
+	privKey  string
+	gasLimit uint64
 }
 
 // Generate parses the hex encoded private key and returns the bind transactor options.
@@ -46,6 +70,9 @@ func (g *transactorFromRaw) Generate(chainID *big.Int) (*bind.TransactOpts, erro
 	transactor, err := bind.NewKeyedTransactorWithChainID(privKey, chainID)
 	if err != nil {
 		return nil, err
+	}
+	if g.gasLimit > 0 {
+		transactor.GasLimit = g.gasLimit
 	}
 
 	return transactor, nil

--- a/chain/evm/provider/signer_generator.go
+++ b/chain/evm/provider/signer_generator.go
@@ -48,6 +48,7 @@ func TransactorFromRaw(privKey string, opts ...GeneratorOption) SignerGenerator 
 	for _, opt := range opts {
 		opt(defaultOpts)
 	}
+
 	return &transactorFromRaw{
 		privKey:  privKey,
 		gasLimit: defaultOpts.gasLimit,

--- a/chain/evm/provider/signer_generator_test.go
+++ b/chain/evm/provider/signer_generator_test.go
@@ -74,6 +74,7 @@ func Test_TransactorFromRaw(t *testing.T) {
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				require.ErrorContains(t, err, tt.wantErr)
+
 				return
 			}
 


### PR DESCRIPTION
This pull request introduces support for specifying a gas limit when generating a raw signer in the Chainlink deployments framework. The changes add a flexible options pattern to the signer generator, allowing users to set a custom gas limit if needed. Unit tests have been updated to cover this new functionality.

**New feature: Gas limit support for raw signer generator**
- Added a `GeneratorOptions` struct and options pattern (`GeneratorOption`, `WithGasLimit`) to `signer_generator.go`, enabling configuration of gas limit for raw signers.
- Updated `TransactorFromRaw` to accept options and set the gas limit on the generated transactor if provided. [[1]](diffhunk://#diff-d969a93d4b9bf394c24013f13cd08f330806edf95bd4536a0e3b78935e38c636R27-R60) [[2]](diffhunk://#diff-d969a93d4b9bf394c24013f13cd08f330806edf95bd4536a0e3b78935e38c636R74-R76)

**Testing improvements**
- Enhanced unit tests in `signer_generator_test.go` to verify correct gas limit behavior, including cases with and without custom gas limits. [[1]](diffhunk://#diff-1212d4f28859805b9036ae27dd95525343ab0ec9143d856d84980583985476b2L33-R51) [[2]](diffhunk://#diff-1212d4f28859805b9036ae27dd95525343ab0ec9143d856d84980583985476b2L60-R82)

**Documentation**
- Added a changeset documenting the new gas limit option for the raw signer generator.