### PR TITLE
fix: correct cognito auth fields names

### DIFF
--- a/.changeset/cruel-things-shave.md
+++ b/.changeset/cruel-things-shave.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+[Breaking] Change CognitoAuth field names

--- a/offchain/jd/cognito.go
+++ b/offchain/jd/cognito.go
@@ -38,11 +38,11 @@ type CognitoTokenSource struct {
 // CognitoAuth contains the Cognito authentication information required to generate a token from
 // Cognito.
 type CognitoAuth struct {
-	AWSRegion              string
-	CognitoAppClientID     string
-	CognitoAppClientSecret string
-	Username               string
-	Password               string
+	AWSRegion       string
+	AppClientID     string
+	AppClientSecret string
+	Username        string
+	Password        string
 }
 
 // NewCognitoTokenSource creates a new CognitoTokenSource with the given CognitoAuth configuration.
@@ -72,7 +72,7 @@ func (c *CognitoTokenSource) Authenticate(ctx context.Context) error {
 	// Authenticate the user
 	input := &cognitoidentityprovider.InitiateAuthInput{
 		AuthFlow: types.AuthFlowTypeUserPasswordAuth,
-		ClientId: aws.String(c.auth.CognitoAppClientID),
+		ClientId: aws.String(c.auth.AppClientID),
 		AuthParameters: map[string]string{
 			"USERNAME":    c.auth.Username,
 			"PASSWORD":    c.auth.Password,
@@ -135,8 +135,8 @@ func (c *CognitoTokenSource) Token() (*oauth2.Token, error) {
 //
 // Returns the computed secret hash as a base64-encoded string.
 func (c *CognitoTokenSource) secretHash() string {
-	hmac := hmac.New(sha256.New, []byte(c.auth.CognitoAppClientSecret))
-	message := []byte(c.auth.Username + c.auth.CognitoAppClientID)
+	hmac := hmac.New(sha256.New, []byte(c.auth.AppClientSecret))
+	message := []byte(c.auth.Username + c.auth.AppClientID)
 	hmac.Write(message)
 	dataHmac := hmac.Sum(nil)
 

--- a/offchain/jd/cognito_test.go
+++ b/offchain/jd/cognito_test.go
@@ -26,11 +26,11 @@ func Test_NewCognitoTokenSource(t *testing.T) {
 	t.Parallel()
 
 	auth := CognitoAuth{
-		AWSRegion:              "us-east-1",
-		CognitoAppClientID:     "test-client-id",
-		CognitoAppClientSecret: "test-client-secret",
-		Username:               "testuser",
-		Password:               "testpass",
+		AWSRegion:       "us-east-1",
+		AppClientID:     "test-client-id",
+		AppClientSecret: "test-client-secret",
+		Username:        "testuser",
+		Password:        "testpass",
 	}
 
 	tokenSource := NewCognitoTokenSource(auth)
@@ -45,11 +45,11 @@ func Test_CognitoTokenSource_Authenticate(t *testing.T) {
 	t.Parallel()
 
 	auth := CognitoAuth{
-		AWSRegion:              "us-east-1",
-		CognitoAppClientID:     "test-client-id",
-		CognitoAppClientSecret: "test-client-secret",
-		Username:               "testuser",
-		Password:               "testpass",
+		AWSRegion:       "us-east-1",
+		AppClientID:     "test-client-id",
+		AppClientSecret: "test-client-secret",
+		Username:        "testuser",
+		Password:        "testpass",
 	}
 
 	tests := []struct {
@@ -72,7 +72,7 @@ func Test_CognitoTokenSource_Authenticate(t *testing.T) {
 				}
 
 				client.EXPECT().InitiateAuth(mock.Anything, mock.MatchedBy(func(input *cognitoidentityprovider.InitiateAuthInput) bool {
-					return *input.ClientId == auth.CognitoAppClientID &&
+					return *input.ClientId == auth.AppClientID &&
 						input.AuthFlow == types.AuthFlowTypeUserPasswordAuth &&
 						input.AuthParameters["USERNAME"] == auth.Username &&
 						input.AuthParameters["PASSWORD"] == auth.Password &&
@@ -175,11 +175,11 @@ func Test_CognitoTokenSource_Token(t *testing.T) {
 
 			client := mocks.NewMockCognitoClient(t)
 			auth := CognitoAuth{
-				AWSRegion:              "us-east-1",
-				CognitoAppClientID:     "test-client-id",
-				CognitoAppClientSecret: "test-client-secret",
-				Username:               "testuser",
-				Password:               "testpass",
+				AWSRegion:       "us-east-1",
+				AppClientID:     "test-client-id",
+				AppClientSecret: "test-client-secret",
+				Username:        "testuser",
+				Password:        "testpass",
 			}
 
 			source := newCognitoTokenSourceWithClient(auth, client)
@@ -206,9 +206,9 @@ func Test_CognitoTokenSource_secretHash(t *testing.T) {
 
 	// Test with static values to ensure the hash calculation is correct
 	auth := CognitoAuth{
-		CognitoAppClientID:     "clientid",
-		CognitoAppClientSecret: "secret",
-		Username:               "user",
+		AppClientID:     "clientid",
+		AppClientSecret: "secret",
+		Username:        "user",
 	}
 
 	tokenSource := NewCognitoTokenSource(auth)


### PR DESCRIPTION
This changes the field names to match the new Cognito auth fields, removing the redundantCognito prefix.