### PR TITLE
[CLD-586]: feat(engine): migrate loadCatalogStore & loadOffchainClient

### DIFF
--- a/.changeset/eleven-turkeys-attack.md
+++ b/.changeset/eleven-turkeys-attack.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+Migrate LoadCatalogStore and LoadJDClient to engine

--- a/engine/cld/catalog/catalog.go
+++ b/engine/cld/catalog/catalog.go
@@ -1,0 +1,45 @@
+package catalog
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore/catalog/remote"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/domain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/internal"
+)
+
+// LoadCatalog loads a catalog data store for the specified domain and environment.
+func LoadCatalog(ctx context.Context, env string,
+	config *environment.Config, domain domain.Domain) (datastore.CatalogStore, error) {
+	catalogClient, err := loadCatalogClient(ctx, env, config.Env.Catalog.GRPC)
+	if err != nil {
+		return nil, err
+	}
+
+	catalogDataStore := remote.NewCatalogDataStore(remote.CatalogDataStoreConfig{
+		Domain:      domain.Key(),
+		Environment: env,
+		Client:      catalogClient,
+	})
+
+	return catalogDataStore, nil
+}
+
+// loadCatalogClient initializes a Catalogue client using the grpc and gap config.
+func loadCatalogClient(
+	ctx context.Context, env string, url string,
+) (*remote.CatalogClient, error) {
+	creds := internal.GetCredsForEnv(env)
+
+	client, err := remote.NewCatalogClient(ctx, remote.CatalogConfig{
+		GRPC:  url,
+		Creds: creds,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}

--- a/engine/cld/catalog/catalog_test.go
+++ b/engine/cld/catalog/catalog_test.go
@@ -1,0 +1,119 @@
+package catalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore/catalog/remote"
+	config_env "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/config/env"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/domain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/environment"
+)
+
+func TestLoadCatalog(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		env     string
+		config  *environment.Config
+		domain  domain.Domain
+		wantErr string
+	}{
+		{
+			name: "successful catalog loading",
+			env:  "testnet",
+			config: &environment.Config{
+				Env: &config_env.Config{
+					Catalog: config_env.CatalogConfig{
+						GRPC: "localhost:50051",
+					},
+				},
+			},
+			domain: domain.NewDomain("test-root", "test-domain"),
+		},
+		{
+			name: "valid config with different grpc url",
+			env:  "testnet",
+			config: &environment.Config{
+				Env: &config_env.Config{
+					Catalog: config_env.CatalogConfig{
+						GRPC: "grpc.example.com:443",
+					},
+				},
+			},
+			domain: domain.NewDomain("test-root", "test-domain"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+
+			result, err := LoadCatalog(ctx, tt.env, tt.config, tt.domain)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Nil(t, result)
+			} else {
+				// For successful cases, we expect the function to create a catalog store
+				// even if it can't connect to the actual gRPC service
+				require.NoError(t, err)
+				require.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestLoadCatalogClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		env     string
+		url     string
+		wantErr string
+	}{
+		{
+			name: "successful client creation with local env",
+			env:  "local",
+			url:  "localhost:50051",
+		},
+		{
+			name: "successful client creation with non-local env",
+			env:  "testnet",
+			url:  "grpc.example.com:443",
+		},
+		{
+			name: "empty url - should still create client",
+			env:  "testnet",
+			url:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+
+			result, err := loadCatalogClient(ctx, tt.env, tt.url)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Nil(t, result)
+			} else {
+				// For successful cases, we expect a client to be created
+				// even if it can't actually connect to the service
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.IsType(t, &remote.CatalogClient{}, result)
+			}
+		})
+	}
+}

--- a/engine/cld/internal/credentials.go
+++ b/engine/cld/internal/credentials.go
@@ -1,0 +1,21 @@
+package internal
+
+import (
+	"crypto/tls"
+
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/environment"
+)
+
+// GetCredsForEnv returns the appropriate gRPC transport credentials based on the environment.
+func GetCredsForEnv(env string) credentials.TransportCredentials {
+	if env == environment.Local {
+		return insecure.NewCredentials()
+	}
+
+	return credentials.NewTLS(&tls.Config{
+		MinVersion: tls.VersionTLS12,
+	})
+}

