### PR TITLE
[CLD-568]: fix: migrate update node from CLD

### DIFF
--- a/.changeset/sour-windows-begin.md
+++ b/.changeset/sour-windows-begin.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+fix: migrate Update Node from CLD

--- a/engine/cld/offchain/node_key.go
+++ b/engine/cld/offchain/node_key.go
@@ -1,0 +1,11 @@
+package offchain
+
+// NodeKey is the key type to use to find a node
+type NodeKey string
+
+const (
+	NodeKey_ID     NodeKey = "id"
+	NodeKey_CSAKey NodeKey = "csa_key"
+	NodeKey_Name   NodeKey = "name"
+	NodeKey_Label  NodeKey = "label"
+)

--- a/engine/cld/offchain/update_node.go
+++ b/engine/cld/offchain/update_node.go
@@ -1,0 +1,205 @@
+package offchain
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
+
+	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/offchain/node"
+
+	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
+)
+
+// UpdateNodeRequest is the request to update a node using JD
+type UpdateNodeRequest struct {
+	// Cfg is the configuration for the used to update node
+	Cfg node.NodeCfg
+	// keyCfg is the configuration for how to find the node to update
+	keyCfg nodeKeyCfg
+}
+
+// NodeFinderCfg is the configuration for how to find the node to update
+type NodeFinderCfg struct {
+	KeyType   NodeKey // type of key to search for
+	LabelName *string // name of label to search for when using NodeKey_Label
+}
+
+func (c NodeFinderCfg) Validate() error {
+	if c.KeyType == NodeKey_Label && c.LabelName == nil {
+		return errors.New("label name is required for label search")
+	}
+
+	return nil
+}
+
+// NewUpdateNodeRequest creates a new UpdateNodeRequest
+func NewUpdateNodeRequest(cfg node.NodeCfg, f NodeFinderCfg) (*UpdateNodeRequest, error) {
+	if err := f.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid node finder config: %w", err)
+	}
+	kc, err := newNodeKeyCfg(cfg, f)
+	if err != nil {
+		return nil, err
+	}
+
+	return &UpdateNodeRequest{
+		Cfg:    cfg,
+		keyCfg: kc,
+	}, nil
+}
+
+// Labels returns the labels for the node, containing the p2p_id, nop, admin_addr and all tags.
+func (r *UpdateNodeRequest) Labels() []*ptypes.Label {
+	raw := r.Cfg.Labels()
+
+	out := make([]*ptypes.Label, 0, len(raw))
+	for k, v := range raw {
+		out = append(out, &ptypes.Label{
+			Key:   k,
+			Value: &v,
+		})
+	}
+
+	return out
+}
+
+// NodeKeyCriteria returns the node key criteria
+func (r *UpdateNodeRequest) NodeKeyCriteria() string {
+	return r.keyCfg.String()
+}
+
+// UpdateNodesRequest is the request to update multiple nodes using JD
+type UpdateNodesRequest struct {
+	Requests []*UpdateNodeRequest
+}
+
+// UpdateNodes updates the nodes with the given configurations.
+func UpdateNodes(ctx context.Context, client cldf_offchain.Client, req UpdateNodesRequest) error {
+	if len(req.Requests) == 0 {
+		return nil
+	}
+	resp, err := client.ListNodes(ctx, &nodev1.ListNodesRequest{})
+	if err != nil {
+		return err
+	}
+	for _, r := range req.Requests {
+		node, err := getNode(resp, r.keyCfg.keyType, r.keyCfg.value, r.keyCfg.labelKey)
+		if err != nil {
+			return fmt.Errorf("failed to get node %s with value %s (label=%v): %w", r.
+				keyCfg.keyType, r.keyCfg.value, r.keyCfg.labelKey, err)
+		}
+		_, err = client.UpdateNode(ctx, &nodev1.UpdateNodeRequest{
+			Id:        node.GetId(),
+			Name:      r.Cfg.Name,
+			PublicKey: r.Cfg.CSAKey,
+			Labels:    r.Labels(),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update node %s name %s csakey %s: %w", node.GetId(), r.Cfg.Name, r.Cfg.CSAKey, err)
+		}
+	}
+
+	return nil
+}
+
+// getNode gets a node from the list of nodes based on the key type and key value.
+// the key is only used for label searches and it is required for label searches.
+func getNode(resp *nodev1.ListNodesResponse, keyType NodeKey, value string, labelKey *string) (*nodev1.Node, error) {
+	switch keyType {
+	case NodeKey_ID:
+		return getNodeByID(resp, value)
+	case NodeKey_CSAKey:
+		return getNodeByCSAKey(resp, value)
+	case NodeKey_Name:
+		return getNodeByName(resp, value)
+	case NodeKey_Label:
+		if labelKey == nil {
+			return nil, errors.New("no key provided for label search")
+		}
+
+		return getNodeByLabel(resp, *labelKey, value)
+	default:
+		return nil, fmt.Errorf("unknown key type %s", keyType)
+	}
+}
+
+func getNodeByID(resp *nodev1.ListNodesResponse, id string) (*nodev1.Node, error) {
+	for _, node := range resp.GetNodes() {
+		if node.GetId() == id {
+			return node, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no node with id %s found", id)
+}
+
+func getNodeByCSAKey(resp *nodev1.ListNodesResponse, csaKey string) (*nodev1.Node, error) {
+	for _, node := range resp.GetNodes() {
+		if node.GetPublicKey() == csaKey {
+			return node, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no node with csa key %s found", csaKey)
+}
+
+func getNodeByName(resp *nodev1.ListNodesResponse, name string) (*nodev1.Node, error) {
+	for _, node := range resp.GetNodes() {
+		if node.GetName() == name {
+			return node, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no node with name %s found", name)
+}
+
+func getNodeByLabel(resp *nodev1.ListNodesResponse, key, value string) (*nodev1.Node, error) {
+	for _, node := range resp.GetNodes() {
+		for _, label := range node.GetLabels() {
+			if label.GetKey() == key && label.GetValue() == value {
+				return node, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no node with label %s=%s found", key, value)
+}
+
+type nodeKeyCfg struct {
+	keyType  NodeKey // type of key to search for
+	value    string  // value to search for
+	labelKey *string // key to search for in labels when using NodeKey_Label
+}
+
+func (c nodeKeyCfg) String() string {
+	v := c.value
+	if c.labelKey != nil {
+		v = fmt.Sprintf("%s=%s", *c.labelKey, c.value)
+	}
+
+	return fmt.Sprintf("key-type=%s, value=%s", c.keyType, v)
+}
+
+func newNodeKeyCfg(n node.NodeCfg, c NodeFinderCfg) (nodeKeyCfg, error) {
+	out := nodeKeyCfg{
+		keyType: c.KeyType,
+	}
+	switch c.KeyType {
+	case NodeKey_CSAKey:
+		out.value = n.CSAKey
+	case NodeKey_Name:
+		out.value = n.Name
+	case NodeKey_Label:
+		out.value = n.Labels()[*c.LabelName]
+		out.labelKey = c.LabelName
+	case NodeKey_ID:
+		return nodeKeyCfg{}, errors.New("id key type is not supported")
+	default:
+		return nodeKeyCfg{}, fmt.Errorf("unknown key type %s", c.KeyType)
+	}
+
+	return out, nil
+}

--- a/engine/cld/offchain/update_node_test.go
+++ b/engine/cld/offchain/update_node_test.go
@@ -1,0 +1,793 @@
+package offchain
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	nodev1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/node"
+	"github.com/smartcontractkit/chainlink-protos/job-distributor/v1/shared/ptypes"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/internal/pointer"
+	"github.com/smartcontractkit/chainlink-deployments-framework/internal/testing/jd/mocks"
+	"github.com/smartcontractkit/chainlink-deployments-framework/offchain/node"
+)
+
+func TestGetNode(t *testing.T) {
+	t.Parallel()
+
+	var (
+		node1 = &nodev1.Node{
+			Id:        "1",
+			Name:      "node1",
+			PublicKey: "csa_key1",
+			Labels: plabels(map[string]string{
+				"p2p_id": "p2p_id1",
+			}),
+		}
+		node2 = &nodev1.Node{
+			Id:        "2",
+			Name:      "node2",
+			PublicKey: "csa_key2",
+			Labels: plabels(map[string]string{
+				"p2p_id": "p2p_id2",
+			}),
+		}
+		resp = &nodev1.ListNodesResponse{
+			Nodes: []*nodev1.Node{
+				node1, node2,
+			},
+		}
+	)
+	type args struct {
+		resp    *nodev1.ListNodesResponse
+		keyType NodeKey
+		key     *string
+		value   string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *nodev1.Node
+		wantErr bool
+	}{
+		{
+			name: "id",
+			args: args{
+				resp:    resp,
+				keyType: NodeKey_ID,
+				value:   "1",
+			},
+			want: node1,
+		},
+		{
+			name: "non existent id",
+			args: args{
+				resp:    resp,
+				keyType: NodeKey_ID,
+				value:   "not_an_id",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "name",
+			args: args{
+				resp:    resp,
+				keyType: NodeKey_Name,
+				value:   "node2",
+			},
+			want: node2,
+		},
+		{
+			name: "non existent name",
+			args: args{
+				resp:    resp,
+				keyType: NodeKey_Name,
+				value:   "not_a_name",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+
+		{
+			name: "csa key",
+			args: args{
+				resp:    resp,
+				keyType: NodeKey_CSAKey,
+				value:   "csa_key1",
+			},
+			want: node1,
+		},
+		{
+			name: "non existent csa key",
+			args: args{
+				resp:    resp,
+				keyType: NodeKey_CSAKey,
+				value:   "not_a_csa_key",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "p2p id label",
+			args: args{
+				resp:    resp,
+				keyType: NodeKey_Label,
+				key:     pointer.To("p2p_id"),
+				value:   "p2p_id2",
+			},
+			want: node2,
+		},
+		{
+			name: "missing label",
+			args: args{
+				resp:    resp,
+				keyType: NodeKey_Label,
+				key:     pointer.To("not_a_label"),
+				value:   "foo",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "label with wrong value",
+			args: args{
+				resp:    resp,
+				keyType: NodeKey_Label,
+				key:     pointer.To("p2p_id"),
+				value:   "not_a_p2p_id",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := getNode(tt.args.resp, tt.args.keyType, tt.args.value, tt.args.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetNode() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetNode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func plabels(m map[string]string) []*ptypes.Label {
+	labels := make([]*ptypes.Label, 0, len(m))
+	for k, v := range m {
+		labels = append(labels, &ptypes.Label{
+			Key:   k,
+			Value: &v,
+		})
+	}
+
+	return labels
+}
+
+func TestNodeFinderCfg_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     NodeFinderCfg
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid id key type",
+			cfg: NodeFinderCfg{
+				KeyType: NodeKey_ID,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid label key type with label name",
+			cfg: NodeFinderCfg{
+				KeyType:   NodeKey_Label,
+				LabelName: pointer.To("p2p_id"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid label key type without label name",
+			cfg: NodeFinderCfg{
+				KeyType:   NodeKey_Label,
+				LabelName: nil,
+			},
+			wantErr: true,
+			errMsg:  "label name is required for label search",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNewUpdateNodeRequest(t *testing.T) {
+	t.Parallel()
+
+	validNodeCfg := node.NodeCfg{
+		MinimalNodeCfg: node.MinimalNodeCfg{
+			Name:                "test-node",
+			CSAKey:              "test-csa-key",
+			NOP:                 "test-nop",
+			EncryptionPublicKey: "test-encryption-key",
+		},
+		P2PID:     "test-p2p-id",
+		AdminAddr: "0x1234567890123456789012345678901234567890",
+		Tags: map[string]string{
+			"region": "us-east-1",
+			"env":    "test",
+		},
+	}
+
+	tests := []struct {
+		name        string
+		cfg         node.NodeCfg
+		finderCfg   NodeFinderCfg
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid request with name key type",
+			cfg:  validNodeCfg,
+			finderCfg: NodeFinderCfg{
+				KeyType: NodeKey_Name,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid request with csa key type",
+			cfg:  validNodeCfg,
+			finderCfg: NodeFinderCfg{
+				KeyType: NodeKey_CSAKey,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid request with label key type",
+			cfg:  validNodeCfg,
+			finderCfg: NodeFinderCfg{
+				KeyType:   NodeKey_Label,
+				LabelName: pointer.To("region"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid finder config - label without label name",
+			cfg:  validNodeCfg,
+			finderCfg: NodeFinderCfg{
+				KeyType:   NodeKey_Label,
+				LabelName: nil,
+			},
+			wantErr:     true,
+			errContains: "invalid node finder config",
+		},
+		{
+			name: "invalid finder config - id key type",
+			cfg:  validNodeCfg,
+			finderCfg: NodeFinderCfg{
+				KeyType: NodeKey_ID,
+			},
+			wantErr:     true,
+			errContains: "id key type is not supported",
+		},
+		{
+			name: "valid request with nonexistent label - gets empty value",
+			cfg:  validNodeCfg,
+			finderCfg: NodeFinderCfg{
+				KeyType:   NodeKey_Label,
+				LabelName: pointer.To("nonexistent"),
+			},
+			wantErr: false, // This doesn't error, it just gets empty string
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := NewUpdateNodeRequest(tt.cfg, tt.finderCfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				assert.Nil(t, req)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, req)
+				assert.Equal(t, tt.cfg, req.Cfg)
+			}
+		})
+	}
+}
+
+func TestUpdateNodeRequest_Labels(t *testing.T) {
+	t.Parallel()
+
+	nodeCfg := node.NodeCfg{
+		MinimalNodeCfg: node.MinimalNodeCfg{
+			Name:                "test-node",
+			CSAKey:              "test-csa-key",
+			NOP:                 "Test NOP",
+			EncryptionPublicKey: "test-encryption-key",
+		},
+		P2PID:        "test-p2p-id",
+		AdminAddr:    "0x1234567890123456789012345678901234567890",
+		MultiAddress: pointer.To("127.0.0.1:8080"),
+		Tags: map[string]string{
+			"region": "us-east-1",
+			"env":    "test",
+		},
+	}
+
+	req, err := NewUpdateNodeRequest(nodeCfg, NodeFinderCfg{KeyType: NodeKey_Name})
+	require.NoError(t, err)
+
+	labels := req.Labels()
+
+	// Convert to map for easier testing
+	labelMap := make(map[string]string)
+	for _, label := range labels {
+		labelMap[label.Key] = *label.Value
+	}
+
+	expectedLabels := map[string]string{
+		"p2p_id":        "test-p2p-id",
+		"nop":           "Test_NOP", // spaces replaced with underscores
+		"admin_addr":    "0x1234567890123456789012345678901234567890",
+		"multi_address": "127.0.0.1:8080",
+		"region":        "us-east-1",
+		"env":           "test",
+	}
+
+	assert.Equal(t, expectedLabels, labelMap)
+}
+
+func TestUpdateNodeRequest_NodeKeyCriteria(t *testing.T) {
+	t.Parallel()
+
+	nodeCfg := node.NodeCfg{
+		MinimalNodeCfg: node.MinimalNodeCfg{
+			Name:   "test-node",
+			CSAKey: "test-csa-key",
+		},
+		Tags: map[string]string{
+			"region": "us-east-1",
+		},
+	}
+
+	tests := []struct {
+		name             string
+		finderCfg        NodeFinderCfg
+		expectedCriteria string
+	}{
+		{
+			name: "name key type",
+			finderCfg: NodeFinderCfg{
+				KeyType: NodeKey_Name,
+			},
+			expectedCriteria: "key-type=name, value=test-node",
+		},
+		{
+			name: "csa key type",
+			finderCfg: NodeFinderCfg{
+				KeyType: NodeKey_CSAKey,
+			},
+			expectedCriteria: "key-type=csa_key, value=test-csa-key",
+		},
+		{
+			name: "label key type",
+			finderCfg: NodeFinderCfg{
+				KeyType:   NodeKey_Label,
+				LabelName: pointer.To("region"),
+			},
+			expectedCriteria: "key-type=label, value=region=us-east-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := NewUpdateNodeRequest(nodeCfg, tt.finderCfg)
+			require.NoError(t, err)
+
+			criteria := req.NodeKeyCriteria()
+			assert.Equal(t, tt.expectedCriteria, criteria)
+		})
+	}
+}
+
+func TestUpdateNodes_Success(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	mockClient := mocks.NewMockJDClient(t)
+
+	// Create test nodes
+	existingNodes := []*nodev1.Node{
+		{
+			Id:        "node-1",
+			Name:      "old-name-1",
+			PublicKey: "csa-key-1",
+			Labels: plabels(map[string]string{
+				"p2p_id": "p2p-1",
+				"region": "us-east-1",
+			}),
+		},
+		{
+			Id:        "node-2",
+			Name:      "old-name-2",
+			PublicKey: "csa-key-2",
+			Labels: plabels(map[string]string{
+				"p2p_id": "p2p-2",
+				"region": "us-west-1",
+			}),
+		},
+	}
+
+	listResponse := &nodev1.ListNodesResponse{
+		Nodes: existingNodes,
+	}
+
+	// Create update requests
+	req1, err := NewUpdateNodeRequest(node.NodeCfg{
+		MinimalNodeCfg: node.MinimalNodeCfg{
+			Name:   "new-name-1",
+			CSAKey: "csa-key-1",
+			NOP:    "nop-1",
+		},
+		P2PID:     "p2p-1",
+		AdminAddr: "0x1111111111111111111111111111111111111111",
+	}, NodeFinderCfg{KeyType: NodeKey_CSAKey})
+	require.NoError(t, err)
+
+	req2, err := NewUpdateNodeRequest(node.NodeCfg{
+		MinimalNodeCfg: node.MinimalNodeCfg{
+			Name:   "new-name-2",
+			CSAKey: "csa-key-2",
+			NOP:    "nop-2",
+		},
+		P2PID:     "p2p-2",
+		AdminAddr: "0x2222222222222222222222222222222222222222",
+	}, NodeFinderCfg{KeyType: NodeKey_CSAKey})
+	require.NoError(t, err)
+
+	updateReq := UpdateNodesRequest{
+		Requests: []*UpdateNodeRequest{req1, req2},
+	}
+
+	// Mock ListNodes call
+	mockClient.MockNodeServiceClient.On("ListNodes", ctx, &nodev1.ListNodesRequest{}).Return(listResponse, nil)
+
+	// Mock UpdateNode calls
+	mockClient.MockNodeServiceClient.On("UpdateNode", ctx, mock.MatchedBy(func(req *nodev1.UpdateNodeRequest) bool {
+		return req.Id == "node-1" && req.Name == "new-name-1" && req.PublicKey == "csa-key-1"
+	})).Return(&nodev1.UpdateNodeResponse{}, nil)
+
+	mockClient.MockNodeServiceClient.On("UpdateNode", ctx, mock.MatchedBy(func(req *nodev1.UpdateNodeRequest) bool {
+		return req.Id == "node-2" && req.Name == "new-name-2" && req.PublicKey == "csa-key-2"
+	})).Return(&nodev1.UpdateNodeResponse{}, nil)
+
+	err = UpdateNodes(ctx, mockClient, updateReq)
+	require.NoError(t, err)
+
+	mockClient.MockNodeServiceClient.AssertExpectations(t)
+}
+
+func TestUpdateNodes_EmptyRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	mockClient := mocks.NewMockJDClient(t)
+
+	updateReq := UpdateNodesRequest{
+		Requests: []*UpdateNodeRequest{},
+	}
+
+	err := UpdateNodes(ctx, mockClient, updateReq)
+	require.NoError(t, err)
+
+	// No calls should be made
+	mockClient.MockNodeServiceClient.AssertExpectations(t)
+}
+
+func TestUpdateNodes_ListNodesError(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	mockClient := mocks.NewMockJDClient(t)
+
+	req, err := NewUpdateNodeRequest(node.NodeCfg{
+		MinimalNodeCfg: node.MinimalNodeCfg{
+			Name:   "test-node",
+			CSAKey: "test-csa-key",
+			NOP:    "test-nop",
+		},
+		P2PID:     "test-p2p",
+		AdminAddr: "0x1111111111111111111111111111111111111111",
+	}, NodeFinderCfg{KeyType: NodeKey_Name})
+	require.NoError(t, err)
+
+	updateReq := UpdateNodesRequest{
+		Requests: []*UpdateNodeRequest{req},
+	}
+
+	// Mock ListNodes error
+	expectedError := errors.New("failed to list nodes")
+	mockClient.MockNodeServiceClient.On("ListNodes", ctx, &nodev1.ListNodesRequest{}).Return(nil, expectedError)
+
+	err = UpdateNodes(ctx, mockClient, updateReq)
+	require.Error(t, err)
+	assert.Equal(t, expectedError, err)
+
+	mockClient.MockNodeServiceClient.AssertExpectations(t)
+}
+
+func TestUpdateNodes_NodeNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	mockClient := mocks.NewMockJDClient(t)
+
+	listResponse := &nodev1.ListNodesResponse{
+		Nodes: []*nodev1.Node{
+			{
+				Id:        "node-1",
+				Name:      "existing-node",
+				PublicKey: "existing-csa-key",
+			},
+		},
+	}
+
+	req, err := NewUpdateNodeRequest(node.NodeCfg{
+		MinimalNodeCfg: node.MinimalNodeCfg{
+			Name:   "nonexistent-node",
+			CSAKey: "nonexistent-csa-key",
+			NOP:    "test-nop",
+		},
+		P2PID:     "test-p2p",
+		AdminAddr: "0x1111111111111111111111111111111111111111",
+	}, NodeFinderCfg{KeyType: NodeKey_Name})
+	require.NoError(t, err)
+
+	updateReq := UpdateNodesRequest{
+		Requests: []*UpdateNodeRequest{req},
+	}
+
+	// Mock ListNodes call
+	mockClient.MockNodeServiceClient.On("ListNodes", ctx, &nodev1.ListNodesRequest{}).Return(listResponse, nil)
+
+	err = UpdateNodes(ctx, mockClient, updateReq)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get node")
+	assert.Contains(t, err.Error(), "nonexistent-node")
+
+	mockClient.MockNodeServiceClient.AssertExpectations(t)
+}
+
+func TestUpdateNodes_UpdateNodeError(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	mockClient := mocks.NewMockJDClient(t)
+
+	existingNodes := []*nodev1.Node{
+		{
+			Id:        "node-1",
+			Name:      "test-node",
+			PublicKey: "test-csa-key",
+		},
+	}
+
+	listResponse := &nodev1.ListNodesResponse{
+		Nodes: existingNodes,
+	}
+
+	req, err := NewUpdateNodeRequest(node.NodeCfg{
+		MinimalNodeCfg: node.MinimalNodeCfg{
+			Name:   "test-node",
+			CSAKey: "test-csa-key",
+			NOP:    "test-nop",
+		},
+		P2PID:     "test-p2p",
+		AdminAddr: "0x1111111111111111111111111111111111111111",
+	}, NodeFinderCfg{KeyType: NodeKey_Name})
+	require.NoError(t, err)
+
+	updateReq := UpdateNodesRequest{
+		Requests: []*UpdateNodeRequest{req},
+	}
+
+	// Mock ListNodes call
+	mockClient.MockNodeServiceClient.On("ListNodes", ctx, &nodev1.ListNodesRequest{}).Return(listResponse, nil)
+
+	// Mock UpdateNode error
+	updateError := errors.New("failed to update node")
+	mockClient.MockNodeServiceClient.On("UpdateNode", ctx, mock.AnythingOfType("*node.UpdateNodeRequest")).Return(nil, updateError)
+
+	err = UpdateNodes(ctx, mockClient, updateReq)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to update node")
+	assert.Contains(t, err.Error(), "node-1")
+
+	mockClient.MockNodeServiceClient.AssertExpectations(t)
+}
+
+func TestNewNodeKeyCfg(t *testing.T) {
+	t.Parallel()
+
+	nodeCfg := node.NodeCfg{
+		MinimalNodeCfg: node.MinimalNodeCfg{
+			Name:   "test-node",
+			CSAKey: "test-csa-key",
+		},
+		Tags: map[string]string{
+			"region": "us-east-1",
+			"env":    "test",
+		},
+	}
+
+	tests := []struct {
+		name        string
+		finderCfg   NodeFinderCfg
+		want        nodeKeyCfg
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "name key type",
+			finderCfg: NodeFinderCfg{
+				KeyType: NodeKey_Name,
+			},
+			want: nodeKeyCfg{
+				keyType: NodeKey_Name,
+				value:   "test-node",
+			},
+			wantErr: false,
+		},
+		{
+			name: "csa key type",
+			finderCfg: NodeFinderCfg{
+				KeyType: NodeKey_CSAKey,
+			},
+			want: nodeKeyCfg{
+				keyType: NodeKey_CSAKey,
+				value:   "test-csa-key",
+			},
+			wantErr: false,
+		},
+		{
+			name: "label key type",
+			finderCfg: NodeFinderCfg{
+				KeyType:   NodeKey_Label,
+				LabelName: pointer.To("region"),
+			},
+			want: nodeKeyCfg{
+				keyType:  NodeKey_Label,
+				value:    "us-east-1",
+				labelKey: pointer.To("region"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "label key type with nonexistent label",
+			finderCfg: NodeFinderCfg{
+				KeyType:   NodeKey_Label,
+				LabelName: pointer.To("nonexistent"),
+			},
+			want: nodeKeyCfg{
+				keyType:  NodeKey_Label,
+				value:    "", // empty string for nonexistent label
+				labelKey: pointer.To("nonexistent"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "id key type - not supported",
+			finderCfg: NodeFinderCfg{
+				KeyType: NodeKey_ID,
+			},
+			wantErr:     true,
+			errContains: "id key type is not supported",
+		},
+		{
+			name: "unknown key type",
+			finderCfg: NodeFinderCfg{
+				KeyType: "unknown",
+			},
+			wantErr:     true,
+			errContains: "unknown key type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := newNodeKeyCfg(nodeCfg, tt.finderCfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestNodeKeyCfg_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  nodeKeyCfg
+		want string
+	}{
+		{
+			name: "name key type",
+			cfg: nodeKeyCfg{
+				keyType: NodeKey_Name,
+				value:   "test-node",
+			},
+			want: "key-type=name, value=test-node",
+		},
+		{
+			name: "csa key type",
+			cfg: nodeKeyCfg{
+				keyType: NodeKey_CSAKey,
+				value:   "test-csa-key",
+			},
+			want: "key-type=csa_key, value=test-csa-key",
+		},
+		{
+			name: "label key type",
+			cfg: nodeKeyCfg{
+				keyType:  NodeKey_Label,
+				value:    "us-east-1",
+				labelKey: pointer.To("region"),
+			},
+			want: "key-type=label, value=region=us-east-1",
+		},
+		{
+			name: "label key type with empty value",
+			cfg: nodeKeyCfg{
+				keyType:  NodeKey_Label,
+				value:    "",
+				labelKey: pointer.To("nonexistent"),
+			},
+			want: "key-type=label, value=nonexistent=",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.cfg.String()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/offchain/internal/p2pkey/peer_id.go
+++ b/offchain/internal/p2pkey/peer_id.go
@@ -1,0 +1,87 @@
+// Package p2pkey contains code adapted from the Chainlink core node with minor modifications.
+// These changes allow us to avoid a direct dependency on the Chainlink core node.
+//
+// https://github.com/smartcontractkit/chainlink/blob/develop/core/services/keystore/keys/p2pkey/peer_id.go
+//
+// Modifications include:
+// - Retained only the functionality for marshaling and unmarshaling PeerID strings.
+// - Updated error handling to use the standard library `errors` package.
+// - Updates to pass linting and formatting checks.
+package p2pkey
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/smartcontractkit/libocr/ragep2p/types"
+)
+
+const peerIDPrefix = "p2p_"
+
+type PeerID types.PeerID
+
+// MakePeerID creates a PeerID from a string. It returns an error if the string
+// cannot be parsed as a PeerID.
+func MakePeerID(s string) (PeerID, error) {
+	var peerID PeerID
+
+	return peerID, peerID.UnmarshalString(s)
+}
+
+// PeerID returns the string representation of the PeerID. It is prefixed with
+// "p2p_" to indicate that it is a PeerID. If the PeerID is zero, it returns an
+// empty string.
+func (p PeerID) String() string {
+	// Handle a zero peerID more gracefully, i.e. print it as empty string rather
+	// than `p2p_`
+	if p == (PeerID{}) {
+		return ""
+	}
+
+	return fmt.Sprintf("%s%s", peerIDPrefix, p.Raw())
+}
+
+// Raw returns the raw string representation of the PeerID without the
+// "p2p_" prefix.
+func (p PeerID) Raw() string {
+	return types.PeerID(p).String()
+}
+
+// UnmarshalString unmarshals a string into a PeerID.
+func (p *PeerID) UnmarshalString(s string) error {
+	return p.UnmarshalText([]byte(s))
+}
+
+// MarshalText marshals the PeerID into a byte slice. If the PeerID is zero, it
+// returns nil.
+func (p *PeerID) MarshalText() ([]byte, error) {
+	if *p == (PeerID{}) {
+		return nil, nil
+	}
+
+	return []byte(p.Raw()), nil
+}
+
+// UnmarshalText unmarshals a byte slice into a PeerID. It expects the byte
+// slice to be a string representation of a PeerID. If the byte slice is empty,
+// it returns nil. If the byte slice has the "p2p_" prefix, it removes it before
+// unmarshaling. If the unmarshaling fails, it returns an error.
+func (p *PeerID) UnmarshalText(bs []byte) error {
+	input := string(bs)
+	if strings.HasPrefix(input, peerIDPrefix) {
+		input = string(bs[len(peerIDPrefix):])
+	}
+
+	if input == "" {
+		return nil
+	}
+
+	var peerID types.PeerID
+	err := peerID.UnmarshalText([]byte(input))
+	if err != nil {
+		return fmt.Errorf(`PeerID#UnmarshalText("%v"): %w`, input, err)
+	}
+	*p = PeerID(peerID)
+
+	return nil
+}

--- a/offchain/internal/p2pkey/peer_id_test.go
+++ b/offchain/internal/p2pkey/peer_id_test.go
@@ -1,0 +1,220 @@
+package p2pkey
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	peerIDStr           = "12D3KooWM1111111111111111111111111111111111111111111"
+	peerIDWithPrefixStr = "p2p_12D3KooWM1111111111111111111111111111111111111111111"
+)
+
+func Test_MakePeerID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid peerID",
+			give: peerIDStr,
+			want: peerIDWithPrefixStr,
+		},
+		{
+			name:    "invalid peerID",
+			give:    "invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			id, err := MakePeerID(tt.give)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, id.String())
+			}
+		})
+	}
+}
+
+func Test_PeerID_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid peerID",
+			give: peerIDStr,
+			want: peerIDWithPrefixStr,
+		},
+		{
+			name: "empty peerID",
+			give: "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			id, err := MakePeerID(tt.give)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, id.String())
+			}
+		})
+	}
+}
+
+func Test_PeerID_Raw(t *testing.T) {
+	t.Parallel()
+
+	id, err := MakePeerID(peerIDStr)
+	require.NoError(t, err)
+	assert.Equal(t, peerIDStr, id.Raw())
+}
+
+func Test_PeerID_UnmarshalString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid peerID",
+			give: peerIDStr,
+			want: peerIDWithPrefixStr,
+		},
+		{
+			name:    "invalid peerID",
+			give:    "invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			id := PeerID{}
+			err := id.UnmarshalString(tt.give)
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, id.String())
+			}
+		})
+	}
+}
+
+func Test_PeerID_MarshalText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		give string
+		want []byte
+	}{
+		{
+			name: "valid peerID with prefix",
+			give: peerIDWithPrefixStr,
+			want: []byte(peerIDStr),
+		},
+		{
+			name: "valid peerID without prefix",
+			give: peerIDStr,
+			want: []byte(peerIDStr),
+		},
+		{
+			name: "empty peerID",
+			give: "",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			id, err := MakePeerID(tt.give)
+			require.NoError(t, err)
+
+			b, err := id.MarshalText()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, b)
+		})
+	}
+}
+
+func Test_PeerID_UnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid peerID with prefix",
+			give: peerIDWithPrefixStr,
+			want: peerIDWithPrefixStr,
+		},
+		{
+			name: "valid peerID without prefix",
+			give: peerIDStr,
+			want: peerIDWithPrefixStr,
+		},
+		{
+			name: "empty peerID",
+			give: "",
+			want: "",
+		},
+		{
+			name:    "invalid peerID",
+			give:    "invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := PeerID{}
+			err := got.UnmarshalText([]byte(tt.give))
+
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got.String())
+			}
+		})
+	}
+}

