### PR TITLE
SPIKE - feat(chain): introduce AddressToBytes

### DIFF
--- a/chain/aptos/aptos_chain.go
+++ b/chain/aptos/aptos_chain.go
@@ -1,6 +1,8 @@
 package aptos
 
 import (
+	"fmt"
+
 	aptoslib "github.com/aptos-labs/aptos-go-sdk"
 
 	chain_common "github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/common"
@@ -38,4 +40,15 @@ func (c Chain) Name() string {
 // Family returns the family of the chain
 func (c Chain) Family() string {
 	return chain_common.ChainMetadata{Selector: c.Selector}.Family()
+}
+
+// AddressToBytes converts an Aptos address string to bytes.
+func (c Chain) AddressToBytes(address string) ([]byte, error) {
+	var addr aptoslib.AccountAddress
+	err := addr.ParseStringRelaxed(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Aptos address format: %s, error: %w", address, err)
+	}
+
+	return addr[:], nil
 }

--- a/chain/aptos/aptos_chain_test.go
+++ b/chain/aptos/aptos_chain_test.go
@@ -5,6 +5,7 @@ import (
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
 )
@@ -41,4 +42,140 @@ func TestChain_ChainInfot(t *testing.T) {
 			assert.Equal(t, tt.wantFamily, c.Family())
 		})
 	}
+}
+
+func TestChain_AddressToBytes(t *testing.T) {
+	t.Parallel()
+
+	chain := aptos.Chain{Selector: 4741444398633441}
+
+	t.Run("valid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			address  string
+			expected []byte
+		}{
+			{
+				name:    "valid short address",
+				address: "0x1",
+				expected: func() []byte {
+					expected := make([]byte, 32)
+					expected[31] = 0x01
+
+					return expected
+				}(),
+			},
+			{
+				name:    "valid full address",
+				address: "0x0000000000000000000000000000000000000000000000000000000000000001",
+				expected: func() []byte {
+					expected := make([]byte, 32)
+					expected[31] = 0x01
+
+					return expected
+				}(),
+			},
+			{
+				name:    "valid address without 0x prefix",
+				address: "1",
+				expected: func() []byte {
+					expected := make([]byte, 32)
+					expected[31] = 0x01
+
+					return expected
+				}(),
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := chain.AddressToBytes(tt.address)
+
+				require.NoError(t, err)
+				assert.Len(t, result, 32)
+				assert.Equal(t, tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("invalid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{
+				name:    "invalid hex characters",
+				address: "invalid",
+			},
+			{
+				name:    "empty address",
+				address: "",
+			},
+			{
+				name:    "invalid hex with 0x prefix",
+				address: "0xGG",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := chain.AddressToBytes(tt.address)
+				require.Error(t, err, "Expected error for address: %s", tt.address)
+				assert.Nil(t, result)
+			})
+		}
+	})
+
+	t.Run("address normalization", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{name: "short form", address: "0x1"},
+			{name: "padded short form", address: "0x01"},
+			{name: "medium padded form", address: "0x0001"},
+			{name: "full form", address: "0x0000000000000000000000000000000000000000000000000000000000000001"},
+			{name: "no prefix", address: "1"},
+		}
+
+		var results [][]byte
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) { //nolint:paralleltest // Cannot use t.Parallel() here because tests share the results slice
+				result, err := chain.AddressToBytes(tt.address)
+				require.NoError(t, err, "Failed to convert address: %s", tt.address)
+				results = append(results, result)
+			})
+		}
+
+		// All should produce the same result
+		t.Run("all forms produce same result", func(t *testing.T) { //nolint:paralleltest // Cannot use t.Parallel() here because it depends on results from previous tests
+			for i := 1; i < len(results); i++ {
+				assert.Equal(t, results[0], results[i], "All address formats should produce the same result")
+			}
+		})
+	})
+
+	t.Run("consistent results", func(t *testing.T) {
+		t.Parallel()
+
+		address := "0x1"
+
+		result1, err1 := chain.AddressToBytes(address)
+		require.NoError(t, err1)
+
+		result2, err2 := chain.AddressToBytes(address)
+		require.NoError(t, err2)
+
+		assert.Equal(t, result1, result2, "Expected consistent results for the same address")
+	})
 }

