### PR TITLE
refactor: do not expose private key in provider generators

### DIFF
--- a/.changeset/smart-hoops-beg.md
+++ b/.changeset/smart-hoops-beg.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+Private Key Generators for Chain Providers no longer expose the private key as a public field

--- a/chain/aptos/provider/account_generator.go
+++ b/chain/aptos/provider/account_generator.go
@@ -73,14 +73,14 @@ func (g *accountGenNewSingleSender) Generate() (*aptoslib.Account, error) {
 
 // accountGenPrivateKey is an account generator that creates an account from the private key.
 type accountGenPrivateKey struct {
-	// PrivateKey is the hex formatted private key used to generate the Aptos account.
-	PrivateKey string
+	// privateKey is the hex formatted private key used to generate the Aptos account.
+	privateKey string
 }
 
 // AccountGenPrivateKey creates a new instance of accountGenPrivateKey with the provided private key.
 func AccountGenPrivateKey(privateKey string) *accountGenPrivateKey {
 	return &accountGenPrivateKey{
-		PrivateKey: privateKey,
+		privateKey: privateKey,
 	}
 }
 
@@ -88,7 +88,7 @@ func AccountGenPrivateKey(privateKey string) *accountGenPrivateKey {
 // private key string cannot be parsed.
 func (g *accountGenPrivateKey) Generate() (*aptoslib.Account, error) {
 	privateKey := &crypto.Ed25519PrivateKey{}
-	if err := privateKey.FromHex(g.PrivateKey); err != nil {
+	if err := privateKey.FromHex(g.privateKey); err != nil {
 		return nil, fmt.Errorf("failed to parse private key: %w", err)
 	}
 

--- a/chain/solana/provider/private_key_generator.go
+++ b/chain/solana/provider/private_key_generator.go
@@ -21,20 +21,20 @@ var (
 // key.
 func PrivateKeyFromRaw(privateKey string) *privateKeyFromRaw {
 	return &privateKeyFromRaw{
-		PrivateKey: privateKey,
+		privateKey: privateKey,
 	}
 }
 
 // privateKeyFromRaw is an Solana keypair generator that creates an keypair from a private key.
 type privateKeyFromRaw struct {
-	// PrivateKey is the base58 encoded private key used to generate the Solana keypair.
-	PrivateKey string
+	// privateKey is the base58 encoded private key used to generate the Solana keypair.
+	privateKey string
 }
 
 // Generate generates a Solana keypair from the provided base58 encoded private key and returns the
 // private key.
 func (g *privateKeyFromRaw) Generate() (sollib.PrivateKey, error) {
-	privKey, err := sollib.PrivateKeyFromBase58(g.PrivateKey)
+	privKey, err := sollib.PrivateKeyFromBase58(g.privateKey)
 	if err != nil {
 		return sollib.PrivateKey{}, fmt.Errorf("failed to parse private key: %w", err)
 	}

--- a/chain/sui/provider/account_generator.go
+++ b/chain/sui/provider/account_generator.go
@@ -15,19 +15,19 @@ var (
 
 // accountGenPrivateKey is an account generator that creates an account from the private key.
 type accountGenPrivateKey struct {
-	// PrivateKey is the hex formatted private key used to generate the Aptos account.
-	PrivateKey string
+	// privateKey is the hex formatted private key used to generate the Aptos account.
+	privateKey string
 }
 
 // AccountGenPrivateKey creates a new instance of accountGenPrivateKey with the provided private key.
 func AccountGenPrivateKey(privateKey string) *accountGenPrivateKey {
 	return &accountGenPrivateKey{
-		PrivateKey: privateKey,
+		privateKey: privateKey,
 	}
 }
 
 // Generate generates an Sui account from the provided private key. It returns an error if the
 // private key string cannot be parsed.
 func (g *accountGenPrivateKey) Generate() (sui.SuiSigner, error) {
-	return sui.NewSignerFromHexPrivateKey(g.PrivateKey)
+	return sui.NewSignerFromHexPrivateKey(g.privateKey)
 }

--- a/chain/ton/provider/private_key_generator.go
+++ b/chain/ton/provider/private_key_generator.go
@@ -22,17 +22,17 @@ var (
 // key.
 func PrivateKeyFromRaw(privateKey string) *privateKeyFromRaw {
 	return &privateKeyFromRaw{
-		PrivateKey: privateKey,
+		privateKey: privateKey,
 	}
 }
 
 type privateKeyFromRaw struct {
-	// PrivateKey is the hex encoded private key used to generate the TON keypair.
-	PrivateKey string
+	// privateKey is the hex encoded private key used to generate the TON keypair.
+	privateKey string
 }
 
 func (g *privateKeyFromRaw) Generate() (ed25519.PrivateKey, error) {
-	privateKeyBytes, err := hex.DecodeString(g.PrivateKey)
+	privateKeyBytes, err := hex.DecodeString(g.privateKey)
 	if err != nil {
 		return ed25519.PrivateKey{}, fmt.Errorf("failed to parse private key: %w", err)
 	}

--- a/chain/tron/provider/signer_generator.go
+++ b/chain/tron/provider/signer_generator.go
@@ -46,8 +46,8 @@ func SignerGenCTFDefault() (*signerGenCTFDefault, error) {
 
 // signerGenPrivateKey is a signer generator that creates a signer from the private key.
 type signerGenPrivateKey struct {
-	// PrivateKey is the hex formatted private key used to generate the Tron account.
-	PrivateKey string
+	// privateKey is the hex formatted private key used to generate the Tron account.
+	privateKey string
 
 	privKey *ecdsa.PrivateKey
 	address address.Address
@@ -56,7 +56,7 @@ type signerGenPrivateKey struct {
 // SignerGenPrivateKey creates a new instance of signerGenPrivateKey with the provided private key.
 func SignerGenPrivateKey(privateKey string) (*signerGenPrivateKey, error) {
 	gen := &signerGenPrivateKey{
-		PrivateKey: privateKey,
+		privateKey: privateKey,
 	}
 
 	if err := gen.initialize(); err != nil {
@@ -69,7 +69,7 @@ func SignerGenPrivateKey(privateKey string) (*signerGenPrivateKey, error) {
 // initialize parses the private key and derives the TRON address.
 func (g *signerGenPrivateKey) initialize() error {
 	// Parse the hex-encoded private key string directly to *ecdsa.PrivateKey
-	privKey, err := crypto.HexToECDSA(g.PrivateKey)
+	privKey, err := crypto.HexToECDSA(g.privateKey)
 	if err != nil {
 		return fmt.Errorf("failed to parse private key: %w", err)
 	}


### PR DESCRIPTION
This changes all private key fields on the provider generators to be private.