### PR TITLE
feat: adds ci config files path methods

### DIFF
--- a/.changeset/four-grapes-warn.md
+++ b/.changeset/four-grapes-warn.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+feat: adds ci config files path methods

--- a/engine/cld/domain/domain.go
+++ b/engine/cld/domain/domain.go
@@ -135,3 +135,13 @@ func (d Domain) ConfigNetworksDirPath() string {
 func (d Domain) ConfigCIDirPath() string {
 	return filepath.Join(d.ConfigDirPath(), DomainConfigCIDirName)
 }
+
+// ConfigCICommonFilePath returns the path to the domain's CI common .env file.
+func (d Domain) ConfigCICommonFilePath() string {
+	return filepath.Join(d.ConfigCIDirPath(), "common.env")
+}
+
+// ConfigCIEnvFilePath returns the path to the domain's CI .env file for the specified environment.
+func (d Domain) ConfigCIEnvFilePath(env string) string {
+	return filepath.Join(d.ConfigCIDirPath(), env+".env")
+}

--- a/engine/cld/domain/domain_test.go
+++ b/engine/cld/domain/domain_test.go
@@ -235,6 +235,18 @@ func Test_Domain_ConfigCIDirPath(t *testing.T) {
 	assert.Equal(t, "domains/ccip/.config/ci", d.ConfigCIDirPath())
 }
 
+func Test_Domain_ConfigCICommonFilePath(t *testing.T) {
+	t.Parallel()
+	d := NewDomain("domains", "ccip")
+	assert.Equal(t, "domains/ccip/.config/ci/common.env", d.ConfigCICommonFilePath())
+}
+
+func Test_Domain_ConfigCIEnvFilePath(t *testing.T) {
+	t.Parallel()
+	d := NewDomain("domains", "ccip")
+	assert.Equal(t, "domains/ccip/.config/ci/staging.env", d.ConfigCIEnvFilePath("staging"))
+}
+
 // todo: uncomment after moving migration registry over to cldf
 // func Test_EnvDir_LatestExecutedMigration(t *testing.T) {
 // 	t.Parallel()


### PR DESCRIPTION
This `PR` adds a couple of CI config file paths:
- common.env path (shared defaults)
- environment-specific .env path(s)