--- a/chain/blockchain.go
+++ b/chain/blockchain.go
@@ -30,6 +30,8 @@ type BlockChain interface {
 	Name() string
 	ChainSelector() uint64
 	Family() string
+	// AddressToBytes converts an address string to bytes.
+	AddressToBytes(address string) ([]byte, error)
 }
 
 // BlockChains represents a collection of chains.

--- a/chain/evm/evm_chain.go
+++ b/chain/evm/evm_chain.go
@@ -2,6 +2,7 @@ package evm
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -70,4 +71,15 @@ func (c Chain) Name() string {
 // Family returns the family of the chain
 func (c Chain) Family() string {
 	return chain_common.ChainMetadata{Selector: c.Selector}.Family()
+}
+
+// AddressToBytes converts an EVM address string to bytes.
+func (c Chain) AddressToBytes(address string) ([]byte, error) {
+	if !common.IsHexAddress(address) {
+		return nil, fmt.Errorf("invalid EVM address format: %s", address)
+	}
+
+	addr := common.HexToAddress(address)
+
+	return addr.Bytes(), nil
 }

--- a/chain/evm/evm_chain_test.go
+++ b/chain/evm/evm_chain_test.go
@@ -5,6 +5,7 @@ import (
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 )
@@ -41,4 +42,116 @@ func TestChain_ChainInfo(t *testing.T) {
 			assert.Equal(t, tt.wantFamily, c.Family())
 		})
 	}
+}
+
+func TestChain_AddressToBytes(t *testing.T) {
+	t.Parallel()
+
+	chain := evm.Chain{Selector: 1}
+
+	tests := []struct {
+		name          string
+		address       string
+		expectedLen   int
+		expectedBytes []byte
+		shouldSucceed bool
+		description   string
+	}{
+		{
+			name:          "valid address with 0x prefix",
+			address:       "0x742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8",
+			expectedLen:   20,
+			expectedBytes: []byte{0x74, 0x2d, 0x35, 0xcc, 0x66, 0x34, 0xc0, 0x53, 0x29, 0x25, 0xa3, 0xb8, 0xd4, 0xc8, 0xc1, 0xb8, 0xc4, 0xc8, 0xc1, 0xb8},
+			shouldSucceed: true,
+			description:   "should convert valid hex address with 0x prefix to bytes",
+		},
+		{
+			name:          "valid address without 0x prefix",
+			address:       "742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8",
+			expectedLen:   20,
+			shouldSucceed: true,
+			description:   "should convert valid hex address without 0x prefix to bytes",
+		},
+		{
+			name:          "zero address",
+			address:       "0x0000000000000000000000000000000000000000",
+			expectedLen:   20,
+			expectedBytes: make([]byte, 20), // All zeros
+			shouldSucceed: true,
+			description:   "should convert zero address to 20 zero bytes",
+		},
+		{
+			name:          "invalid - too short",
+			address:       "0x123",
+			shouldSucceed: false,
+			description:   "should reject address that is too short",
+		},
+		{
+			name:          "invalid - invalid hex characters",
+			address:       "742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8XX",
+			shouldSucceed: false,
+			description:   "should reject address with invalid hex characters",
+		},
+		{
+			name:          "invalid - empty string",
+			address:       "",
+			shouldSucceed: false,
+			description:   "should reject empty address string",
+		},
+		{
+			name:          "invalid - non-hex string",
+			address:       "invalid",
+			shouldSucceed: false,
+			description:   "should reject non-hex address string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := chain.AddressToBytes(tt.address)
+
+			if tt.shouldSucceed {
+				require.NoError(t, err, tt.description)
+				assert.Len(t, result, tt.expectedLen, "Expected length %d for address %s", tt.expectedLen, tt.address)
+
+				if tt.expectedBytes != nil {
+					assert.Equal(t, tt.expectedBytes, result, "Expected specific bytes for address %s", tt.address)
+				}
+			} else {
+				require.Error(t, err, tt.description)
+				assert.Nil(t, result, "Expected nil result for invalid address %s", tt.address)
+			}
+		})
+	}
+
+	t.Run("case sensitivity", func(t *testing.T) {
+		t.Parallel()
+
+		// EVM addresses should be case-insensitive
+		addr1 := "0x742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8"
+		addr2 := "0x742D35CC6634C0532925A3B8D4C8C1B8C4C8C1B8"
+
+		result1, err1 := chain.AddressToBytes(addr1)
+		result2, err2 := chain.AddressToBytes(addr2)
+
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		assert.Equal(t, result1, result2, "EVM addresses should be case-insensitive")
+	})
+
+	t.Run("consistent results", func(t *testing.T) {
+		t.Parallel()
+
+		address := "0x742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8"
+
+		result1, err1 := chain.AddressToBytes(address)
+		require.NoError(t, err1)
+
+		result2, err2 := chain.AddressToBytes(address)
+		require.NoError(t, err2)
+
+		assert.Equal(t, result1, result2, "Expected consistent results for the same address")
+	})
 }

