### PR TITLE
chore: migrate state commands to cld engine as legacy

### DIFF
--- a/engine/cld/legacy/cli/commands/commands.go
+++ b/engine/cld/legacy/cli/commands/commands.go
@@ -1,0 +1,17 @@
+// Package commands contains common commands that can be injected into each domain's CLI
+// application.
+package commands
+
+import (
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+// Commands provides a set of common commands that can be integrated into Domain-specific CLIs.
+type Commands struct {
+	lggr logger.Logger
+}
+
+// NewCommands creates a new instance of Commands.
+func NewCommands(lggr logger.Logger) *Commands {
+	return &Commands{lggr: lggr}
+}

--- a/engine/cld/legacy/cli/commands/state.go
+++ b/engine/cld/legacy/cli/commands/state.go
@@ -1,0 +1,104 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/domain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/environment"
+)
+
+// NewStateCmds creates a new set of commands for state environment.
+func (c Commands) NewStateCmds(dom domain.Domain, config StateConfig) *cobra.Command {
+	stateCmd := &cobra.Command{
+		Use:   "state",
+		Short: "State commands",
+	}
+	stateCmd.AddCommand(c.newStateGenerate(dom, config))
+
+	stateCmd.PersistentFlags().
+		StringP("environment", "e", "", "Deployment environment (required)")
+	_ = stateCmd.MarkPersistentFlagRequired("environment")
+
+	return stateCmd
+}
+
+type StateConfig struct {
+	ViewState cldf.ViewStateV2
+}
+
+func (c Commands) newStateGenerate(dom domain.Domain, cfg StateConfig) *cobra.Command {
+	var (
+		persist       bool
+		outputPath    string
+		prevStatePath string
+	)
+
+	cmd := cobra.Command{
+		Use:   "generate",
+		Short: "Generate latest state. Nodes must be present in the `nodes.json` to be included.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			envKey, _ := cmd.Flags().GetString("environment")
+			envdir := dom.EnvDir(envKey)
+			viewTimeout := 10 * time.Minute
+
+			cmd.Printf("Generate latest state for %s in environment: %s\n", dom, envKey)
+			cmd.Printf("This command may take a while to complete, please be patient. Timeout set to %v\n", viewTimeout)
+			ctx, cancel := context.WithTimeout(cmd.Context(), viewTimeout)
+			defer cancel()
+
+			ctxFunc := func() context.Context {
+				return ctx
+			}
+
+			env, err := environment.Load(ctxFunc, c.lggr, envKey, dom, true /*useRealBackends*/)
+			if err != nil {
+				return fmt.Errorf("failed to load environment %w", err)
+			}
+
+			prevState, err := envdir.LoadState()
+			if err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("failed to load previous state: %w", err)
+			}
+
+			state, err := cfg.ViewState(env, prevState)
+			if err != nil {
+				return fmt.Errorf("unable to snapshot state: %w", err)
+			}
+
+			b, err := state.MarshalJSON()
+			if err != nil {
+				return fmt.Errorf("unable to marshal state: %w", err)
+			}
+
+			if persist {
+				// Save the state to the outputPath if defined, otherwise save it with the default
+				// path in the product and environment directory with the default file name.
+				if outputPath != "" {
+					err = domain.SaveViewState(outputPath, state)
+				} else {
+					err = envdir.SaveViewState(state)
+				}
+
+				if err != nil {
+					return fmt.Errorf("failed to save state: %w", err)
+				}
+			}
+
+			cmd.Println(string(b))
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVarP(&persist, "persist", "p", false, "Persist state to disk")
+	cmd.Flags().StringVarP(&outputPath, "outputPath", "o", "", "Output path. Default is <product>/<environment>/state.json")
+	cmd.Flags().StringVarP(&prevStatePath, "previousState", "s", "", "Previous state's path. Default is <product>/<environment>/state.json")
+
+	return &cmd
+}

--- a/engine/cld/legacy/cli/commands/state_test.go
+++ b/engine/cld/legacy/cli/commands/state_test.go
@@ -1,0 +1,72 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/domain"
+)
+
+func TestNewStateCmds_Structure(t *testing.T) {
+	t.Parallel()
+	c := Commands{}
+	dom := domain.NewDomain("/tmp", "foo")
+	var cfg StateConfig
+	root := c.NewStateCmds(dom, cfg)
+
+	// root command
+	require.Equal(t, "state", root.Use)
+	require.Equal(t, "State commands", root.Short)
+
+	// one subcommand: generate
+	subs := root.Commands()
+	require.Len(t, subs, 1)
+	require.Equal(t, "generate", subs[0].Use)
+
+	// persistent 'environment' flag on root
+	f := root.PersistentFlags().Lookup("environment")
+	require.NotNil(t, f)
+	require.Equal(t, "e", f.Shorthand)
+}
+
+func TestNewStateGenerateCmd_Metadata(t *testing.T) {
+	t.Parallel()
+	dom := domain.NewDomain("/tmp", "foo")
+	var cfg StateConfig
+	cmd := (&Commands{}).newStateGenerate(dom, cfg)
+
+	require.Equal(t, "generate", cmd.Use)
+	require.Contains(t, cmd.Short, "Generate latest state")
+
+	// local flags
+	p := cmd.Flags().Lookup("persist")
+	require.NotNil(t, p)
+	require.Equal(t, "p", p.Shorthand)
+	require.Equal(t, "false", p.Value.String())
+
+	o := cmd.Flags().Lookup("outputPath")
+	require.NotNil(t, o)
+	require.Equal(t, "o", o.Shorthand)
+	require.Empty(t, o.Value.String())
+
+	s := cmd.Flags().Lookup("previousState")
+	require.NotNil(t, s)
+	require.Equal(t, "s", s.Shorthand)
+	require.Empty(t, s.Value.String())
+}
+
+func TestStateGenerate_MissingEnvFails(t *testing.T) {
+	t.Parallel()
+	c := Commands{}
+	dom := domain.NewDomain("/tmp", "foo")
+	var cfg StateConfig
+	root := c.NewStateCmds(dom, cfg)
+
+	// invoke without the required --environment flag
+	root.SetArgs([]string{"generate"})
+	err := root.Execute()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `required flag(s) "environment" not set`)
+}


### PR DESCRIPTION
This commit migrates the state commands to the cld engine as legacy commands.