### PR TITLE
fix: correct function names in domain.go and domain_test.go

### DIFF
--- a/.changeset/plain-dragons-eat.md
+++ b/.changeset/plain-dragons-eat.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+[BREAKING] Fixes domain config path getters to have more consistent naming

--- a/engine/cld/domain/domain.go
+++ b/engine/cld/domain/domain.go
@@ -121,13 +121,13 @@ func (d Domain) ConfigLocalDirPath() string {
 	return filepath.Join(d.ConfigDirPath(), DomainConfigLocalDirName)
 }
 
-// ConfigLocalFileName returns the path to a domain environment's local execution config file.
-func (d Domain) ConfigLocalFileName(env string) string {
+// ConfigLocalFilePath returns the path to a domain environment's local execution config file.
+func (d Domain) ConfigLocalFilePath(env string) string {
 	return filepath.Join(d.ConfigLocalDirPath(), "config."+env+".yaml")
 }
 
-// ConfigNetworksFilePath returns the path where the domain's networks config files are stored.
-func (d Domain) ConfigNetworksFilePath() string {
+// ConfigNetworksDirPath returns the path where the domain's networks config files are stored.
+func (d Domain) ConfigNetworksDirPath() string {
 	return filepath.Join(d.ConfigDirPath(), DomainConfigNetworksDirName)
 }
 

--- a/engine/cld/domain/domain_test.go
+++ b/engine/cld/domain/domain_test.go
@@ -220,13 +220,13 @@ func Test_Domain_ConfigLocalDirPath(t *testing.T) {
 func Test_Domain_ConfigLocalFileName(t *testing.T) {
 	t.Parallel()
 	d := NewDomain("domains", "ccip")
-	assert.Equal(t, "domains/ccip/.config/local/config.staging.yaml", d.ConfigLocalFileName("staging"))
+	assert.Equal(t, "domains/ccip/.config/local/config.staging.yaml", d.ConfigLocalFilePath("staging"))
 }
 
 func Test_Domain_ConfigNetworksFilePath(t *testing.T) {
 	t.Parallel()
 	d := NewDomain("domains", "ccip")
-	assert.Equal(t, "domains/ccip/.config/networks", d.ConfigNetworksFilePath())
+	assert.Equal(t, "domains/ccip/.config/networks", d.ConfigNetworksDirPath())
 }
 
 func Test_Domain_ConfigCIDirPath(t *testing.T) {


### PR DESCRIPTION
Fixes to correctly reference the difference between dir and file path.