--- a/chain/solana/solana_chain.go
+++ b/chain/solana/solana_chain.go
@@ -208,3 +208,14 @@ func (c Chain) Name() string {
 func (c Chain) Family() string {
 	return common.ChainMetadata{Selector: c.Selector}.Family()
 }
+
+// AddressToBytes converts a Solana address string to bytes.
+// Solana addresses are base58-encoded public keys (32 bytes).
+func (c Chain) AddressToBytes(address string) ([]byte, error) {
+	pubkey, err := sollib.PublicKeyFromBase58(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Solana address format: %s, error: %w", address, err)
+	}
+
+	return pubkey.Bytes(), nil
+}

--- a/chain/solana/solana_chain_test.go
+++ b/chain/solana/solana_chain_test.go
@@ -5,6 +5,7 @@ import (
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 )
@@ -41,4 +42,87 @@ func TestChain_ChainInfot(t *testing.T) {
 			assert.Equal(t, tt.wantFamily, c.Family())
 		})
 	}
+}
+
+func TestChain_AddressToBytes(t *testing.T) {
+	t.Parallel()
+
+	chain := solana.Chain{Selector: 1151111081099710}
+
+	tests := []struct {
+		name          string
+		address       string
+		expectedLen   int
+		shouldSucceed bool
+		description   string
+	}{
+		{
+			name:          "valid system program address",
+			address:       "11111111111111111111111111111112", // System program
+			expectedLen:   32,
+			shouldSucceed: true,
+			description:   "should convert system program address to 32 bytes",
+		},
+		{
+			name:          "valid token program address",
+			address:       "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", // Token program
+			expectedLen:   32,
+			shouldSucceed: true,
+			description:   "should convert token program address to 32 bytes",
+		},
+		{
+			name:          "invalid - non-base58 string",
+			address:       "invalid",
+			shouldSucceed: false,
+			description:   "should reject non-base58 address string",
+		},
+		{
+			name:          "invalid - empty string",
+			address:       "",
+			shouldSucceed: false,
+			description:   "should reject empty address string",
+		},
+		{
+			name:          "invalid - too short",
+			address:       "123",
+			shouldSucceed: false,
+			description:   "should reject address that is too short",
+		},
+		{
+			name:          "invalid - invalid base58 characters",
+			address:       "InvalidBase58Characters!",
+			shouldSucceed: false,
+			description:   "should reject address with invalid base58 characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := chain.AddressToBytes(tt.address)
+
+			if tt.shouldSucceed {
+				require.NoError(t, err, tt.description)
+				assert.Len(t, result, tt.expectedLen, "Expected length %d for address %s", tt.expectedLen, tt.address)
+			} else {
+				require.Error(t, err, tt.description)
+				assert.Nil(t, result, "Expected nil result for invalid address %s", tt.address)
+			}
+		})
+	}
+
+	t.Run("consistent results", func(t *testing.T) {
+		t.Parallel()
+
+		address := "11111111111111111111111111111112"
+
+		result1, err1 := chain.AddressToBytes(address)
+		require.NoError(t, err1)
+
+		result2, err2 := chain.AddressToBytes(address)
+		require.NoError(t, err2)
+
+		assert.Equal(t, result1, result2, "Expected consistent results for the same address")
+	})
 }