--- a/offchain/node/config.go
+++ b/offchain/node/config.go
@@ -1,0 +1,81 @@
+package node
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/offchain/internal/p2pkey"
+)
+
+// MinimalNodeCfg is the minimal configuration that can be used to identify a node.
+// It represents information that cannot be programmatically derived from Job Distributor.
+type MinimalNodeCfg struct {
+	Name                string `json:"name" toml:"name" yaml:"name"`
+	CSAKey              string `json:"csa_key" toml:"csa_key" yaml:"csa_key"`
+	NOP                 string `json:"nop" toml:"nop" yaml:"nop"`
+	EncryptionPublicKey string `json:"encryption_public_key" toml:"encryption_public_key" yaml:"encryption_public_key"`
+}
+
+// NodeCfg is the configuration for a node.
+// It is used to register a node with the job distributor and contains only public information, no secrets or api keys.
+type NodeCfg struct {
+	MinimalNodeCfg
+	P2PID string `json:"p2p_id" toml:"p2p_id" yaml:"p2p_id"`
+
+	AdminAddr    string            `json:"admin_addr" toml:"admin_addr" yaml:"admin_addr"`
+	MultiAddress *string           `json:"multi_address,omitempty" toml:"multi_address,omitempty" yaml:"multi_address,omitempty"` // needed only for bootstrap nodes, bootstrap IP:P2P PORT
+	Tags         map[string]string `json:"tags,omitempty" toml:"tags,omitempty" yaml:"tags,omitempty"`
+}
+
+func (n NodeCfg) Validate() error {
+	if n.Name == "" {
+		return errors.New("no name in node")
+	}
+	if n.CSAKey == "" {
+		return errors.New("no CSAKey in node")
+	}
+	if n.P2PID == "" {
+		return errors.New("no P2PID in node")
+	}
+	_, err := p2pkey.MakePeerID(n.P2PID)
+	if err != nil {
+		return fmt.Errorf("invalid P2PID '%s' in node: %w", n.P2PID, err)
+	}
+	if n.NOP == "" {
+		return errors.New("no Nop in node")
+	}
+	if n.AdminAddr == "" {
+		return errors.New("no AdminAddr in node")
+	}
+	var a = new(common.Address)
+	err = a.UnmarshalText([]byte(n.AdminAddr))
+	if err != nil {
+		return fmt.Errorf("invalid AdminAddr '%s' in node: %w", n.AdminAddr, err)
+	}
+
+	return nil
+}
+
+// Labels returns the labels for the node, containing the p2p_id, nop, admin_addr and all tags.
+func (n NodeCfg) Labels() map[string]string {
+	m := map[string]string{
+		"p2p_id":     n.P2PID,
+		"nop":        strings.ReplaceAll(n.NOP, " ", "_"),
+		"admin_addr": n.AdminAddr,
+	}
+	for k, v := range n.Tags {
+		m[k] = v
+	}
+	if n.MultiAddress != nil {
+		m["multi_address"] = *n.MultiAddress
+	}
+
+	return m
+}
+
+func (n NodeCfg) IsBootstrap() bool {
+	return n.MultiAddress != nil
+}