--- a/engine/cld/internal/credentials_test.go
+++ b/engine/cld/internal/credentials_test.go
@@ -1,0 +1,74 @@
+package internal
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/environment"
+)
+
+func TestGetCredsForEnv(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		env          string
+		wantInsecure bool
+		wantTLS      bool
+	}{
+		{
+			name:         "local environment returns insecure credentials",
+			env:          environment.Local,
+			wantInsecure: true,
+			wantTLS:      false,
+		},
+		{
+			name:         "empty environment returns TLS credentials",
+			env:          "",
+			wantInsecure: false,
+			wantTLS:      true,
+		},
+		{
+			name:         "non local environment returns TLS credentials",
+			env:          "custom-env",
+			wantInsecure: false,
+			wantTLS:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			creds := GetCredsForEnv(tt.env)
+			require.NotNil(t, creds)
+
+			if tt.wantInsecure {
+				// For insecure credentials, check that it's the insecure type
+				insecureCreds := insecure.NewCredentials()
+				assert.IsType(t, insecureCreds, creds)
+			}
+
+			if tt.wantTLS {
+				// For TLS credentials, verify it's a TLS type and check configuration
+				info := creds.Info()
+				assert.Equal(t, "tls", info.SecurityProtocol)
+
+				// Create a reference TLS credential to compare behavior
+				expectedCreds := credentials.NewTLS(&tls.Config{
+					MinVersion: tls.VersionTLS12,
+				})
+				expectedInfo := expectedCreds.Info()
+
+				// Both should have the same security protocol and server name behavior
+				assert.Equal(t, expectedInfo.SecurityProtocol, info.SecurityProtocol)
+				assert.Equal(t, expectedInfo.ServerName, info.ServerName)
+			}
+		})
+	}
+}

--- a/engine/cld/offchain/offchain.go
+++ b/engine/cld/offchain/offchain.go
@@ -1,0 +1,84 @@
+package offchain
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	csav1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/csa"
+	"golang.org/x/oauth2"
+
+	cldf_config_env "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/config/env"
+	cldf_domain "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/domain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/internal"
+	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
+	offchain_jd "github.com/smartcontractkit/chainlink-deployments-framework/offchain/jd"
+	offchain_jd_provider "github.com/smartcontractkit/chainlink-deployments-framework/offchain/jd/provider"
+)
+
+// LoadOffchainClient loads an offchain client for the specified domain and environment.
+func LoadOffchainClient(
+	ctx context.Context,
+	domain cldf_domain.Domain,
+	env string,
+	config *cldf_config_env.Config,
+	lggr logger.Logger,
+	useRealBackends bool,
+) (cldf_offchain.Client, error) {
+	var jd cldf_offchain.Client
+
+	endpoints := config.Offchain.JobDistributor.Endpoints
+	auth := config.Offchain.JobDistributor.Auth
+
+	if domain.Key() == cldf_domain.MustGetDomain("keystone").Key() && endpoints.WSRPC == "" {
+		lggr.Warn("Skipping JD initialization for Keystone, fallback to CLO data")
+	} else if endpoints.WSRPC == "" || endpoints.GRPC == "" {
+		lggr.Warn("Skipping JD initialization no JD config for WS or gRPC")
+	} else if endpoints.WSRPC != "" && endpoints.GRPC != "" {
+		lggr.Info("Initializing JD client")
+		var oauth oauth2.TokenSource
+		if config.Offchain.JobDistributor.Auth != nil {
+			source := offchain_jd.NewCognitoTokenSource(offchain_jd.CognitoAuth{
+				AppClientID:     auth.CognitoAppClientID,
+				AppClientSecret: auth.CognitoAppClientSecret,
+				Username:        auth.Username,
+				Password:        auth.Password,
+				AWSRegion:       auth.AWSRegion,
+			})
+			if err := source.Authenticate(ctx); err != nil {
+				return nil, err
+			}
+
+			oauth = source
+		}
+		creds := internal.GetCredsForEnv(env)
+
+		var offchainOptions []offchain_jd_provider.ClientProviderOption
+		if !useRealBackends {
+			lggr.Infow("Using a dry-run JD client")
+			offchainOptions = append(offchainOptions, offchain_jd_provider.WithDryRun(lggr))
+		}
+
+		provider := offchain_jd_provider.NewClientOffchainProvider(offchain_jd_provider.ClientOffchainProviderConfig{
+			GRPC:  endpoints.GRPC,
+			WSRPC: endpoints.WSRPC,
+			Creds: creds,
+			Auth:  oauth,
+		}, offchainOptions...)
+
+		var err error
+		jd, err = provider.Initialize(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		var kp *csav1.ListKeypairsResponse
+		kp, err = jd.ListKeypairs(ctx, &csav1.ListKeypairsRequest{})
+		if err != nil {
+			return jd, fmt.Errorf("unable to reach the JD instance %s. Are you on the VPN? %w", endpoints.GRPC, err)
+		}
+		lggr.Debugw("JD CSA Key", "key", kp.Keypairs[0].PublicKey)
+	}
+
+	return jd, nil
+}


### PR DESCRIPTION
In order to load environment, we need to load the catalog store first and also the offchain client. These will be used when we load environment.

- added tests

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-586