--- a/chain/sui/sui_chain.go
+++ b/chain/sui/sui_chain.go
@@ -1,6 +1,10 @@
 package sui
 
 import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
 	"github.com/block-vision/sui-go-sdk/sui"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/common"
@@ -15,4 +19,23 @@ type Chain struct {
 	Signer SuiSigner
 	URL    string
 	// TODO: Implement ConfirmTransaction. Current tooling relies on node local execution
+}
+
+// AddressToBytes converts a Sui address string to bytes.
+// Sui addresses are hex strings typically prefixed with "0x" (32 bytes).
+func (c Chain) AddressToBytes(address string) ([]byte, error) {
+	// Remove "0x" prefix if present
+	address = strings.TrimPrefix(address, "0x")
+
+	// Sui addresses should be 64 hex characters (32 bytes)
+	if len(address) != 64 {
+		return nil, fmt.Errorf("invalid Sui address format: expected 64 hex characters, got %d", len(address))
+	}
+
+	addressBytes, err := hex.DecodeString(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Sui address format: %s, error: %w", address, err)
+	}
+
+	return addressBytes, nil
 }

--- a/chain/sui/sui_chain_test.go
+++ b/chain/sui/sui_chain_test.go
@@ -5,6 +5,7 @@ import (
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/sui"
 )
@@ -41,4 +42,121 @@ func TestChain_ChainInfot(t *testing.T) {
 			assert.Equal(t, tt.wantFamily, c.Family())
 		})
 	}
+}
+
+func TestChain_AddressToBytes(t *testing.T) {
+	t.Parallel()
+
+	chain := sui.Chain{ChainMetadata: sui.ChainMetadata{Selector: 13264668187771770619}}
+
+	t.Run("valid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{
+				name:    "valid address with 0x prefix",
+				address: "0xa402ce953053607dffcdfec89406c579c8d8ddb9c90e01b7aa28f5f1538ac289",
+			},
+			{
+				name:    "valid address without 0x prefix",
+				address: "a402ce953053607dffcdfec89406c579c8d8ddb9c90e01b7aa28f5f1538ac289",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := chain.AddressToBytes(tt.address)
+
+				require.NoError(t, err)
+				assert.Len(t, result, 32)
+			})
+		}
+	})
+
+	t.Run("invalid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{
+				name:    "invalid hex characters",
+				address: "invalid",
+			},
+			{
+				name:    "empty address",
+				address: "",
+			},
+			{
+				name:    "address too short",
+				address: "0xa402ce953053607dffcdfec89406c579c8d8ddb9c90e01b7aa28f5f1538ac2",
+			},
+			{
+				name:    "address too long",
+				address: "0xa402ce953053607dffcdfec89406c579c8d8ddb9c90e01b7aa28f5f1538ac289a",
+			},
+			{
+				name:    "invalid hex with 0x prefix",
+				address: "0xGGGGce953053607dffcdfec89406c579c8d8ddb9c90e01b7aa28f5f1538ac289",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := chain.AddressToBytes(tt.address)
+				require.Error(t, err, "Expected error for address: %s", tt.address)
+				assert.Nil(t, result)
+			})
+		}
+	})
+
+	t.Run("address normalization", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{name: "with 0x prefix", address: "0xa402ce953053607dffcdfec89406c579c8d8ddb9c90e01b7aa28f5f1538ac289"},
+			{name: "without 0x prefix", address: "a402ce953053607dffcdfec89406c579c8d8ddb9c90e01b7aa28f5f1538ac289"},
+		}
+
+		var results [][]byte
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) { //nolint:paralleltest // Cannot use t.Parallel() here because tests share the results slice
+				result, err := chain.AddressToBytes(tt.address)
+				require.NoError(t, err, "Failed to convert address: %s", tt.address)
+				results = append(results, result)
+			})
+		}
+
+		// Both formats should produce the same result
+		t.Run("both formats produce same result", func(t *testing.T) { //nolint:paralleltest // Cannot use t.Parallel() here because it depends on results from previous tests
+			if len(results) >= 2 {
+				assert.Equal(t, results[0], results[1], "Sui addresses with and without 0x should produce same result")
+			}
+		})
+	})
+
+	t.Run("consistent results", func(t *testing.T) {
+		t.Parallel()
+
+		address := "0xa402ce953053607dffcdfec89406c579c8d8ddb9c90e01b7aa28f5f1538ac289"
+
+		result1, err1 := chain.AddressToBytes(address)
+		require.NoError(t, err1)
+
+		result2, err2 := chain.AddressToBytes(address)
+		require.NoError(t, err2)
+
+		assert.Equal(t, result1, result2, "Expected consistent results for the same address")
+	})
 }

