### PR TITLE
chore: migrate cli package into the CLD engine legacy package

### DIFF
--- a/.changeset/major-walls-stop.md
+++ b/.changeset/major-walls-stop.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+Adds `cli` package to `engine/cld/legacy`

--- a/engine/cld/legacy/cli/cli.go
+++ b/engine/cld/legacy/cli/cli.go
@@ -1,0 +1,62 @@
+// Package cli provides a base struct for creating CLI applications using Cobra. It contains common
+// functionality for creating CLI applications, such as providing a logger, adding commands and
+// running the root command.
+package cli
+
+import (
+	"os"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Base is a base struct for creating CLI applications using Cobra. This should be embedded into
+// a struct that contains the specific commands for the CLI application.
+type Base struct {
+	Log logger.Logger
+
+	rootCmd *cobra.Command
+}
+
+// NewBase creates a new CLIBase instance.
+func NewBase(log logger.Logger, rootCmd *cobra.Command) *Base {
+	return &Base{
+		Log:     log,
+		rootCmd: rootCmd,
+	}
+}
+
+// AddCommand adds one or more commands to the root command of the CLI application.
+func (base *Base) AddCommand(cmds ...*cobra.Command) {
+	base.rootCmd.AddCommand(cmds...)
+}
+
+// Run executes the root command of the CLI application.
+func (base *Base) Run() error {
+	return base.rootCmd.Execute()
+}
+
+// RootCmd returns the root command of the CLI application.
+func (base *Base) RootCmd() *cobra.Command {
+	return base.rootCmd
+}
+
+// NewLogger creates a new logger instance from chainlink-common. This is a helper function to
+// initialize a logger to provide to `NewBase`.
+func NewLogger(level zapcore.Level) (logger.Logger, error) {
+	c := logger.Config{Level: level}
+	if os.Getenv("LOG_FORMAT") == "console" || os.Getenv("LOG_FORMAT") == "human" {
+		return logger.NewWith(func(config *zap.Config) {
+			config.Level.SetLevel(level)
+			config.Development = true
+			config.DisableStacktrace = true
+			config.Encoding = "console"
+			config.EncoderConfig = zap.NewDevelopmentEncoderConfig()
+			config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+		})
+	}
+
+	return c.New()
+}

--- a/engine/cld/legacy/cli/cli_test.go
+++ b/engine/cld/legacy/cli/cli_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+func Test_Base_AddCommand(t *testing.T) {
+	t.Parallel()
+
+	base := Base{
+		rootCmd: &cobra.Command{},
+	}
+
+	give := &cobra.Command{}
+
+	base.AddCommand(give)
+
+	assert.Equal(t, []*cobra.Command{give}, base.rootCmd.Commands())
+}
+
+func Test_Base_Run(t *testing.T) {
+	t.Parallel()
+
+	var val string
+
+	base := Base{
+		rootCmd: &cobra.Command{
+			Use: "test",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				val = "ran"
+
+				return nil
+			},
+		},
+	}
+
+	err := base.Run()
+	require.NoError(t, err)
+	assert.Equal(t, "ran", val)
+}
+
+func Test_NewLogger(t *testing.T) {
+	t.Parallel()
+
+	log, err := NewLogger(zapcore.DebugLevel)
+	require.NoError(t, err)
+	assert.NotNil(t, log)
+}