--- a/offchain/node/config_test.go
+++ b/offchain/node/config_test.go
@@ -1,0 +1,247 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/internal/pointer"
+)
+
+const (
+	validP2PID     = "12D3KooWM1111111111111111111111111111111111111111111"
+	validCSAKey    = "csa_key_123"
+	validAdminAddr = "0x1234567890123456789012345678901234567890"
+	validNOP       = "Test NOP"
+	validName      = "test-node"
+	validEncKey    = "encryption_key_123"
+)
+
+func TestNodeCfg_Validate_Success(t *testing.T) {
+	t.Parallel()
+
+	cfg := NodeCfg{
+		MinimalNodeCfg: MinimalNodeCfg{
+			Name:                validName,
+			CSAKey:              validCSAKey,
+			NOP:                 validNOP,
+			EncryptionPublicKey: validEncKey,
+		},
+		P2PID:     validP2PID,
+		AdminAddr: validAdminAddr,
+	}
+
+	err := cfg.Validate()
+	require.NoError(t, err)
+}
+
+func TestNodeCfg_Validate_Failures(t *testing.T) {
+	t.Parallel()
+
+	baseConfig := NodeCfg{
+		MinimalNodeCfg: MinimalNodeCfg{
+			Name:                validName,
+			CSAKey:              validCSAKey,
+			NOP:                 validNOP,
+			EncryptionPublicKey: validEncKey,
+		},
+		P2PID:     validP2PID,
+		AdminAddr: validAdminAddr,
+	}
+
+	tests := []struct {
+		name      string
+		modifyFn  func(*NodeCfg)
+		wantError string
+	}{
+		{
+			name: "empty name",
+			modifyFn: func(cfg *NodeCfg) {
+				cfg.Name = ""
+			},
+			wantError: "no name in node",
+		},
+		{
+			name: "empty CSAKey",
+			modifyFn: func(cfg *NodeCfg) {
+				cfg.CSAKey = ""
+			},
+			wantError: "no CSAKey in node",
+		},
+		{
+			name: "empty P2PID",
+			modifyFn: func(cfg *NodeCfg) {
+				cfg.P2PID = ""
+			},
+			wantError: "no P2PID in node",
+		},
+		{
+			name: "invalid P2PID",
+			modifyFn: func(cfg *NodeCfg) {
+				cfg.P2PID = "invalid_p2p_id"
+			},
+			wantError: "invalid P2PID 'invalid_p2p_id' in node",
+		},
+		{
+			name: "empty NOP",
+			modifyFn: func(cfg *NodeCfg) {
+				cfg.NOP = ""
+			},
+			wantError: "no Nop in node",
+		},
+		{
+			name: "empty AdminAddr",
+			modifyFn: func(cfg *NodeCfg) {
+				cfg.AdminAddr = ""
+			},
+			wantError: "no AdminAddr in node",
+		},
+		{
+			name: "invalid AdminAddr",
+			modifyFn: func(cfg *NodeCfg) {
+				cfg.AdminAddr = "invalid_address"
+			},
+			wantError: "invalid AdminAddr 'invalid_address' in node",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := baseConfig // copy
+			tt.modifyFn(&cfg)
+
+			err := cfg.Validate()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantError)
+		})
+	}
+}
+
+func TestNodeCfg_Labels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      NodeCfg
+		expected map[string]string
+	}{
+		{
+			name: "basic labels without tags",
+			cfg: NodeCfg{
+				MinimalNodeCfg: MinimalNodeCfg{
+					Name:   validName,
+					CSAKey: validCSAKey,
+					NOP:    validNOP,
+				},
+				P2PID:     validP2PID,
+				AdminAddr: validAdminAddr,
+			},
+			expected: map[string]string{
+				"p2p_id":     validP2PID,
+				"nop":        "Test_NOP", // spaces replaced with underscores
+				"admin_addr": validAdminAddr,
+			},
+		},
+		{
+			name: "labels with tags",
+			cfg: NodeCfg{
+				MinimalNodeCfg: MinimalNodeCfg{
+					Name:   validName,
+					CSAKey: validCSAKey,
+					NOP:    "Test NOP With Spaces",
+				},
+				P2PID:     validP2PID,
+				AdminAddr: validAdminAddr,
+				Tags: map[string]string{
+					"region":      "us-east-1",
+					"environment": "testnet",
+				},
+			},
+			expected: map[string]string{
+				"p2p_id":      validP2PID,
+				"nop":         "Test_NOP_With_Spaces", // spaces replaced with underscores
+				"admin_addr":  validAdminAddr,
+				"region":      "us-east-1",
+				"environment": "testnet",
+			},
+		},
+		{
+			name: "bootstrap node with multi_address",
+			cfg: NodeCfg{
+				MinimalNodeCfg: MinimalNodeCfg{
+					Name:   validName,
+					CSAKey: validCSAKey,
+					NOP:    validNOP,
+				},
+				P2PID:        validP2PID,
+				AdminAddr:    validAdminAddr,
+				MultiAddress: pointer.To("192.168.1.1:8080"),
+			},
+			expected: map[string]string{
+				"p2p_id":        validP2PID,
+				"nop":           "Test_NOP",
+				"admin_addr":    validAdminAddr,
+				"multi_address": "192.168.1.1:8080",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			labels := tt.cfg.Labels()
+			assert.Equal(t, tt.expected, labels)
+		})
+	}
+}
+
+func TestNodeCfg_IsBootstrap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      NodeCfg
+		expected bool
+	}{
+		{
+			name: "regular node (not bootstrap)",
+			cfg: NodeCfg{
+				MinimalNodeCfg: MinimalNodeCfg{
+					Name:   validName,
+					CSAKey: validCSAKey,
+					NOP:    validNOP,
+				},
+				P2PID:     validP2PID,
+				AdminAddr: validAdminAddr,
+			},
+			expected: false,
+		},
+		{
+			name: "bootstrap node with multi_address",
+			cfg: NodeCfg{
+				MinimalNodeCfg: MinimalNodeCfg{
+					Name:   validName,
+					CSAKey: validCSAKey,
+					NOP:    validNOP,
+				},
+				P2PID:        validP2PID,
+				AdminAddr:    validAdminAddr,
+				MultiAddress: pointer.To("192.168.1.1:8080"),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := tt.cfg.IsBootstrap()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Update Node in CLD requires a few other components.

pkg/offchain/node_cfg.go -> engine/cld/offchain/node_key.go (separated out node key) 
pkg/offchain/node_cfg.go -> offchain/node/config.go (separated out NodeCfg struct) 
pkg/offchain/update_node.go -> engine/cld/offchain/update_node.go 
pkg/lib/p2pkey/peer_id.go -> offchain/internal/p2pkey/peer_id.go

added more tests too

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-568