### PR TITLE
[CLD-518]: fix(anvil): fix nil pointer when T is not provided

### DIFF
--- a/.changeset/tricky-trams-sin.md
+++ b/.changeset/tricky-trams-sin.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix(anvil): fix nil pointer when T is not provided


### PR DESCRIPTION
Because anvil provider can be used outside of testing, the testing.T is not available, however currently , when it is not provided, the code returns nil pointer error during the call to testcontainers.CleanupContainer, this fix handles that scenario and provide a dedicated method for cleaning up container.

```
// Usage in production/non-test contexts with manual cleanup:
//
//	func main() {
//		var once sync.Once
//		config := CTFAnvilChainProviderConfig{
//			Once:           &once,
//			ConfirmFunctor: ConfirmFuncGeth(2 * time.Minute),
//			Port:           "8545", // T not required when Port is provided
//		}
//
//		provider := NewCTFAnvilChainProvider(chainSelector, config)
//		blockchain, err := provider.Initialize(context.Background())
//		if err != nil {
//			log.Fatal(err)
//		}
//
//		// Use the blockchain...
//
//		// Important: Clean up the container when done
//		defer func() {
//			if err := provider.Cleanup(context.Background()); err != nil {
//				log.Printf("Failed to cleanup container: %v", err)
//			}
//		}()
//	}

```

When used in testing environment (passing in testing.T), container will be auto cleaned up.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-518