### PR TITLE
[CLD-559]: test(job): fix race condition

### DIFF
--- a/offchain/jd/client_test.go
+++ b/offchain/jd/client_test.go
@@ -198,23 +198,16 @@ func TestJDClient_GetCSAPublicKey(t *testing.T) {
 func TestJDClient_ProposeJob(t *testing.T) {
 	t.Parallel()
 
-	var (
-		request = &jobv1.ProposeJobRequest{
-			NodeId: "test-node-123",
-			Spec:   "test-job-spec",
-		}
-	)
-
 	tests := []struct {
 		name       string
-		beforeFunc func(t *testing.T, mockJob *mocks.MockJobServiceClient)
+		beforeFunc func(t *testing.T, mockJob *mocks.MockJobServiceClient, request *jobv1.ProposeJobRequest)
 		request    *jobv1.ProposeJobRequest
 		want       *jobv1.ProposeJobResponse
 		wantErr    string
 	}{
 		{
 			name: "success with valid proposal",
-			beforeFunc: func(t *testing.T, mockJob *mocks.MockJobServiceClient) {
+			beforeFunc: func(t *testing.T, mockJob *mocks.MockJobServiceClient, request *jobv1.ProposeJobRequest) {
 				t.Helper()
 
 				response := &jobv1.ProposeJobResponse{
@@ -244,7 +237,7 @@ func TestJDClient_ProposeJob(t *testing.T) {
 		},
 		{
 			name: "error when ProposeJob service call fails",
-			beforeFunc: func(t *testing.T, mockJob *mocks.MockJobServiceClient) {
+			beforeFunc: func(t *testing.T, mockJob *mocks.MockJobServiceClient, request *jobv1.ProposeJobRequest) {
 				t.Helper()
 
 				mockJob.EXPECT().ProposeJob(
@@ -260,7 +253,7 @@ func TestJDClient_ProposeJob(t *testing.T) {
 		},
 		{
 			name: "error when proposal is nil in response",
-			beforeFunc: func(t *testing.T, mockJob *mocks.MockJobServiceClient) {
+			beforeFunc: func(t *testing.T, mockJob *mocks.MockJobServiceClient, request *jobv1.ProposeJobRequest) {
 				t.Helper()
 
 				response := &jobv1.ProposeJobResponse{
@@ -280,10 +273,9 @@ func TestJDClient_ProposeJob(t *testing.T) {
 		},
 		{
 			name: "success with empty request",
-			beforeFunc: func(t *testing.T, mockJob *mocks.MockJobServiceClient) {
+			beforeFunc: func(t *testing.T, mockJob *mocks.MockJobServiceClient, request *jobv1.ProposeJobRequest) {
 				t.Helper()
 
-				request := &jobv1.ProposeJobRequest{}
 				response := &jobv1.ProposeJobResponse{
 					Proposal: &jobv1.Proposal{
 						Id: "empty-proposal-123",
@@ -310,7 +302,7 @@ func TestJDClient_ProposeJob(t *testing.T) {
 
 			// Create mock job service client
 			mockClients := mocks.NewMockClients(t)
-			tt.beforeFunc(t, mockClients.JobServiceClient)
+			tt.beforeFunc(t, mockClients.JobServiceClient, tt.request)
 
 			// Create JobDistributor with mock
 			jd := &JobDistributor{


### PR DESCRIPTION
Recently, we been [getting race condition](https://github.com/smartcontractkit/chainlink-deployments-framework/actions/runs/17254351292/job/48963163120?pr=328#step:2:491) on the mocked JobClient when ProposeJob is called.

From the stack trace, we know there is a read ProposeJob from log:
```
  github.com/stretchr/testify/mock.(*Mock).Called()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.10.0/mock/mock.go:481 +0x191
  github.com/smartcontractkit/chainlink-deployments-framework/offchain/jd/internal/mocks.(*MockJobServiceClient).ProposeJob()
      /home/runner/work/chainlink-deployments-framework/chainlink-deployments-framework/offchain/jd/internal/mocks/mock_job_service_client.go:546 +0x34c
```

and a write at

```
Previous write at 0x00c000188060 by goroutine 15:
  sync/atomic.StoreInt64()
      /opt/hostedtoolcache/go/1.24.4/x64/src/runtime/race_amd64.s:237 +0xb
  sync/atomic.StorePointer()
      /opt/hostedtoolcache/go/1.24.4/x64/src/runtime/atomic_pointer.go:92 +0x44
  github.com/smartcontractkit/chainlink-protos/job-distributor/v1/job.(*ProposeJobRequest).ProtoReflect()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-protos/job-distributor@v0.12.0/v1/job/job.pb.go:791 +0x93
```

We know it is the test `TestJDClient_ProposeJob` from the logs below
```
Goroutine 15 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.24.4/x64/src/testing/testing.go:1851 +0x8f2
  github.com/smartcontractkit/chainlink-deployments-framework/offchain/jd.TestJDClient_ProposeJob()
      /home/runner/work/chainlink-deployments-framework/chainlink-deployments-framework/offchain/jd/client_test.go:308 +0xae4
```

After some investigation, we use the same pointer for `jobv1.ProposeJobRequest` on all the test cases for `TestJDClient_ProposeJob`.

```
--- FAIL: TestJDClient_ProposeJob (0.00s)
    --- FAIL: TestJDClient_ProposeJob/success_with_empty_request (0.00s)
        testing.go:1490: race detected during execution of test
    --- FAIL: TestJDClient_ProposeJob/success_with_valid_proposal (0.00s)
        testing.go:1490: race detected during execution of test
    --- FAIL: TestJDClient_ProposeJob/error_when_ProposeJob_service_call_fails (0.00s)
        testing.go:1490: race detected during execution of test
```

How it happen:

```
// Shared ProposeJobRequest object
request := &jobv1.ProposeJobRequest{...}

// Goroutine 15 (Test A)
mockJob.EXPECT().ProposeJob(ctx, request) // Triggers:
  └─ Arguments.Diff()
     └─ fmt.Sprintf("%v", request)
        └─ request.String()
           └─ request.ProtoReflect()
              └─ atomic.StorePointer(&metadata) // WRITE!

// Goroutine 16 (Test B) - happening simultaneously
mockJob.EXPECT().ProposeJob(ctx, request) // Triggers:
  └─ Arguments comparison
     └─ reflect.DeepEqual()
        └─ reflect.Value.IsNil()
           └─ reads the same memory location // READ!
```
Looks like for mocked object, when using `Arguments.Diff()` for comparing arguments called and expected, it will call `String()` of the object, which for protobuf object, it eventually calls ProtoReflect which performs a write [here](https://github.com/smartcontractkit/chainlink-protos/blob/main/job-distributor/v1/job/job.pb.go#L174), this may be the reason for the race condition.

Not super confident, but lets see if it happens again.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-559