### PR TITLE
chore: moves ocr_secrets.go `deployment` -> `offchain/ocr`

### DIFF
--- a/.changeset/famous-beans-work.md
+++ b/.changeset/famous-beans-work.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+chore: moves ocr_secrets deployment -> offchain/ocr

--- a/deployment/changeset_test.go
+++ b/deployment/changeset_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 )
 
 type MyChangeSet struct{}
@@ -105,7 +106,7 @@ func NewNoopEnvironment(t *testing.T) Environment {
 		[]string{},
 		nil,
 		t.Context,
-		XXXGenerateTestOCRSecrets(),
+		focr.XXXGenerateTestOCRSecrets(),
 		chain.NewBlockChains(map[uint64]chain.BlockChain{}),
 	)
 }

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -13,6 +13,7 @@ import (
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/offchain"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
@@ -56,7 +57,7 @@ type Environment struct {
 	NodeIDs    []string
 	Offchain   offchain.Client
 	GetContext func() context.Context
-	OCRSecrets OCRSecrets
+	OCRSecrets focr.OCRSecrets
 	// OperationsBundle contains dependencies required by the operations API.
 	OperationsBundle operations.Bundle
 	// BlockChains is the container of all chains in the environment.
@@ -82,7 +83,7 @@ func NewEnvironment(
 	nodeIDs []string,
 	offchain offchain.Client,
 	ctx func() context.Context,
-	secrets OCRSecrets,
+	secrets focr.OCRSecrets,
 	blockChains chain.BlockChains,
 	opts ...EnvironmentOption,
 ) *Environment {

--- a/deployment/ocr_secrets.go
+++ b/deployment/ocr_secrets.go
@@ -1,36 +1,21 @@
 package deployment
 
 import (
-	"errors"
-
-	"github.com/ethereum/go-ethereum/crypto"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 )
 
 var (
 	// ErrMnemonicRequired is returned when the OCR mnemonic is not set
-	ErrMnemonicRequired = errors.New("xsigners or xproposers required")
+	ErrMnemonicRequired = focr.ErrMnemonicRequired
 )
 
 // OCRSecrets are used to disseminate a shared secret to OCR nodes
 // through the blockchain where OCR configuration is stored. Its a low value secret used
 // to derive transmission order etc. They are extracted here such that they can common
 // across signers when multiple signers are signing the same OCR config.
-type OCRSecrets struct {
-	SharedSecret [16]byte
-	EphemeralSk  [32]byte
-}
+type OCRSecrets = focr.OCRSecrets
 
-func (s OCRSecrets) IsEmpty() bool {
-	return s.SharedSecret == [16]byte{} || s.EphemeralSk == [32]byte{}
-}
-
-func XXXGenerateTestOCRSecrets() OCRSecrets {
-	var s OCRSecrets
-	copy(s.SharedSecret[:], crypto.Keccak256([]byte("shared"))[:16])
-	copy(s.EphemeralSk[:], crypto.Keccak256([]byte("ephemeral")))
-
-	return s
-}
+var XXXGenerateTestOCRSecrets = focr.XXXGenerateTestOCRSecrets
 
 // SharedSecrets generates shared secrets from the BIP39 mnemonic phrases for the OCR signers
 // and proposers.
@@ -39,22 +24,4 @@ func XXXGenerateTestOCRSecrets() OCRSecrets {
 // https://github.com/smartcontractkit/offchain-reporting/blob/14a57d70e50474a2104aa413214e464d6bc69e16/lib/offchainreporting/internal/config/shared_secret_test.go#L32
 // Historically signers (fixed secret) and proposers (ephemeral secret) were
 // combined in this manner. We simply leave that as is.
-func GenerateSharedSecrets(xSigners, xProposers string) (OCRSecrets, error) {
-	if xSigners == "" || xProposers == "" {
-		return OCRSecrets{}, ErrMnemonicRequired
-	}
-
-	xSignersHash := crypto.Keccak256([]byte(xSigners))
-	xProposersHash := crypto.Keccak256([]byte(xProposers))
-	xSignersHashxProposersHashZero := append(append(append([]byte{}, xSignersHash...), xProposersHash...), 0)
-	xSignersHashxProposersHashOne := append(append(append([]byte{}, xSignersHash...), xProposersHash...), 1)
-	var sharedSecret [16]byte
-	copy(sharedSecret[:], crypto.Keccak256(xSignersHashxProposersHashZero))
-	var sk [32]byte
-	copy(sk[:], crypto.Keccak256(xSignersHashxProposersHashOne))
-
-	return OCRSecrets{
-		SharedSecret: sharedSecret,
-		EphemeralSk:  sk,
-	}, nil
-}
+var GenerateSharedSecrets = focr.GenerateSharedSecrets

--- a/engine/cld/environment/environment.go
+++ b/engine/cld/environment/environment.go
@@ -18,6 +18,7 @@ import (
 	cldf_domain "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/domain"
 	cldf_engine_offchain "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/offchain"
 	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
@@ -156,7 +157,7 @@ func Load(
 
 	lggr.Debugw("Loaded environment", "env", env, "addressBook", ab)
 
-	sharedSecrets, err := cldf.GenerateSharedSecrets(
+	sharedSecrets, err := focr.GenerateSharedSecrets(
 		config.Env.Offchain.OCR.XSigners, config.Env.Offchain.OCR.XProposers,
 	)
 	if err != nil {

--- a/engine/cld/environment/fork.go
+++ b/engine/cld/environment/fork.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/domain"
 	cldf_engine_offchain "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/offchain"
 	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
+	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
@@ -127,7 +128,7 @@ func LoadForkedEnvironment(ctx context.Context, lggr logger.Logger, env string, 
 		nodes.Keys(),
 		oc,
 		func() context.Context { return ctx },
-		cldf.XXXGenerateTestOCRSecrets(),
+		focr.XXXGenerateTestOCRSecrets(),
 		chain.NewBlockChains(blockChains),
 	)
 

--- a/offchain/ocr/secrets.go
+++ b/offchain/ocr/secrets.go
@@ -1,0 +1,60 @@
+package ocr
+
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var (
+	// ErrMnemonicRequired is returned when the OCR mnemonic is not set
+	ErrMnemonicRequired = errors.New("xsigners or xproposers required")
+)
+
+// OCRSecrets are used to disseminate a shared secret to OCR nodes
+// through the blockchain where OCR configuration is stored. Its a low value secret used
+// to derive transmission order etc. They are extracted here such that they can common
+// across signers when multiple signers are signing the same OCR config.
+type OCRSecrets struct {
+	SharedSecret [16]byte
+	EphemeralSk  [32]byte
+}
+
+func (s OCRSecrets) IsEmpty() bool {
+	return s.SharedSecret == [16]byte{} || s.EphemeralSk == [32]byte{}
+}
+
+func XXXGenerateTestOCRSecrets() OCRSecrets {
+	var s OCRSecrets
+	copy(s.SharedSecret[:], crypto.Keccak256([]byte("shared"))[:16])
+	copy(s.EphemeralSk[:], crypto.Keccak256([]byte("ephemeral")))
+
+	return s
+}
+
+// SharedSecrets generates shared secrets from the BIP39 mnemonic phrases for the OCR signers
+// and proposers.
+//
+// Lifted from here
+// https://github.com/smartcontractkit/offchain-reporting/blob/14a57d70e50474a2104aa413214e464d6bc69e16/lib/offchainreporting/internal/config/shared_secret_test.go#L32
+// Historically signers (fixed secret) and proposers (ephemeral secret) were
+// combined in this manner. We simply leave that as is.
+func GenerateSharedSecrets(xSigners, xProposers string) (OCRSecrets, error) {
+	if xSigners == "" || xProposers == "" {
+		return OCRSecrets{}, ErrMnemonicRequired
+	}
+
+	xSignersHash := crypto.Keccak256([]byte(xSigners))
+	xProposersHash := crypto.Keccak256([]byte(xProposers))
+	xSignersHashxProposersHashZero := append(append(append([]byte{}, xSignersHash...), xProposersHash...), 0)
+	xSignersHashxProposersHashOne := append(append(append([]byte{}, xSignersHash...), xProposersHash...), 1)
+	var sharedSecret [16]byte
+	copy(sharedSecret[:], crypto.Keccak256(xSignersHashxProposersHashZero))
+	var sk [32]byte
+	copy(sk[:], crypto.Keccak256(xSignersHashxProposersHashOne))
+
+	return OCRSecrets{
+		SharedSecret: sharedSecret,
+		EphemeralSk:  sk,
+	}, nil
+}

--- a/offchain/ocr/secrets_test.go
+++ b/offchain/ocr/secrets_test.go
@@ -147,7 +147,7 @@ func TestGenerateSharedSecrets(t *testing.T) {
 			if tt.expectError {
 				require.Error(t, err)
 				if tt.errorType != nil {
-					assert.ErrorIs(t, err, tt.errorType)
+					require.ErrorIs(t, err, tt.errorType)
 				}
 				assert.True(t, secrets.IsEmpty(), "secrets should be empty when error occurs")
 			} else {

--- a/offchain/ocr/secrets_test.go
+++ b/offchain/ocr/secrets_test.go
@@ -1,0 +1,180 @@
+package ocr
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOCRSecrets_IsEmpty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		secrets  OCRSecrets
+		expected bool
+	}{
+		{
+			name: "both fields empty - should be empty",
+			secrets: OCRSecrets{
+				SharedSecret: [16]byte{},
+				EphemeralSk:  [32]byte{},
+			},
+			expected: true,
+		},
+		{
+			name: "shared secret empty, ephemeral sk not empty - should be empty",
+			secrets: OCRSecrets{
+				SharedSecret: [16]byte{},
+				EphemeralSk:  [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
+			},
+			expected: true,
+		},
+		{
+			name: "shared secret not empty, ephemeral sk empty - should be empty",
+			secrets: OCRSecrets{
+				SharedSecret: [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+				EphemeralSk:  [32]byte{},
+			},
+			expected: true,
+		},
+		{
+			name: "both fields not empty - should not be empty",
+			secrets: OCRSecrets{
+				SharedSecret: [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+				EphemeralSk:  [32]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := tt.secrets.IsEmpty()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestXXXGenerateTestOCRSecrets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "generates deterministic secrets",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Test that the function generates non-empty secrets
+			secrets1 := XXXGenerateTestOCRSecrets()
+			assert.False(t, secrets1.IsEmpty(), "generated secrets should not be empty")
+
+			// Test deterministic behavior - should generate same secrets each time
+			secrets2 := XXXGenerateTestOCRSecrets()
+			assert.Equal(t, secrets1, secrets2, "function should be deterministic")
+
+			// Test that generated values match expected keccak256 hashes
+			expectedSharedSecret := crypto.Keccak256([]byte("shared"))[:16]
+			expectedEphemeralSk := crypto.Keccak256([]byte("ephemeral"))
+
+			assert.Equal(t, expectedSharedSecret, secrets1.SharedSecret[:], "shared secret should match keccak256 of 'shared'")
+			assert.Equal(t, expectedEphemeralSk, secrets1.EphemeralSk[:], "ephemeral sk should match keccak256 of 'ephemeral'")
+
+			// Verify that the secrets are properly sized
+			assert.Len(t, secrets1.SharedSecret, 16, "shared secret should be 16 bytes")
+			assert.Len(t, secrets1.EphemeralSk, 32, "ephemeral sk should be 32 bytes")
+		})
+	}
+}
+
+func TestGenerateSharedSecrets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		xSigners    string
+		xProposers  string
+		expectError bool
+		errorType   error
+	}{
+		// Basic valid cases
+		{
+			name:        "valid signers and proposers",
+			xSigners:    "test-signers",
+			xProposers:  "test-proposers",
+			expectError: false,
+		},
+		// Error cases
+		{
+			name:        "empty signers",
+			xSigners:    "",
+			xProposers:  "test-proposers",
+			expectError: true,
+			errorType:   ErrMnemonicRequired,
+		},
+		{
+			name:        "empty proposers",
+			xSigners:    "test-signers",
+			xProposers:  "",
+			expectError: true,
+			errorType:   ErrMnemonicRequired,
+		},
+		{
+			name:        "both empty",
+			xSigners:    "",
+			xProposers:  "",
+			expectError: true,
+			errorType:   ErrMnemonicRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			secrets, err := GenerateSharedSecrets(tt.xSigners, tt.xProposers)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorType != nil {
+					assert.ErrorIs(t, err, tt.errorType)
+				}
+				assert.True(t, secrets.IsEmpty(), "secrets should be empty when error occurs")
+			} else {
+				require.NoError(t, err)
+				assert.False(t, secrets.IsEmpty(), "secrets should not be empty when successful")
+
+				// Verify that the secrets are properly sized
+				assert.Len(t, secrets.SharedSecret, 16, "shared secret should be 16 bytes")
+				assert.Len(t, secrets.EphemeralSk, 32, "ephemeral sk should be 32 bytes")
+
+				// Verify deterministic behavior - same inputs should produce same outputs
+				secrets2, err2 := GenerateSharedSecrets(tt.xSigners, tt.xProposers)
+				require.NoError(t, err2)
+				assert.Equal(t, secrets, secrets2, "function should be deterministic")
+
+				// Verify that the generated secrets match the expected algorithm
+				xSignersHash := crypto.Keccak256([]byte(tt.xSigners))
+				xProposersHash := crypto.Keccak256([]byte(tt.xProposers))
+				xSignersHashxProposersHashZero := append(append(append([]byte{}, xSignersHash...), xProposersHash...), 0)
+				xSignersHashxProposersHashOne := append(append(append([]byte{}, xSignersHash...), xProposersHash...), 1)
+
+				expectedSharedSecret := crypto.Keccak256(xSignersHashxProposersHashZero)[:16]
+				expectedEphemeralSk := crypto.Keccak256(xSignersHashxProposersHashOne)
+
+				assert.Equal(t, expectedSharedSecret, secrets.SharedSecret[:], "shared secret should match expected hash")
+				assert.Equal(t, expectedEphemeralSk, secrets.EphemeralSk[:], "ephemeral sk should match expected hash")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR moves `ocr_secrets.go` from the `deployment` package to `offchain/ocr`. The original definitions are temporarily preserved as type aliases and will be removed once the transition is fully complete."