--- a/engine/cld/legacy/cli/logger.go
+++ b/engine/cld/legacy/cli/logger.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func NewCLILogger(logLevel zapcore.Level) (logger.Logger, error) {
+	lggr, err := logger.NewWith(func(cfg *zap.Config) {
+		*cfg = zap.NewDevelopmentConfig()
+		cfg.Level.SetLevel(logLevel)
+		cfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return lggr, nil
+}

--- a/engine/cld/legacy/cli/templates.go
+++ b/engine/cld/legacy/cli/templates.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"strings"
+)
+
+const Indentation = `  `
+
+// LongDesc normalizes a command's long description to follow the conventions.
+func LongDesc(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+
+	return normalizer{s}.trim().string
+}
+
+// Examples normalizes a command's examples to follow the conventions.
+func Examples(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+
+	return normalizer{s}.trim().indent().string
+}
+
+type normalizer struct {
+	string
+}
+
+func (s normalizer) trim() normalizer {
+	s.string = strings.TrimSpace(s.string)
+
+	return s
+}
+
+func (s normalizer) indent() normalizer {
+	indentedLines := []string{}
+	for line := range strings.SplitSeq(s.string, "\n") {
+		trimmed := strings.TrimSpace(line)
+		indented := Indentation + trimmed
+		indentedLines = append(indentedLines, indented)
+	}
+	s.string = strings.Join(indentedLines, "\n")
+
+	return s
+}

--- a/engine/cld/legacy/cli/templates_test.go
+++ b/engine/cld/legacy/cli/templates_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_LongDesc(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		give string
+		want string
+	}{
+		{
+			name: "empty string produces empty string",
+			give: "",
+			want: "",
+		},
+		{
+			name: "single line string produces same string",
+			give: "hello world",
+			want: "hello world",
+		},
+		{
+			name: "multi line string produces same string",
+			give: "hello\nworld",
+			want: "hello\nworld",
+		},
+		{
+			name: "multi line string with leading/trailing whitespace trims whitespace",
+			give: "  hello\nworld  ",
+			want: "hello\nworld",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := LongDesc(tt.give)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_Examples(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		give string
+		want string
+	}{
+		{
+			name: "empty string produces empty string",
+			give: "",
+			want: "",
+		},
+		{
+			name: "single line string indents the line",
+			give: "hello world",
+			want: "  hello world",
+		},
+		{
+			name: "multi line string indents each line",
+			give: "hello\nworld",
+			want: "  hello\n  world",
+		},
+		{
+			name: "multi line string with leading/trailing whitespace trims trailing whitespace and indents each line",
+			give: "  hello\nworld  ",
+			want: "  hello\n  world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := Examples(tt.give)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335
 	github.com/smartcontractkit/freeport v0.1.2
 	github.com/smartcontractkit/mcms v0.21.1
+	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.38.0
@@ -147,6 +148,7 @@ require (
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/huin/goupnp v1.3.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.14.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,6 +167,7 @@ github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a h1:W8mUrRp6NOVl3J+MYp5kPMoUZPp7aOYHtaua31lwRHg=
@@ -371,6 +372,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb-client-go/v2 v2.4.0 h1:HGBfZYStlx3Kqvsv1h2pJixbCl/jhnFtxpKFAv9Tu5k=
 github.com/influxdata/influxdb-client-go/v2 v2.4.0/go.mod h1:vLNHdxTJkIf2mSLvGrpj8TCcISApPoXkaxP8g9uRlW8=
 github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c h1:qSHzRbhzK8RdXOsAdfDgO49TtqC1oZ+acxPrkfTxcCs=
@@ -716,6 +719,9 @@ github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=
 github.com/spf13/afero v1.12.0/go.mod h1:ZTlWwG4/ahT8W7T0WQ5uYmjI9duaLQGy3Q2OAl4sk/4=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.20.1 h1:ZMi+z/lvLyPSCoNtFCpqjy0S4kPbirhpTMwl8BkW9X4=

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,13 +9,15 @@ docs/**/*,\
 **/mocks/**/*,\
 **/mocks_test.go,\
 **/*.json, \
-**/*.pb.go
+**/*.pb.go, \
+engine/cld/legacy/**/*
 
-# docs/**/*,        # Documentation directory
-# **/mocks/**/*     # Any generated mocks directory
-# **/mocks_test.go  # Standard generated mocks test file
-# **/*.json \       # JSON files - speed up indexing
-# **/*.pb.go        # Protobuf generated files
+# docs/**/*,             # Documentation directory
+# **/mocks/**/*          # Any generated mocks directory
+# **/mocks_test.go       # Standard generated mocks test file
+# **/*.json \            # JSON files - speed up indexing
+# **/*.pb.go             # Protobuf generated files
+# engine/cld/legacy/**/* # Legacy code that has been ported over. This will be removed in the future.
 
 sonar.coverage.exclusions=\
 **/*_test.go, \


### PR DESCRIPTION
This is a temporary migration to get the CLI package into the CLD engine legacy package.

As we determine how to best design CLI management, we will deprecate this package.