--- a/chain/ton/ton_chain.go
+++ b/chain/ton/ton_chain.go
@@ -1,6 +1,8 @@
 package ton
 
 import (
+	"fmt"
+
 	"github.com/xssnick/tonutils-go/address"
 	"github.com/xssnick/tonutils-go/ton"
 	"github.com/xssnick/tonutils-go/ton/wallet"
@@ -18,4 +20,15 @@ type Chain struct {
 	WalletAddress *address.Address // Address of deployer wallet
 	URL           string           // Liteserver URL
 	DeployerSeed  string           // Optional: mnemonic or raw seed
+}
+
+// AddressToBytes converts a TON address string to bytes.
+func (c Chain) AddressToBytes(addressStr string) ([]byte, error) {
+	addr, err := address.ParseAddr(addressStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid TON address format: %s, error: %w", addressStr, err)
+	}
+
+	// Return the raw 32-byte address data
+	return addr.Data(), nil
 }

--- a/chain/ton/ton_chain_test.go
+++ b/chain/ton/ton_chain_test.go
@@ -5,6 +5,7 @@ import (
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/ton"
 )
@@ -41,4 +42,94 @@ func TestChain_ChainInfot(t *testing.T) {
 			assert.Equal(t, tt.wantFamily, c.Family())
 		})
 	}
+}
+
+func TestChain_AddressToBytes(t *testing.T) {
+	t.Parallel()
+
+	chain := ton.Chain{ChainMetadata: ton.ChainMetadata{Selector: 7668063110026875610}}
+
+	t.Run("valid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{
+				name:    "valid address",
+				address: "EQAAAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHx2j",
+			},
+			{
+				name:    "valid address with zero data",
+				address: "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAd99",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := chain.AddressToBytes(tt.address)
+
+				require.NoError(t, err, "Should successfully parse valid TON address: %s", tt.address)
+				assert.Len(t, result, 32, "TON address should produce 32 bytes")
+				assert.NotNil(t, result)
+			})
+		}
+	})
+
+	t.Run("invalid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{
+				name:    "invalid hex characters",
+				address: "invalid",
+			},
+			{
+				name:    "empty address",
+				address: "",
+			},
+			{
+				name:    "too short",
+				address: "123",
+			},
+			{
+				name:    "invalid base64 format",
+				address: "EQ!!!invalid!!!",
+			},
+			{
+				name:    "wrong length after decoding",
+				address: "EQD4FPq-PRDieyQKkizFTRtSDyucUIqrj0MSWb_BdJKL", // truncated
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := chain.AddressToBytes(tt.address)
+				require.Error(t, err, "Expected error for address: %s", tt.address)
+				assert.Nil(t, result)
+			})
+		}
+	})
+
+	t.Run("consistent results", func(t *testing.T) {
+		t.Parallel()
+
+		address := "EQAAAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHx2j"
+
+		result1, err1 := chain.AddressToBytes(address)
+		require.NoError(t, err1)
+
+		result2, err2 := chain.AddressToBytes(address)
+		require.NoError(t, err2)
+
+		assert.Equal(t, result1, result2, "Expected consistent results for the same address")
+	})
 }

