### PR TITLE
[CLD-569]:fix(operations): handle marshalable edge case

### DIFF
--- a/.changeset/quick-bats-grab.md
+++ b/.changeset/quick-bats-grab.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix(operations): handle missing case causing Operations APi unable to serialize certain Marshalable struct

--- a/operations/validation.go
+++ b/operations/validation.go
@@ -32,12 +32,17 @@ func isValueSerializable(lggr logger.Logger, v reflect.Value) bool {
 	}
 
 	// Check if type implements json.Marshaler and json.Unmarshaler
-	t := v.Type()
+	fieldTypeRef := v.Type()
+	ptrFieldTypeRef := reflect.PointerTo(fieldTypeRef)
+
 	marshalType := reflect.TypeOf((*json.Marshaler)(nil)).Elem()
 	unmarshalType := reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()
 
+	implementsMarshaler := fieldTypeRef.Implements(marshalType) || ptrFieldTypeRef.Implements(marshalType)
+	implementsUnmarshaler := fieldTypeRef.Implements(unmarshalType) || ptrFieldTypeRef.Implements(unmarshalType)
+
 	// If it implements both interfaces, assume it's serializable
-	if t.Implements(marshalType) && t.Implements(unmarshalType) {
+	if implementsMarshaler && implementsUnmarshaler {
 		return true
 	}
 

--- a/operations/validation_test.go
+++ b/operations/validation_test.go
@@ -12,6 +12,8 @@ import (
 	mcmslib "github.com/smartcontractkit/mcms"
 	"github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 )
 
 func Test_IsSerializable(t *testing.T) {
@@ -78,9 +80,9 @@ func Test_IsSerializable(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "should fail to serialise value customMarshaler - does not implements MarshalJSON & UnmarshalJSON",
+			name: "should serialise value customMarshaler - also implements MarshalJSON & UnmarshalJSON",
 			v:    customMarshaler{data: "test"},
-			want: false,
+			want: true,
 		},
 		{
 			name: "should serialise nested struct",
@@ -142,6 +144,11 @@ func Test_IsSerializable(t *testing.T) {
 		{
 			name: "should serialise TimelockProposal",
 			v:    createMCMSTimelockProposal(t),
+			want: true,
+		},
+		{
+			name: "should serialize Datastore AddressRef",
+			v:    datastore.AddressRef{},
 			want: true,
 		},
 	}


### PR DESCRIPTION
This bug was caught in this [support ticket](https://chainlink-core.slack.com/archives/C08QF1BEW4T/p1756395130562909)

Since all the fields in AddressRef is public and each field is either public or implement Marshaler and Unmarshaler , operations api should be able to serialise it. There is a bug where operations API fails to serialize it if both marshalJSON and unmarshalJSON are different receiver types eg

```
func (s LabelSet) MarshalJSON() ([]byte, error) {
	...
}

func (s *LabelSet) UnmarshalJSON(data []byte) error {
	...
}
```

Note MarshalJSON is a value receiver and UnmarshalJSON is a pointer receiver, then even though LabelSet is serializable but operations api validation fails it.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-569