--- a/chain/tron/tron_chain.go
+++ b/chain/tron/tron_chain.go
@@ -2,6 +2,7 @@ package tron
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/fbsobreira/gotron-sdk/pkg/address"
@@ -86,4 +87,15 @@ func DefaultTriggerOptions() *TriggerOptions {
 		TAmount:             0,          // No TRX transferred by default.
 		ConfirmRetryOptions: DefaultConfirmRetryOptions(),
 	}
+}
+
+// AddressToBytes converts a Tron address string to bytes.
+// Tron addresses can be in base58 format (like "TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH").
+func (c Chain) AddressToBytes(addressStr string) ([]byte, error) {
+	addr, err := address.Base58ToAddress(addressStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Tron address format: %s, error: %w", addressStr, err)
+	}
+
+	return addr.Bytes(), nil
 }

--- a/chain/tron/tron_chain_test.go
+++ b/chain/tron/tron_chain_test.go
@@ -6,6 +6,7 @@ import (
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/tron"
 )
@@ -69,5 +70,98 @@ func Test_DefaultOptions(t *testing.T) {
 		assert.Equal(t, int32(10_000_000), opts.FeeLimit)
 		assert.Equal(t, int64(0), opts.TAmount)
 		assert.Equal(t, tron.DefaultConfirmRetryOptions(), opts.ConfirmRetryOptions)
+	})
+}
+
+func TestChain_AddressToBytes(t *testing.T) {
+	t.Parallel()
+
+	chain := tron.Chain{ChainMetadata: tron.ChainMetadata{Selector: 6433500567565415381}}
+
+	t.Run("valid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name        string
+			address     string
+			description string
+		}{
+			{
+				name:        "standard TRON address",
+				address:     "TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH",
+				description: "typical TRON wallet address",
+			},
+			{
+				name:        "USDT contract address",
+				address:     "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+				description: "USDT contract on TRON network",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := chain.AddressToBytes(tt.address)
+
+				require.NoError(t, err, "Should successfully parse valid TRON address: %s (%s)", tt.address, tt.description)
+				assert.Len(t, result, 21, "TRON address should produce 21 bytes")
+				assert.NotNil(t, result)
+			})
+		}
+	})
+
+	t.Run("invalid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{
+				name:    "invalid characters",
+				address: "invalid",
+			},
+			{
+				name:    "empty address",
+				address: "",
+			},
+			{
+				name:    "too short",
+				address: "123",
+			},
+			{
+				name:    "invalid base58 characters",
+				address: "InvalidBase58!",
+			},
+			{
+				name:    "wrong prefix (Bitcoin-like)",
+				address: "1LyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := chain.AddressToBytes(tt.address)
+				require.Error(t, err, "Expected error for address: %s", tt.address)
+				assert.Nil(t, result)
+			})
+		}
+	})
+
+	t.Run("consistent results", func(t *testing.T) {
+		t.Parallel()
+
+		address := "TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH"
+
+		result1, err1 := chain.AddressToBytes(address)
+		require.NoError(t, err1)
+
+		result2, err2 := chain.AddressToBytes(address)
+		require.NoError(t, err2)
+
+		assert.Equal(t, result1, result2, "Expected consistent results for the same address")
 	})
 }


### PR DESCRIPTION
Spiking - introducing AddressToBytes which converts string to bytes for each of the support chain family.

This is originated from [this use case raised by support ticket](https://chainlink-core.slack.com/archives/C08QF1BEW4T/p1756934131485399)