### PR TITLE
chore(framework): standarize import aliases

### DIFF
--- a/chain/aptos/aptos_chain.go
+++ b/chain/aptos/aptos_chain.go
@@ -3,7 +3,7 @@ package aptos
 import (
 	aptoslib "github.com/aptos-labs/aptos-go-sdk"
 
-	chain_common "github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/common"
+	chaincommon "github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/common"
 )
 
 // Chain represents an Aptos chain.
@@ -27,15 +27,15 @@ func (c Chain) ChainSelector() uint64 {
 
 // String returns chain name and selector "<name> (<selector>)"
 func (c Chain) String() string {
-	return chain_common.ChainMetadata{Selector: c.Selector}.String()
+	return chaincommon.ChainMetadata{Selector: c.Selector}.String()
 }
 
 // Name returns the name of the chain
 func (c Chain) Name() string {
-	return chain_common.ChainMetadata{Selector: c.Selector}.Name()
+	return chaincommon.ChainMetadata{Selector: c.Selector}.Name()
 }
 
 // Family returns the family of the chain
 func (c Chain) Family() string {
-	return chain_common.ChainMetadata{Selector: c.Selector}.Family()
+	return chaincommon.ChainMetadata{Selector: c.Selector}.Family()
 }

--- a/chain/aptos/aptos_chain_test.go
+++ b/chain/aptos/aptos_chain_test.go
@@ -3,7 +3,7 @@ package aptos_test
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
@@ -21,10 +21,10 @@ func TestChain_ChainInfot(t *testing.T) {
 	}{
 		{
 			name:       "returns correct info",
-			selector:   chain_selectors.APTOS_MAINNET.Selector,
+			selector:   chainsel.APTOS_MAINNET.Selector,
 			wantString: "aptos-mainnet (4741433654826277614)",
-			wantName:   chain_selectors.APTOS_MAINNET.Name,
-			wantFamily: chain_selectors.FamilyAptos,
+			wantName:   chainsel.APTOS_MAINNET.Name,
+			wantFamily: chainsel.FamilyAptos,
 		},
 	}
 

--- a/chain/aptos/provider/ctf_provider.go
+++ b/chain/aptos/provider/ctf_provider.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	aptoslib "github.com/aptos-labs/aptos-go-sdk"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/freeport"
@@ -92,7 +92,7 @@ func (p *CTFChainProvider) Initialize(_ context.Context) (chain.BlockChain, erro
 	}
 
 	// Get the Aptos Chain ID
-	chainID, err := chain_selectors.GetChainIDFromSelector(p.selector)
+	chainID, err := chainsel.GetChainIDFromSelector(p.selector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain ID from selector %d: %w", p.selector, err)
 	}

--- a/chain/aptos/provider/ctf_provider_test.go
+++ b/chain/aptos/provider/ctf_provider_test.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -70,7 +70,7 @@ func Test_CTFChainProvider_Initialize(t *testing.T) {
 	}{
 		{
 			name:         "valid initialization",
-			giveSelector: chain_selectors.APTOS_LOCALNET.Selector,
+			giveSelector: chainsel.APTOS_LOCALNET.Selector,
 			giveConfig: CTFChainProviderConfig{
 				DeployerSignerGen: AccountGenCTFDefault(),
 				Once:              testutils.DefaultNetworkOnce,
@@ -78,7 +78,7 @@ func Test_CTFChainProvider_Initialize(t *testing.T) {
 		},
 		{
 			name:         "fails config validation",
-			giveSelector: chain_selectors.APTOS_LOCALNET.Selector,
+			giveSelector: chainsel.APTOS_LOCALNET.Selector,
 			giveConfig: CTFChainProviderConfig{
 				Once: testutils.DefaultNetworkOnce,
 			},
@@ -86,7 +86,7 @@ func Test_CTFChainProvider_Initialize(t *testing.T) {
 		},
 		{
 			name:         "fails to generate deployer account",
-			giveSelector: chain_selectors.APTOS_LOCALNET.Selector,
+			giveSelector: chainsel.APTOS_LOCALNET.Selector,
 			giveConfig: CTFChainProviderConfig{
 				DeployerSignerGen: AccountGenPrivateKey("invalid_private_key"),
 				Once:              testutils.DefaultNetworkOnce,
@@ -140,8 +140,8 @@ func Test_CTFChainProvider_Name(t *testing.T) {
 func Test_CTFChainProvider_ChainSelector(t *testing.T) {
 	t.Parallel()
 
-	p := &CTFChainProvider{selector: chain_selectors.APTOS_LOCALNET.Selector}
-	assert.Equal(t, chain_selectors.APTOS_LOCALNET.Selector, p.ChainSelector())
+	p := &CTFChainProvider{selector: chainsel.APTOS_LOCALNET.Selector}
+	assert.Equal(t, chainsel.APTOS_LOCALNET.Selector, p.ChainSelector())
 }
 
 func Test_CTFChainProvider_BlockChain(t *testing.T) {

--- a/chain/aptos/provider/rpc_provider.go
+++ b/chain/aptos/provider/rpc_provider.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	aptoslib "github.com/aptos-labs/aptos-go-sdk"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
@@ -79,7 +79,7 @@ func (p *RPCChainProvider) Initialize(_ context.Context) (chain.BlockChain, erro
 	}
 
 	// Initialize the Aptos client with the provided RPC URL and chain ID
-	chainIDStr, err := chain_selectors.GetChainIDFromSelector(p.selector)
+	chainIDStr, err := chainsel.GetChainIDFromSelector(p.selector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain ID from selector %d: %w", p.selector, err)
 	}

--- a/chain/aptos/provider/rpc_provider_test.go
+++ b/chain/aptos/provider/rpc_provider_test.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -68,7 +68,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 	}{
 		{
 			name:         "valid initialization",
-			giveSelector: chain_selectors.APTOS_LOCALNET.Selector,
+			giveSelector: chainsel.APTOS_LOCALNET.Selector,
 			giveConfig: RPCChainProviderConfig{
 				RPCURL:            "http://localhost:8080",
 				DeployerSignerGen: AccountGenPrivateKey(testPrivateKey),
@@ -76,7 +76,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 		},
 		{
 			name:         "fails config validation",
-			giveSelector: chain_selectors.APTOS_LOCALNET.Selector,
+			giveSelector: chainsel.APTOS_LOCALNET.Selector,
 			giveConfig: RPCChainProviderConfig{
 				RPCURL:            "",
 				DeployerSignerGen: AccountGenPrivateKey(testPrivateKey),
@@ -85,7 +85,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 		},
 		{
 			name:         "fails to generate deployer account",
-			giveSelector: chain_selectors.APTOS_LOCALNET.Selector,
+			giveSelector: chainsel.APTOS_LOCALNET.Selector,
 			giveConfig: RPCChainProviderConfig{
 				RPCURL:            "http://localhost:8080",
 				DeployerSignerGen: AccountGenPrivateKey("invalid_private_key"),
@@ -138,8 +138,8 @@ func Test_RPCChainProvider_Name(t *testing.T) {
 func Test_RPCChainProvider_ChainSelector(t *testing.T) {
 	t.Parallel()
 
-	p := &RPCChainProvider{selector: chain_selectors.APTOS_LOCALNET.Selector}
-	assert.Equal(t, chain_selectors.APTOS_LOCALNET.Selector, p.ChainSelector())
+	p := &RPCChainProvider{selector: chainsel.APTOS_LOCALNET.Selector}
+	assert.Equal(t, chainsel.APTOS_LOCALNET.Selector, p.ChainSelector())
 }
 
 func Test_RPCChainProvider_BlockChain(t *testing.T) {

--- a/chain/blockchain.go
+++ b/chain/blockchain.go
@@ -133,7 +133,7 @@ type chainSelectorsOptions struct {
 }
 
 // WithFamily returns an option to filter chains by family (evm, solana, aptos)
-// Use constants from chain_selectors package eg WithFamily(chain_selectors.FamilySolana)
+// Use constants from chainsel package eg WithFamily(chainsel.FamilySolana)
 // This can be used more than once to include multiple families.
 func WithFamily(family string) ChainSelectorsOption {
 	return func(o *chainSelectorsOptions) {
@@ -158,7 +158,7 @@ func WithChainSelectorsExclusion(chainSelectors []uint64) ChainSelectorsOption {
 
 // ListChainSelectors returns all chain selectors with optional filtering
 // Options:
-// - WithFamily: filter by family eg WithFamily(chain_selectors.FamilySolana)
+// - WithFamily: filter by family eg WithFamily(chainsel.FamilySolana)
 // - WithChainSelectorsExclusion: exclude specific chain selectors
 func (b BlockChains) ListChainSelectors(options ...ChainSelectorsOption) []uint64 {
 	opts := chainSelectorsOptions{}

--- a/chain/blockchain_test.go
+++ b/chain/blockchain_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
@@ -18,13 +18,13 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/tron"
 )
 
-var evmChain1 = evm.Chain{Selector: chain_selectors.TEST_90000001.Selector}
-var evmChain2 = evm.Chain{Selector: chain_selectors.TEST_90000002.Selector}
-var solanaChain1 = solana.Chain{Selector: chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector}
-var aptosChain1 = aptos.Chain{Selector: chain_selectors.APTOS_LOCALNET.Selector}
-var suiChain1 = sui.Chain{ChainMetadata: sui.ChainMetadata{Selector: chain_selectors.SUI_LOCALNET.Selector}}
-var tonChain1 = ton.Chain{ChainMetadata: ton.ChainMetadata{Selector: chain_selectors.TON_LOCALNET.Selector}}
-var tronChain1 = tron.Chain{ChainMetadata: tron.ChainMetadata{Selector: chain_selectors.TRON_MAINNET.Selector}}
+var evmChain1 = evm.Chain{Selector: chainsel.TEST_90000001.Selector}
+var evmChain2 = evm.Chain{Selector: chainsel.TEST_90000002.Selector}
+var solanaChain1 = solana.Chain{Selector: chainsel.TEST_22222222222222222222222222222222222222222222.Selector}
+var aptosChain1 = aptos.Chain{Selector: chainsel.APTOS_LOCALNET.Selector}
+var suiChain1 = sui.Chain{ChainMetadata: sui.ChainMetadata{Selector: chainsel.SUI_LOCALNET.Selector}}
+var tonChain1 = ton.Chain{ChainMetadata: ton.ChainMetadata{Selector: chainsel.TON_LOCALNET.Selector}}
+var tronChain1 = tron.Chain{ChainMetadata: tron.ChainMetadata{Selector: chainsel.TRON_MAINNET.Selector}}
 
 func TestNewBlockChains(t *testing.T) {
 	t.Parallel()
@@ -310,43 +310,43 @@ func TestBlockChainsListChainSelectors(t *testing.T) {
 		},
 		{
 			name:        "with family filter - EVM",
-			options:     []chain.ChainSelectorsOption{chain.WithFamily(chain_selectors.FamilyEVM)},
+			options:     []chain.ChainSelectorsOption{chain.WithFamily(chainsel.FamilyEVM)},
 			expectedIDs: []uint64{evmChain1.ChainSelector(), evmChain2.ChainSelector()},
 			description: "expected EVM chain selectors",
 		},
 		{
 			name:        "with family filter - Solana",
-			options:     []chain.ChainSelectorsOption{chain.WithFamily(chain_selectors.FamilySolana)},
+			options:     []chain.ChainSelectorsOption{chain.WithFamily(chainsel.FamilySolana)},
 			expectedIDs: []uint64{solanaChain1.Selector},
 			description: "expected Solana chain selectors",
 		},
 		{
 			name:        "with family filter - Aptos",
-			options:     []chain.ChainSelectorsOption{chain.WithFamily(chain_selectors.FamilyAptos)},
+			options:     []chain.ChainSelectorsOption{chain.WithFamily(chainsel.FamilyAptos)},
 			expectedIDs: []uint64{aptosChain1.Selector},
 			description: "expected Aptos chain selectors",
 		},
 		{
 			name:        "with family filter - Sui",
-			options:     []chain.ChainSelectorsOption{chain.WithFamily(chain_selectors.FamilySui)},
+			options:     []chain.ChainSelectorsOption{chain.WithFamily(chainsel.FamilySui)},
 			expectedIDs: []uint64{suiChain1.Selector},
 			description: "expected Sui chain selectors",
 		},
 		{
 			name:        "with family filter - Ton",
-			options:     []chain.ChainSelectorsOption{chain.WithFamily(chain_selectors.FamilyTon)},
+			options:     []chain.ChainSelectorsOption{chain.WithFamily(chainsel.FamilyTon)},
 			expectedIDs: []uint64{tonChain1.Selector},
 			description: "expected Ton chain selectors",
 		},
 		{
 			name:        "with family filter - Tron",
-			options:     []chain.ChainSelectorsOption{chain.WithFamily(chain_selectors.FamilyTron)},
+			options:     []chain.ChainSelectorsOption{chain.WithFamily(chainsel.FamilyTron)},
 			expectedIDs: []uint64{tronChain1.Selector},
 			description: "expected Tron chain selectors",
 		},
 		{
 			name:        "with multiple families",
-			options:     []chain.ChainSelectorsOption{chain.WithFamily(chain_selectors.FamilyEVM), chain.WithFamily(chain_selectors.FamilySolana)},
+			options:     []chain.ChainSelectorsOption{chain.WithFamily(chainsel.FamilyEVM), chain.WithFamily(chainsel.FamilySolana)},
 			expectedIDs: []uint64{evmChain1.Selector, evmChain2.Selector, solanaChain1.Selector},
 			description: "expected EVM and Solana chain selectors",
 		},
@@ -361,7 +361,7 @@ func TestBlockChainsListChainSelectors(t *testing.T) {
 		{
 			name: "with family and exclusion",
 			options: []chain.ChainSelectorsOption{
-				chain.WithFamily(chain_selectors.FamilyEVM),
+				chain.WithFamily(chainsel.FamilyEVM),
 				chain.WithChainSelectorsExclusion([]uint64{evmChain1.Selector}),
 			},
 			expectedIDs: []uint64{evmChain2.Selector},

--- a/chain/evm/evm_chain.go
+++ b/chain/evm/evm_chain.go
@@ -10,7 +10,7 @@ import (
 	"github.com/zksync-sdk/zksync2-go/accounts"
 	"github.com/zksync-sdk/zksync2-go/clients"
 
-	chain_common "github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/common"
+	chaincommon "github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/common"
 )
 
 // ConfirmFunc is a function that takes a transaction, waits for the transaction to be confirmed,
@@ -59,15 +59,15 @@ func (c Chain) ChainSelector() uint64 {
 
 // String returns chain name and selector "<name> (<selector>)"
 func (c Chain) String() string {
-	return chain_common.ChainMetadata{Selector: c.Selector}.String()
+	return chaincommon.ChainMetadata{Selector: c.Selector}.String()
 }
 
 // Name returns the name of the chain
 func (c Chain) Name() string {
-	return chain_common.ChainMetadata{Selector: c.Selector}.Name()
+	return chaincommon.ChainMetadata{Selector: c.Selector}.Name()
 }
 
 // Family returns the family of the chain
 func (c Chain) Family() string {
-	return chain_common.ChainMetadata{Selector: c.Selector}.Family()
+	return chaincommon.ChainMetadata{Selector: c.Selector}.Family()
 }

--- a/chain/evm/evm_chain_test.go
+++ b/chain/evm/evm_chain_test.go
@@ -3,7 +3,7 @@ package evm_test
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
@@ -21,10 +21,10 @@ func TestChain_ChainInfo(t *testing.T) {
 	}{
 		{
 			name:       "returns correct info",
-			selector:   chain_selectors.ETHEREUM_MAINNET.Selector,
+			selector:   chainsel.ETHEREUM_MAINNET.Selector,
 			wantString: "ethereum-mainnet (5009297550715157269)",
-			wantName:   chain_selectors.ETHEREUM_MAINNET.Name,
-			wantFamily: chain_selectors.FamilyEVM,
+			wantName:   chainsel.ETHEREUM_MAINNET.Name,
+			wantFamily: chainsel.FamilyEVM,
 		},
 	}
 

--- a/chain/evm/provider/confirm_functor.go
+++ b/chain/evm/provider/confirm_functor.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider/rpcclient"
@@ -119,7 +119,7 @@ func (g *confirmFuncSeth) Generate(
 	}
 
 	// Get the ChainID from the selector
-	chainIDStr, err := chain_selectors.GetChainIDFromSelector(selector)
+	chainIDStr, err := chainsel.GetChainIDFromSelector(selector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain ID from selector %d: %w", selector, err)
 	}

--- a/chain/evm/provider/confirm_functor_test.go
+++ b/chain/evm/provider/confirm_functor_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient/simulated"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
@@ -123,7 +123,7 @@ func Test_ConfirmFuncGeth_ConfirmFunc(t *testing.T) {
 			// Generate the confirm function
 			functor := ConfirmFuncGeth(1 * time.Second)
 			confirmFunc, err := functor.Generate(
-				t.Context(), chain_selectors.TEST_1000.Selector, client, adminTransactor.From,
+				t.Context(), chainsel.TEST_1000.Selector, client, adminTransactor.From,
 			)
 			require.NoError(t, err)
 
@@ -145,7 +145,7 @@ func Test_ConfirmFuncSeth_Generate(t *testing.T) {
 	rpcSrv := newFakeRPCServer(t)
 
 	var (
-		chainSelector = chain_selectors.TEST_1000.Selector
+		chainSelector = chainsel.TEST_1000.Selector
 		rpcURL        = rpcSrv.URL
 		fromAddr      = common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
 

--- a/chain/evm/provider/ctf_anvil_provider.go
+++ b/chain/evm/provider/ctf_anvil_provider.go
@@ -217,7 +217,7 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/crypto"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
@@ -372,7 +372,7 @@ func (p *CTFAnvilChainProvider) Initialize(ctx context.Context) (chain.BlockChai
 		return nil, err
 	}
 
-	chainID, err := chain_selectors.GetChainIDFromSelector(p.selector)
+	chainID, err := chainsel.GetChainIDFromSelector(p.selector)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/evm/provider/rpc_provider.go
+++ b/chain/evm/provider/rpc_provider.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
@@ -96,7 +96,7 @@ func (p *RPCChainProvider) Initialize(ctx context.Context) (chain.BlockChain, er
 	}
 
 	// Get the Chain ID
-	chainIDStr, err := chain_selectors.GetChainIDFromSelector(p.selector)
+	chainIDStr, err := chainsel.GetChainIDFromSelector(p.selector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain ID from selector %d: %w", p.selector, err)
 	}

--- a/chain/evm/provider/rpc_provider_test.go
+++ b/chain/evm/provider/rpc_provider_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -81,7 +81,7 @@ func Test_RPCChainProviderConfig_validate(t *testing.T) {
 //nolint:paralleltest // This test cannot run in parallel due to a race condition in seth's log initialization
 func Test_RPCChainProvider_Initialize(t *testing.T) {
 	var (
-		chainSelector = chain_selectors.TEST_1000.Selector
+		chainSelector = chainsel.TEST_1000.Selector
 		existingChain = &evm.Chain{}
 		configPath    = writeSethConfigFile(t)
 	)
@@ -261,8 +261,8 @@ func Test_RPCChainProvider_Name(t *testing.T) {
 func Test_RPCChainProvider_ChainSelector(t *testing.T) {
 	t.Parallel()
 
-	p := &RPCChainProvider{selector: chain_selectors.TEST_1000.Selector}
-	assert.Equal(t, chain_selectors.TEST_1000.Selector, p.ChainSelector())
+	p := &RPCChainProvider{selector: chainsel.TEST_1000.Selector}
+	assert.Equal(t, chainsel.TEST_1000.Selector, p.ChainSelector())
 }
 
 func Test_RPCChainProvider_BlockChain(t *testing.T) {

--- a/chain/evm/provider/seth_client_test.go
+++ b/chain/evm/provider/seth_client_test.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -11,7 +11,7 @@ import (
 //nolint:paralleltest // This test cannot run in parallel due to a race condition in seth's log initialization
 func Test_newSethClient(t *testing.T) {
 	var (
-		chainID    = chain_selectors.TEST_1000.EvmChainID
+		chainID    = chainsel.TEST_1000.EvmChainID
 		configPath = writeSethConfigFile(t)
 	)
 

--- a/chain/evm/provider/sim_provider_test.go
+++ b/chain/evm/provider/sim_provider_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -15,7 +15,7 @@ func Test_SimChainProvider_Initialize(t *testing.T) {
 	t.Parallel()
 
 	var (
-		chainSelector = chain_selectors.TEST_1000.Selector
+		chainSelector = chainsel.TEST_1000.Selector
 		existingChain = &evm.Chain{}
 	)
 
@@ -111,8 +111,8 @@ func Test_SimChainProvider_Name(t *testing.T) {
 func Test_SimChainProvider_ChainSelector(t *testing.T) {
 	t.Parallel()
 
-	p := &SimChainProvider{selector: chain_selectors.TEST_1000.Selector}
-	assert.Equal(t, chain_selectors.TEST_1000.Selector, p.ChainSelector())
+	p := &SimChainProvider{selector: chainsel.TEST_1000.Selector}
+	assert.Equal(t, chainsel.TEST_1000.Selector, p.ChainSelector())
 }
 
 func Test_SimChainProvider_BlockChain(t *testing.T) {

--- a/chain/evm/provider/testdata_test.go
+++ b/chain/evm/provider/testdata_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/kms"
@@ -23,8 +23,8 @@ var (
 
 // Defines standard variables for a test chain.
 var (
-	testChainID    = chain_selectors.TEST_1000.EvmChainID // Defines a standard test EVM chain ID
-	testChainIDBig = new(big.Int).SetUint64(testChainID)  // Defines the testChainID in *big.Int format
+	testChainID    = chainsel.TEST_1000.EvmChainID       // Defines a standard test EVM chain ID
+	testChainIDBig = new(big.Int).SetUint64(testChainID) // Defines the testChainID in *big.Int format
 )
 
 // Variables used for testing the KMS provider.

--- a/chain/evm/provider/zksync_ctf_provider.go
+++ b/chain/evm/provider/zksync_ctf_provider.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/freeport"
@@ -89,7 +89,7 @@ func (p *ZkSyncCTFChainProvider) Initialize(ctx context.Context) (chain.BlockCha
 	require.NoError(p.t, err, "failed to validate provider config")
 
 	// Get the Chain ID
-	chainID, err := chain_selectors.GetChainIDFromSelector(p.selector)
+	chainID, err := chainsel.GetChainIDFromSelector(p.selector)
 	require.NoError(p.t, err, "failed to get chain ID from selector")
 
 	// Start the Zksync CTF container

--- a/chain/evm/provider/zksync_ctf_provider_test.go
+++ b/chain/evm/provider/zksync_ctf_provider_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/testutils"
@@ -54,7 +54,7 @@ func Test_ZkSyncCTFChainProviderConfig_validate(t *testing.T) {
 func Test_CTFChainProvider_Initialize(t *testing.T) {
 	t.Parallel()
 
-	var chainSelector = chain_selectors.TEST_1000.Selector
+	var chainSelector = chainsel.TEST_1000.Selector
 
 	tests := []struct {
 		name         string
@@ -111,8 +111,8 @@ func Test_ZkSyncCTFChainProvider_Name(t *testing.T) {
 func Test_ZkSyncCTFChainProvider_ChainSelector(t *testing.T) {
 	t.Parallel()
 
-	p := &ZkSyncCTFChainProvider{selector: chain_selectors.TEST_1000.Selector}
-	assert.Equal(t, chain_selectors.TEST_1000.Selector, p.ChainSelector())
+	p := &ZkSyncCTFChainProvider{selector: chainsel.TEST_1000.Selector}
+	assert.Equal(t, chainsel.TEST_1000.Selector, p.ChainSelector())
 }
 
 func Test_ZkSyncCTFChainProvider_BlockChain(t *testing.T) {
@@ -130,7 +130,7 @@ func Test_ZkSyncCTFChainProvider_BlockChain(t *testing.T) {
 func Test_ZkSyncCTFChainProvider_SignHash(t *testing.T) {
 	t.Parallel()
 
-	var chainSelector = chain_selectors.TEST_1000.Selector
+	var chainSelector = chainsel.TEST_1000.Selector
 
 	p := NewZkSyncCTFChainProvider(t, chainSelector, ZkSyncCTFChainProviderConfig{
 		Once: testutils.DefaultNetworkOnce,

--- a/chain/evm/provider/zksync_rpc_provider.go
+++ b/chain/evm/provider/zksync_rpc_provider.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"math/big"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	zkAccounts "github.com/zksync-sdk/zksync2-go/accounts"
 	zkClients "github.com/zksync-sdk/zksync2-go/clients"
@@ -107,7 +107,7 @@ func (p *ZkSyncRPCChainProvider) Initialize(ctx context.Context) (chain.BlockCha
 	}
 
 	// Get the Chain ID
-	chainIDStr, err := chain_selectors.GetChainIDFromSelector(p.selector)
+	chainIDStr, err := chainsel.GetChainIDFromSelector(p.selector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain ID from selector %d: %w", p.selector, err)
 	}

--- a/chain/evm/provider/zksync_rpc_provider_test.go
+++ b/chain/evm/provider/zksync_rpc_provider_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -94,7 +94,7 @@ func Test_ZkSyncRPCChainProviderConfig_validate(t *testing.T) {
 //nolint:paralleltest // This test cannot run in parallel due to a race condition in seth's log initialization
 func Test_ZkSyncRPCChainProvider_Initialize(t *testing.T) {
 	var (
-		chainSelector = chain_selectors.TEST_1000.Selector
+		chainSelector = chainsel.TEST_1000.Selector
 		existingChain = &evm.Chain{}
 		configPath    = writeSethConfigFile(t)
 	)
@@ -279,8 +279,8 @@ func Test_ZkSyncRPCChainProvider_Name(t *testing.T) {
 func Test_ZkSyncRPCChainProvider_ChainSelector(t *testing.T) {
 	t.Parallel()
 
-	p := &ZkSyncRPCChainProvider{selector: chain_selectors.TEST_1000.Selector}
-	assert.Equal(t, chain_selectors.TEST_1000.Selector, p.ChainSelector())
+	p := &ZkSyncRPCChainProvider{selector: chainsel.TEST_1000.Selector}
+	assert.Equal(t, chainsel.TEST_1000.Selector, p.ChainSelector())
 }
 
 func Test_ZkSyncRPCChainProvider_BlockChain(t *testing.T) {

--- a/chain/internal/common/chain_metadata.go
+++ b/chain/internal/common/chain_metadata.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/utils"
 )
@@ -44,7 +44,7 @@ func (c ChainMetadata) Name() string {
 
 // Family returns the family of the chain
 func (c ChainMetadata) Family() string {
-	family, err := chain_selectors.GetSelectorFamily(c.Selector)
+	family, err := chainsel.GetSelectorFamily(c.Selector)
 	if err != nil {
 		return ""
 	}

--- a/chain/internal/common/chain_metadata_test.go
+++ b/chain/internal/common/chain_metadata_test.go
@@ -3,7 +3,7 @@ package common_test
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/common"
@@ -21,10 +21,10 @@ func TestChainMetadata(t *testing.T) {
 	}{
 		{
 			name:       "returns correct info",
-			selector:   chain_selectors.ETHEREUM_MAINNET.Selector,
+			selector:   chainsel.ETHEREUM_MAINNET.Selector,
 			wantString: "ethereum-mainnet (5009297550715157269)",
-			wantName:   chain_selectors.ETHEREUM_MAINNET.Name,
-			wantFamily: chain_selectors.FamilyEVM,
+			wantName:   chainsel.ETHEREUM_MAINNET.Name,
+			wantFamily: chainsel.FamilyEVM,
 		},
 		{
 			name:       "returns empty for unknown chain",

--- a/chain/solana/provider/ctf_provider.go
+++ b/chain/solana/provider/ctf_provider.go
@@ -14,7 +14,7 @@ import (
 	"github.com/avast/retry-go/v4"
 	sollib "github.com/gagliardetto/solana-go"
 	solrpc "github.com/gagliardetto/solana-go/rpc"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	solCommonUtil "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
@@ -109,7 +109,7 @@ func (p *CTFChainProvider) Initialize(_ context.Context) (chain.BlockChain, erro
 	}
 
 	// Get the Solana Chain ID
-	chainID, err := chain_selectors.GetChainIDFromSelector(p.selector)
+	chainID, err := chainsel.GetChainIDFromSelector(p.selector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain ID from selector %d: %w", p.selector, err)
 	}

--- a/chain/solana/provider/ctf_provider_test.go
+++ b/chain/solana/provider/ctf_provider_test.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -82,7 +82,7 @@ func Test_CTFChainProvider_Initialize(t *testing.T) {
 	t.Parallel()
 
 	var (
-		chainSelector = chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector
+		chainSelector = chainsel.TEST_22222222222222222222222222222222222222222222.Selector
 		existingChain = &solana.Chain{}
 	)
 
@@ -190,8 +190,8 @@ func Test_CTFChainProvider_Name(t *testing.T) {
 func Test_CTFChainProvider_ChainSelector(t *testing.T) {
 	t.Parallel()
 
-	p := &CTFChainProvider{selector: chain_selectors.SOLANA_DEVNET.Selector}
-	assert.Equal(t, chain_selectors.SOLANA_DEVNET.Selector, p.ChainSelector())
+	p := &CTFChainProvider{selector: chainsel.SOLANA_DEVNET.Selector}
+	assert.Equal(t, chainsel.SOLANA_DEVNET.Selector, p.ChainSelector())
 }
 
 func Test_CTFChainProvider_BlockChain(t *testing.T) {

--- a/chain/solana/provider/rpc_provider_test.go
+++ b/chain/solana/provider/rpc_provider_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -104,7 +104,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 	t.Parallel()
 
 	var (
-		chainSelector = chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector
+		chainSelector = chainsel.TEST_22222222222222222222222222222222222222222222.Selector
 		existingChain = &solana.Chain{}
 	)
 
@@ -248,8 +248,8 @@ func Test_RPCChainProvider_Name(t *testing.T) {
 func Test_RPCChainProvider_ChainSelector(t *testing.T) {
 	t.Parallel()
 
-	p := &RPCChainProvider{selector: chain_selectors.SOLANA_DEVNET.Selector}
-	assert.Equal(t, chain_selectors.SOLANA_DEVNET.Selector, p.ChainSelector())
+	p := &RPCChainProvider{selector: chainsel.SOLANA_DEVNET.Selector}
+	assert.Equal(t, chainsel.SOLANA_DEVNET.Selector, p.ChainSelector())
 }
 
 func Test_RPCChainProvider_BlockChain(t *testing.T) {

--- a/chain/solana/provider/rpcclient/client_test.go
+++ b/chain/solana/provider/rpcclient/client_test.go
@@ -11,7 +11,7 @@ import (
 	sollib "github.com/gagliardetto/solana-go"
 	solsystem "github.com/gagliardetto/solana-go/programs/system"
 	solrpc "github.com/gagliardetto/solana-go/rpc"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/freeport"
@@ -25,7 +25,7 @@ func Test_Client_SendAndConfirmTx(t *testing.T) {
 	t.Parallel()
 
 	var (
-		chainID = chain_selectors.TEST_22222222222222222222222222222222222222222222.ChainID
+		chainID = chainsel.TEST_22222222222222222222222222222222222222222222.ChainID
 	)
 	// The admin key is a private key assigned as the token mint authority
 	minterKey, err := sollib.NewRandomPrivateKey()

--- a/chain/solana/solana_chain_test.go
+++ b/chain/solana/solana_chain_test.go
@@ -3,7 +3,7 @@ package solana_test
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
@@ -21,10 +21,10 @@ func TestChain_ChainInfot(t *testing.T) {
 	}{
 		{
 			name:       "returns correct info",
-			selector:   chain_selectors.SOLANA_MAINNET.Selector,
+			selector:   chainsel.SOLANA_MAINNET.Selector,
 			wantString: "solana-mainnet (124615329519749607)",
-			wantName:   chain_selectors.SOLANA_MAINNET.Name,
-			wantFamily: chain_selectors.FamilySolana,
+			wantName:   chainsel.SOLANA_MAINNET.Name,
+			wantFamily: chainsel.FamilySolana,
 		},
 	}
 

--- a/chain/sui/provider/ctf_provider.go
+++ b/chain/sui/provider/ctf_provider.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	sui_sdk "github.com/block-vision/sui-go-sdk/sui"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/freeport"
@@ -102,7 +102,7 @@ func (p *CTFChainProvider) Initialize(_ context.Context) (chain.BlockChain, erro
 	}
 
 	// Get the Sui Chain ID
-	chainID, err := chain_selectors.GetChainIDFromSelector(p.selector)
+	chainID, err := chainsel.GetChainIDFromSelector(p.selector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain ID from selector %d: %w", p.selector, err)
 	}

--- a/chain/sui/provider/ctf_provider_test.go
+++ b/chain/sui/provider/ctf_provider_test.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -71,7 +71,7 @@ func Test_CTFChainProvider_Initialize(t *testing.T) {
 	}{
 		{
 			name:         "valid initialization",
-			giveSelector: chain_selectors.SUI_LOCALNET.Selector,
+			giveSelector: chainsel.SUI_LOCALNET.Selector,
 			giveConfig: CTFChainProviderConfig{
 				DeployerSignerGen: AccountGenPrivateKey(testPrivateKey),
 				Once:              testutils.DefaultNetworkOnce,
@@ -79,7 +79,7 @@ func Test_CTFChainProvider_Initialize(t *testing.T) {
 		},
 		{
 			name:         "fails config validation",
-			giveSelector: chain_selectors.SUI_LOCALNET.Selector,
+			giveSelector: chainsel.SUI_LOCALNET.Selector,
 			giveConfig: CTFChainProviderConfig{
 				Once: testutils.DefaultNetworkOnce,
 			},
@@ -87,7 +87,7 @@ func Test_CTFChainProvider_Initialize(t *testing.T) {
 		},
 		{
 			name:         "fails to generate deployer account",
-			giveSelector: chain_selectors.SUI_LOCALNET.Selector,
+			giveSelector: chainsel.SUI_LOCALNET.Selector,
 			giveConfig: CTFChainProviderConfig{
 				DeployerSignerGen: AccountGenPrivateKey("invalid_private_key"),
 				Once:              testutils.DefaultNetworkOnce,
@@ -140,8 +140,8 @@ func Test_CTFChainProvider_Name(t *testing.T) {
 func Test_CTFChainProvider_ChainSelector(t *testing.T) {
 	t.Parallel()
 
-	p := &CTFChainProvider{selector: chain_selectors.SUI_LOCALNET.Selector}
-	assert.Equal(t, chain_selectors.SUI_LOCALNET.Selector, p.ChainSelector())
+	p := &CTFChainProvider{selector: chainsel.SUI_LOCALNET.Selector}
+	assert.Equal(t, chainsel.SUI_LOCALNET.Selector, p.ChainSelector())
 }
 
 func Test_CTFChainProvider_BlockChain(t *testing.T) {

--- a/chain/sui/provider/rpc_provider.go
+++ b/chain/sui/provider/rpc_provider.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	sui_sdk "github.com/block-vision/sui-go-sdk/sui"
+	suisdk "github.com/block-vision/sui-go-sdk/sui"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/sui"
@@ -77,12 +77,12 @@ func (p *RPCChainProvider) Initialize(_ context.Context) (chain.BlockChain, erro
 	}
 
 	// Validate that the chain selector is known
-	_, err = chain_selectors.GetChainIDFromSelector(p.selector)
+	_, err = chainsel.GetChainIDFromSelector(p.selector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain ID from selector %d: %w", p.selector, err)
 	}
 
-	client := sui_sdk.NewSuiClient(p.config.RPCURL)
+	client := suisdk.NewSuiClient(p.config.RPCURL)
 
 	p.chain = &sui.Chain{
 		ChainMetadata: sui.ChainMetadata{

--- a/chain/sui/provider/rpc_provider_test.go
+++ b/chain/sui/provider/rpc_provider_test.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -68,7 +68,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 	}{
 		{
 			name:         "valid initialization",
-			giveSelector: chain_selectors.SUI_LOCALNET.Selector,
+			giveSelector: chainsel.SUI_LOCALNET.Selector,
 			giveConfig: RPCChainProviderConfig{
 				RPCURL:            "http://localhost:9000",
 				DeployerSignerGen: AccountGenPrivateKey(testPrivateKey),
@@ -76,7 +76,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 		},
 		{
 			name:         "fails config validation",
-			giveSelector: chain_selectors.SUI_LOCALNET.Selector,
+			giveSelector: chainsel.SUI_LOCALNET.Selector,
 			giveConfig: RPCChainProviderConfig{
 				RPCURL:            "",
 				DeployerSignerGen: AccountGenPrivateKey(testPrivateKey),
@@ -85,7 +85,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 		},
 		{
 			name:         "fails to generate deployer account",
-			giveSelector: chain_selectors.SUI_LOCALNET.Selector,
+			giveSelector: chainsel.SUI_LOCALNET.Selector,
 			giveConfig: RPCChainProviderConfig{
 				RPCURL:            "http://localhost:9000",
 				DeployerSignerGen: AccountGenPrivateKey("invalid_private_key"),
@@ -137,8 +137,8 @@ func Test_RPCChainProvider_Name(t *testing.T) {
 func Test_RPCChainProvider_ChainSelector(t *testing.T) {
 	t.Parallel()
 
-	p := &RPCChainProvider{selector: chain_selectors.SUI_LOCALNET.Selector}
-	assert.Equal(t, chain_selectors.SUI_LOCALNET.Selector, p.ChainSelector())
+	p := &RPCChainProvider{selector: chainsel.SUI_LOCALNET.Selector}
+	assert.Equal(t, chainsel.SUI_LOCALNET.Selector, p.ChainSelector())
 }
 
 func Test_RPCChainProvider_BlockChain(t *testing.T) {

--- a/chain/sui/sui_chain_test.go
+++ b/chain/sui/sui_chain_test.go
@@ -3,7 +3,7 @@ package sui_test
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/sui"
@@ -21,10 +21,10 @@ func TestChain_ChainInfot(t *testing.T) {
 	}{
 		{
 			name:       "returns correct info",
-			selector:   chain_selectors.SUI_MAINNET.Selector,
+			selector:   chainsel.SUI_MAINNET.Selector,
 			wantString: "sui-mainnet (17529533435026248318)",
-			wantName:   chain_selectors.SUI_MAINNET.Name,
-			wantFamily: chain_selectors.FamilySui,
+			wantName:   chainsel.SUI_MAINNET.Name,
+			wantFamily: chainsel.FamilySui,
 		},
 	}
 

--- a/chain/ton/provider/ctf_provider.go
+++ b/chain/ton/provider/ctf_provider.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/freeport"
@@ -84,7 +84,7 @@ func (p *CTFChainProvider) Initialize(_ context.Context) (chain.BlockChain, erro
 	}
 
 	// Get the Chain ID
-	chainID, err := chain_selectors.GetChainIDFromSelector(p.selector)
+	chainID, err := chainsel.GetChainIDFromSelector(p.selector)
 	require.NoError(p.t, err, "failed to get chain ID from selector")
 
 	url, nodeClient := p.startContainer(chainID)

--- a/chain/ton/provider/ctf_provider_test.go
+++ b/chain/ton/provider/ctf_provider_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/testutils"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/ton"
@@ -53,7 +53,7 @@ func Test_CTFChainProviderConfig_validate(t *testing.T) {
 func Test_CTFChainProvider_Initialize(t *testing.T) {
 	t.Parallel()
 
-	var chainSelector = chain_selectors.TEST_1000.Selector
+	var chainSelector = chainsel.TEST_1000.Selector
 
 	tests := []struct {
 		name         string
@@ -105,8 +105,8 @@ func Test_CTFChainProvider_Name(t *testing.T) {
 func Test_CTFChainProvider_ChainSelector(t *testing.T) {
 	t.Parallel()
 
-	p := &CTFChainProvider{selector: chain_selectors.TEST_1000.Selector}
-	assert.Equal(t, chain_selectors.TEST_1000.Selector, p.ChainSelector())
+	p := &CTFChainProvider{selector: chainsel.TEST_1000.Selector}
+	assert.Equal(t, chainsel.TEST_1000.Selector, p.ChainSelector())
 }
 
 func Test_CTFChainProvider_BlockChain(t *testing.T) {

--- a/chain/ton/ton_chain_test.go
+++ b/chain/ton/ton_chain_test.go
@@ -3,7 +3,7 @@ package ton_test
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/ton"
@@ -21,10 +21,10 @@ func TestChain_ChainInfot(t *testing.T) {
 	}{
 		{
 			name:       "returns correct info",
-			selector:   chain_selectors.TON_MAINNET.Selector,
+			selector:   chainsel.TON_MAINNET.Selector,
 			wantString: "ton-mainnet (16448340667252469081)",
-			wantName:   chain_selectors.TON_MAINNET.Name,
-			wantFamily: chain_selectors.FamilyTon,
+			wantName:   chainsel.TON_MAINNET.Name,
+			wantFamily: chainsel.FamilyTon,
 		},
 	}
 

--- a/chain/tron/provider/ctf_provider.go
+++ b/chain/tron/provider/ctf_provider.go
@@ -15,7 +15,7 @@ import (
 	"github.com/fbsobreira/gotron-sdk/pkg/address"
 	"github.com/fbsobreira/gotron-sdk/pkg/http/common"
 	"github.com/fbsobreira/gotron-sdk/pkg/http/soliditynode"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/chainlink-tron/relayer/sdk"
@@ -97,7 +97,7 @@ func (p *CTFChainProvider) Initialize(_ context.Context) (chain.BlockChain, erro
 	}
 
 	// Get the TRON Chain ID
-	chainID, err := chain_selectors.GetChainIDFromSelector(p.selector)
+	chainID, err := chainsel.GetChainIDFromSelector(p.selector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get chain ID from selector %d: %w", p.selector, err)
 	}

--- a/chain/tron/provider/ctf_provider_test.go
+++ b/chain/tron/provider/ctf_provider_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/fbsobreira/gotron-sdk/pkg/address"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -98,7 +98,7 @@ func TestCTFChainProvider_Initialize(t *testing.T) {
 	}{
 		{
 			name:         "valid initialization",
-			giveSelector: chain_selectors.TRON_TESTNET_NILE.Selector,
+			giveSelector: chainsel.TRON_TESTNET_NILE.Selector,
 			giveConfig: func() CTFChainProviderConfig {
 				signerGen, err := SignerGenCTFDefault()
 				require.NoError(t, err)
@@ -111,7 +111,7 @@ func TestCTFChainProvider_Initialize(t *testing.T) {
 		},
 		{
 			name:         "fails config validation",
-			giveSelector: chain_selectors.TRON_TESTNET_NILE.Selector,
+			giveSelector: chainsel.TRON_TESTNET_NILE.Selector,
 			giveConfig: CTFChainProviderConfig{
 				Once: &sync.Once{},
 			},
@@ -119,7 +119,7 @@ func TestCTFChainProvider_Initialize(t *testing.T) {
 		},
 		{
 			name:         "missing sync.Once",
-			giveSelector: chain_selectors.TRON_TESTNET_NILE.Selector,
+			giveSelector: chainsel.TRON_TESTNET_NILE.Selector,
 			giveConfig: func() CTFChainProviderConfig {
 				signerGen, err := SignerGenCTFDefault()
 				require.NoError(t, err)
@@ -186,9 +186,9 @@ func TestCTFChainProvider_ContainerStartup(t *testing.T) {
 		Once:              &sync.Once{},
 	}
 
-	provider := NewCTFChainProvider(t, chain_selectors.TRON_TESTNET_NILE.Selector, config)
+	provider := NewCTFChainProvider(t, chainsel.TRON_TESTNET_NILE.Selector, config)
 
-	chainID, err := chain_selectors.GetChainIDFromSelector(chain_selectors.TRON_MAINNET.Selector)
+	chainID, err := chainsel.GetChainIDFromSelector(chainsel.TRON_MAINNET.Selector)
 	require.NoError(t, err)
 	fullNodeURL, solidityNodeURL := provider.startContainer(chainID)
 	require.NotEmpty(t, fullNodeURL)
@@ -208,7 +208,7 @@ func TestCTFProvider_SendAndConfirmTx_And_CheckContractDeployed(t *testing.T) {
 		Once:              &sync.Once{},
 	}
 
-	chainSelector := chain_selectors.TRON_TESTNET_NILE.Selector
+	chainSelector := chainsel.TRON_TESTNET_NILE.Selector
 
 	// Create and initialize the CTF provider
 	ctfProvider := NewCTFChainProvider(t, chainSelector, config)
@@ -333,8 +333,8 @@ func Test_CTFChainProvider_Name(t *testing.T) {
 func Test_CTFChainProvider_ChainSelector(t *testing.T) {
 	t.Parallel()
 
-	p := CTFChainProvider{selector: chain_selectors.TRON_MAINNET.Selector}
-	assert.Equal(t, chain_selectors.TRON_MAINNET.Selector, p.ChainSelector())
+	p := CTFChainProvider{selector: chainsel.TRON_MAINNET.Selector}
+	assert.Equal(t, chainsel.TRON_MAINNET.Selector, p.ChainSelector())
 }
 
 func Test_CTFChainProvider_BlockChain(t *testing.T) {

--- a/chain/tron/provider/rpc_provider_test.go
+++ b/chain/tron/provider/rpc_provider_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	"github.com/fbsobreira/gotron-sdk/pkg/address"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/freeport"
 	"github.com/stretchr/testify/assert"
@@ -78,7 +78,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 	t.Parallel()
 
 	var (
-		chainSelector = chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector
+		chainSelector = chainsel.TEST_22222222222222222222222222222222222222222222.Selector
 		existingChain = &tron.Chain{}
 	)
 
@@ -193,8 +193,8 @@ func Test_RPCChainProvider_Name(t *testing.T) {
 func Test_RPCChainProvider_ChainSelector(t *testing.T) {
 	t.Parallel()
 
-	p := RPCChainProvider{selector: chain_selectors.TRON_MAINNET.Selector}
-	assert.Equal(t, chain_selectors.TRON_MAINNET.Selector, p.ChainSelector())
+	p := RPCChainProvider{selector: chainsel.TRON_MAINNET.Selector}
+	assert.Equal(t, chainsel.TRON_MAINNET.Selector, p.ChainSelector())
 }
 
 func Test_RPCChainProvider_BlockChain(t *testing.T) {
@@ -356,7 +356,7 @@ func setupLocalStack(t *testing.T) *tron.Chain {
 
 	t.Logf("TRON node config: fullNodeUrl=%s, solidityNodeUrl=%s", fullNodeUrl, solidityNodeUrl)
 
-	chainSelector := chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector
+	chainSelector := chainsel.TEST_22222222222222222222222222222222222222222222.Selector
 	signerGenerator, err := SignerGenPrivateKey(blockchain.TRONAccounts.PrivateKeys[0])
 	require.NoError(t, err)
 

--- a/chain/tron/tron_chain.go
+++ b/chain/tron/tron_chain.go
@@ -9,11 +9,11 @@ import (
 	"github.com/fbsobreira/gotron-sdk/pkg/http/soliditynode"
 	"github.com/smartcontractkit/chainlink-tron/relayer/sdk"
 
-	cld_common "github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/common"
+	chaincommon "github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/common"
 )
 
 // ChainMetadata = generic metadata from the framework
-type ChainMetadata = cld_common.ChainMetadata
+type ChainMetadata = chaincommon.ChainMetadata
 
 type ConfirmRetryOptions struct {
 	RetryAttempts uint          // Max number of retries for confirming a transaction.

--- a/chain/tron/tron_chain_test.go
+++ b/chain/tron/tron_chain_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/tron"
@@ -22,10 +22,10 @@ func TestChain_ChainInfo(t *testing.T) {
 	}{
 		{
 			name:       "returns correct info",
-			selector:   chain_selectors.TRON_MAINNET.Selector,
+			selector:   chainsel.TRON_MAINNET.Selector,
 			wantString: "tron-mainnet (1546563616611573945)",
-			wantName:   chain_selectors.TRON_MAINNET.Name,
-			wantFamily: chain_selectors.FamilyTron,
+			wantName:   chainsel.TRON_MAINNET.Name,
+			wantFamily: chainsel.FamilyTron,
 		},
 	}
 

--- a/chain/utils/chain_info.go
+++ b/chain/utils/chain_info.go
@@ -1,21 +1,21 @@
 package utils
 
-import chain_selectors "github.com/smartcontractkit/chain-selectors"
+import chainsel "github.com/smartcontractkit/chain-selectors"
 
 // ChainInfo returns the chain info for the given selector.
 // It returns an error if the selector is invalid or if the chain info cannot be retrieved.
-func ChainInfo(cs uint64) (chain_selectors.ChainDetails, error) {
-	id, err := chain_selectors.GetChainIDFromSelector(cs)
+func ChainInfo(cs uint64) (chainsel.ChainDetails, error) {
+	id, err := chainsel.GetChainIDFromSelector(cs)
 	if err != nil {
-		return chain_selectors.ChainDetails{}, err
+		return chainsel.ChainDetails{}, err
 	}
-	family, err := chain_selectors.GetSelectorFamily(cs)
+	family, err := chainsel.GetSelectorFamily(cs)
 	if err != nil {
-		return chain_selectors.ChainDetails{}, err
+		return chainsel.ChainDetails{}, err
 	}
-	info, err := chain_selectors.GetChainDetailsByChainIDAndFamily(id, family)
+	info, err := chainsel.GetChainDetailsByChainIDAndFamily(id, family)
 	if err != nil {
-		return chain_selectors.ChainDetails{}, err
+		return chainsel.ChainDetails{}, err
 	}
 
 	return info, nil

--- a/chain/utils/chain_info_test.go
+++ b/chain/utils/chain_info_test.go
@@ -3,7 +3,7 @@ package utils_test
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,15 +17,15 @@ func TestChainInfo(t *testing.T) {
 		name          string
 		selector      uint64
 		expectError   string
-		validateChain func(t *testing.T, info chain_selectors.ChainDetails)
+		validateChain func(t *testing.T, info chainsel.ChainDetails)
 	}{
 		{
 			name:     "returns details for valid chain selector",
-			selector: chain_selectors.ETHEREUM_MAINNET.Selector,
-			validateChain: func(t *testing.T, info chain_selectors.ChainDetails) {
+			selector: chainsel.ETHEREUM_MAINNET.Selector,
+			validateChain: func(t *testing.T, info chainsel.ChainDetails) {
 				t.Helper()
-				assert.Equal(t, chain_selectors.ETHEREUM_MAINNET.Name, info.ChainName)
-				assert.Equal(t, chain_selectors.ETHEREUM_MAINNET.Selector, info.ChainSelector)
+				assert.Equal(t, chainsel.ETHEREUM_MAINNET.Name, info.ChainName)
+				assert.Equal(t, chainsel.ETHEREUM_MAINNET.Selector, info.ChainSelector)
 			},
 		},
 		{

--- a/datastore/chain_metadata_test.go
+++ b/datastore/chain_metadata_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 )
 
 func TestChainMetadata_Clone(t *testing.T) {
@@ -15,7 +15,7 @@ func TestChainMetadata_Clone(t *testing.T) {
 		ChainSelector: 1,
 		Metadata: testMetadata{
 			Field:         "test field",
-			ChainSelector: chain_selectors.APTOS_MAINNET.Selector,
+			ChainSelector: chainsel.APTOS_MAINNET.Selector,
 		},
 	}
 
@@ -32,7 +32,7 @@ func TestChainMetadata_Clone(t *testing.T) {
 	original.ChainSelector = 2
 	original.Metadata = testMetadata{
 		Field:         "updated field",
-		ChainSelector: chain_selectors.APTOS_MAINNET.Selector,
+		ChainSelector: chainsel.APTOS_MAINNET.Selector,
 	}
 
 	require.NotEqual(t, original.ChainSelector, cloned.ChainSelector)

--- a/datastore/clone_test.go
+++ b/datastore/clone_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 )
 
 type testStruct struct {
@@ -29,11 +29,11 @@ func TestClone(t *testing.T) {
 	}{
 		{
 			name: "simple struct",
-			give: testStruct{A: chain_selectors.APTOS_MAINNET.Selector, B: "foo", C: []int{1, 2, 3}},
+			give: testStruct{A: chainsel.APTOS_MAINNET.Selector, B: "foo", C: []int{1, 2, 3}},
 		},
 		{
 			name:    "struct with channel",
-			give:    chanStruct{A: chain_selectors.APTOS_MAINNET.Selector, Ch: make(chan int)},
+			give:    chanStruct{A: chainsel.APTOS_MAINNET.Selector, Ch: make(chan int)},
 			wantErr: "json: unsupported type: chan int",
 		},
 	}

--- a/datastore/contract_metadata_test.go
+++ b/datastore/contract_metadata_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 )
 
 func TestContractMetadata_Clone(t *testing.T) {
@@ -16,7 +16,7 @@ func TestContractMetadata_Clone(t *testing.T) {
 		Address:       "0x123",
 		Metadata: testMetadata{
 			Field:         "test field",
-			ChainSelector: chain_selectors.APTOS_MAINNET.Selector,
+			ChainSelector: chainsel.APTOS_MAINNET.Selector,
 		},
 	}
 
@@ -35,7 +35,7 @@ func TestContractMetadata_Clone(t *testing.T) {
 	original.Address = "0x456"
 	original.Metadata = testMetadata{
 		Field:         "updated field",
-		ChainSelector: chain_selectors.APTOS_MAINNET.Selector,
+		ChainSelector: chainsel.APTOS_MAINNET.Selector,
 	}
 
 	require.NotEqual(t, original.ChainSelector, cloned.ChainSelector)

--- a/datastore/memory_chain_metadata_store_test.go
+++ b/datastore/memory_chain_metadata_store_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 )
 
 func TestMemoryChainMetadataStore_indexOf(t *testing.T) {
@@ -302,7 +302,7 @@ func TestMemoryChainMetadataStore_Fetch(t *testing.T) {
 			ChainSelector: 1,
 			Metadata: testMetadata{
 				Field:         "test field",
-				ChainSelector: chain_selectors.APTOS_MAINNET.Selector,
+				ChainSelector: chainsel.APTOS_MAINNET.Selector,
 			},
 		}
 
@@ -310,7 +310,7 @@ func TestMemoryChainMetadataStore_Fetch(t *testing.T) {
 			ChainSelector: 2,
 			Metadata: testMetadata{
 				Field:         "test field 2",
-				ChainSelector: chain_selectors.APTOS_MAINNET.Selector,
+				ChainSelector: chainsel.APTOS_MAINNET.Selector,
 			},
 		}
 	)

--- a/datastore/memory_contract_metadata_store_test.go
+++ b/datastore/memory_contract_metadata_store_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 )
 
 func TestMemoryContractMetadataStore_indexOf(t *testing.T) {
@@ -313,7 +313,7 @@ func TestMemoryContractMetadataStore_Fetch(t *testing.T) {
 			Address:       "0x2324224",
 			Metadata: testMetadata{
 				Field:         "test field",
-				ChainSelector: chain_selectors.APTOS_MAINNET.Selector,
+				ChainSelector: chainsel.APTOS_MAINNET.Selector,
 			},
 		}
 
@@ -322,7 +322,7 @@ func TestMemoryContractMetadataStore_Fetch(t *testing.T) {
 			Address:       "0x2324224",
 			Metadata: testMetadata{
 				Field:         "test field 2",
-				ChainSelector: chain_selectors.APTOS_MAINNET.Selector,
+				ChainSelector: chainsel.APTOS_MAINNET.Selector,
 			},
 		}
 	)

--- a/datastore/transform_test.go
+++ b/datastore/transform_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 )
 
 func TestAs(t *testing.T) {
@@ -14,7 +14,7 @@ func TestAs(t *testing.T) {
 	// create a CustomMetadata instance
 	orig := testMetadata{
 		Field:         "test",
-		ChainSelector: chain_selectors.APTOS_MAINNET.Selector,
+		ChainSelector: chainsel.APTOS_MAINNET.Selector,
 	}
 
 	// put it in an `any` type and use As to convert it back

--- a/deployment/environment.go
+++ b/deployment/environment.go
@@ -10,10 +10,10 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
-	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/offchain"
-	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
+	"github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
@@ -57,7 +57,7 @@ type Environment struct {
 	NodeIDs    []string
 	Offchain   offchain.Client
 	GetContext func() context.Context
-	OCRSecrets focr.OCRSecrets
+	OCRSecrets ocr.OCRSecrets
 	// OperationsBundle contains dependencies required by the operations API.
 	OperationsBundle operations.Bundle
 	// BlockChains is the container of all chains in the environment.
@@ -83,7 +83,7 @@ func NewEnvironment(
 	nodeIDs []string,
 	offchain offchain.Client,
 	ctx func() context.Context,
-	secrets focr.OCRSecrets,
+	secrets ocr.OCRSecrets,
 	blockChains chain.BlockChains,
 	opts ...EnvironmentOption,
 ) *Environment {
@@ -140,7 +140,7 @@ func (e Environment) Clone() Environment {
 
 // ConfirmIfNoError confirms the transaction if no error occurred.
 // if the error is a DataError, it will return the decoded error message and data.
-func ConfirmIfNoError(chain cldf_evm.Chain, tx *types.Transaction, err error) (uint64, error) {
+func ConfirmIfNoError(chain evm.Chain, tx *types.Transaction, err error) (uint64, error) {
 	if err != nil {
 		//revive:disable
 		var d rpc.DataError
@@ -157,7 +157,7 @@ func ConfirmIfNoError(chain cldf_evm.Chain, tx *types.Transaction, err error) (u
 
 // ConfirmIfNoErrorWithABI confirms the transaction if no error occurred.
 // if the error is a DataError, it will return the decoded error message and data.
-func ConfirmIfNoErrorWithABI(chain cldf_evm.Chain, tx *types.Transaction, abi string, err error) (uint64, error) {
+func ConfirmIfNoErrorWithABI(chain evm.Chain, tx *types.Transaction, abi string, err error) (uint64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("transaction reverted on chain %s: Error %w",
 			chain.String(), DecodedErrFromABIIfDataErr(err, abi))

--- a/deployment/helpers.go
+++ b/deployment/helpers.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
@@ -137,7 +137,7 @@ func IsValidChainSelector(cs uint64) error {
 	if cs == 0 {
 		return errors.New("chain selector must be set")
 	}
-	_, err := chain_selectors.GetSelectorFamily(cs)
+	_, err := chainsel.GetSelectorFamily(cs)
 	if err != nil {
 		return err
 	}

--- a/deployment/ocr_secrets.go
+++ b/deployment/ocr_secrets.go
@@ -1,21 +1,21 @@
 package deployment
 
 import (
-	focr "github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
+	"github.com/smartcontractkit/chainlink-deployments-framework/offchain/ocr"
 )
 
 var (
 	// ErrMnemonicRequired is returned when the OCR mnemonic is not set
-	ErrMnemonicRequired = focr.ErrMnemonicRequired
+	ErrMnemonicRequired = ocr.ErrMnemonicRequired
 )
 
 // OCRSecrets are used to disseminate a shared secret to OCR nodes
 // through the blockchain where OCR configuration is stored. Its a low value secret used
 // to derive transmission order etc. They are extracted here such that they can common
 // across signers when multiple signers are signing the same OCR config.
-type OCRSecrets = focr.OCRSecrets
+type OCRSecrets = ocr.OCRSecrets
 
-var XXXGenerateTestOCRSecrets = focr.XXXGenerateTestOCRSecrets
+var XXXGenerateTestOCRSecrets = ocr.XXXGenerateTestOCRSecrets
 
 // SharedSecrets generates shared secrets from the BIP39 mnemonic phrases for the OCR signers
 // and proposers.
@@ -24,4 +24,4 @@ var XXXGenerateTestOCRSecrets = focr.XXXGenerateTestOCRSecrets
 // https://github.com/smartcontractkit/offchain-reporting/blob/14a57d70e50474a2104aa413214e464d6bc69e16/lib/offchainreporting/internal/config/shared_secret_test.go#L32
 // Historically signers (fixed secret) and proposers (ephemeral secret) were
 // combined in this manner. We simply leave that as is.
-var GenerateSharedSecrets = focr.GenerateSharedSecrets
+var GenerateSharedSecrets = ocr.GenerateSharedSecrets

--- a/engine/cld/chains/chains_test.go
+++ b/engine/cld/chains/chains_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/gagliardetto/solana-go"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,12 +26,12 @@ func Test_LoadChains(t *testing.T) {
 	var (
 		fakeSrv = newFakeRPCServer(t)
 
-		evmSelector    = chain_selectors.TEST_1000.Selector
-		solanaSelector = chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector
-		aptosSelector  = chain_selectors.APTOS_LOCALNET.Selector
-		tronSelector   = chain_selectors.TRON_TESTNET_NILE.Selector
-		suiSelector    = chain_selectors.SUI_LOCALNET.Selector
-		tonSelector    = chain_selectors.TON_TESTNET.Selector
+		evmSelector    = chainsel.TEST_1000.Selector
+		solanaSelector = chainsel.TEST_22222222222222222222222222222222222222222222.Selector
+		aptosSelector  = chainsel.APTOS_LOCALNET.Selector
+		tronSelector   = chainsel.TRON_TESTNET_NILE.Selector
+		suiSelector    = chainsel.SUI_LOCALNET.Selector
+		tonSelector    = chainsel.TON_TESTNET.Selector
 	)
 
 	networks := []config_network.Network{
@@ -173,7 +173,7 @@ func Test_LoadChains(t *testing.T) {
 			name:              "skips selector not found in networks",
 			giveNetworkConfig: networksConfig,
 			giveOnchainConfig: onchainConfig,
-			giveSelectors:     []uint64{evmSelector, chain_selectors.TEST_90000001.Selector},
+			giveSelectors:     []uint64{evmSelector, chainsel.TEST_90000001.Selector},
 			wantErr:           "failed to load 1 out of 2 chains",
 		},
 		{
@@ -234,7 +234,7 @@ func Test_chainLoaderAptos_Load(t *testing.T) {
 	ctx := t.Context()
 
 	// Test chain selector for Aptos mainnet
-	var aptosSelector = chain_selectors.APTOS_LOCALNET.Selector
+	var aptosSelector = chainsel.APTOS_LOCALNET.Selector
 
 	// Create test network config
 	networkCfg := config_network.NewConfig([]config_network.Network{
@@ -349,7 +349,7 @@ func Test_chainLoaderAptos_Load(t *testing.T) {
 func Test_chainLoaderSui_Load(t *testing.T) {
 	t.Parallel()
 
-	var suiSelector = chain_selectors.SUI_LOCALNET.Selector
+	var suiSelector = chainsel.SUI_LOCALNET.Selector
 
 	networkCfg := config_network.NewConfig([]config_network.Network{
 		{
@@ -462,7 +462,7 @@ func Test_ChainLoaderSolana_Load(t *testing.T) {
 	ctx := t.Context()
 
 	// Test chain selector for Solana localnet
-	var solanaSelector = chain_selectors.TEST_22222222222222222222222222222222222222222222.Selector
+	var solanaSelector = chainsel.TEST_22222222222222222222222222222222222222222222.Selector
 
 	// Create test network config
 	networkCfg := config_network.NewConfig([]config_network.Network{
@@ -594,8 +594,8 @@ func Test_ChainLoaderEVM_Load(t *testing.T) {
 	var (
 		ctx            = t.Context()
 		fakeSrv        = newFakeRPCServer(t)
-		evmSelector    = chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector
-		zksyncSelector = chain_selectors.ETHEREUM_TESTNET_SEPOLIA_ZKSYNC_1.Selector
+		evmSelector    = chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector
+		zksyncSelector = chainsel.ETHEREUM_TESTNET_SEPOLIA_ZKSYNC_1.Selector
 	)
 
 	// Create test network config
@@ -753,7 +753,7 @@ func Test_ChainLoaderTron_Load(t *testing.T) {
 
 	ctx := t.Context()
 
-	var tronSelector = chain_selectors.TRON_TESTNET_NILE.Selector
+	var tronSelector = chainsel.TRON_TESTNET_NILE.Selector
 
 	networks := config_network.NewConfig([]config_network.Network{
 		{

--- a/engine/cld/config/network/config_test.go
+++ b/engine/cld/config/network/config_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -257,7 +257,7 @@ func Test_Config_FilterWith(t *testing.T) {
 	// Create test networks
 	mainnetNetwork1 := Network{
 		Type:          "mainnet",
-		ChainSelector: chain_selectors.ETHEREUM_MAINNET.Selector,
+		ChainSelector: chainsel.ETHEREUM_MAINNET.Selector,
 		RPCs: []RPC{
 			{
 				RPCName:            "test_rpc",
@@ -270,7 +270,7 @@ func Test_Config_FilterWith(t *testing.T) {
 
 	mainnetNetwork2 := Network{
 		Type:          "mainnet",
-		ChainSelector: chain_selectors.SOLANA_MAINNET.Selector,
+		ChainSelector: chainsel.SOLANA_MAINNET.Selector,
 		RPCs: []RPC{
 			{
 				RPCName:            "test_rpc3",
@@ -283,7 +283,7 @@ func Test_Config_FilterWith(t *testing.T) {
 
 	testnetNetwork := Network{
 		Type:          "testnet",
-		ChainSelector: chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector,
+		ChainSelector: chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector,
 		RPCs: []RPC{
 			{
 				RPCName:            "test_rpc2",
@@ -317,7 +317,7 @@ func Test_Config_FilterWith(t *testing.T) {
 		},
 		{
 			name:        "filter by chain selector 1",
-			giveFilters: []NetworkFilter{ChainSelectorFilter(chain_selectors.ETHEREUM_MAINNET.Selector)},
+			giveFilters: []NetworkFilter{ChainSelectorFilter(chainsel.ETHEREUM_MAINNET.Selector)},
 			want:        NewConfig([]Network{mainnetNetwork1}),
 		},
 		{
@@ -327,14 +327,14 @@ func Test_Config_FilterWith(t *testing.T) {
 		},
 		{
 			name:        "filter by chain family",
-			giveFilters: []NetworkFilter{ChainFamilyFilter(chain_selectors.FamilyEVM)},
+			giveFilters: []NetworkFilter{ChainFamilyFilter(chainsel.FamilyEVM)},
 			want:        NewConfig([]Network{mainnetNetwork1, testnetNetwork}),
 		},
 		{
 			name: "combination: filter by mainnet and chain selector 1",
 			giveFilters: []NetworkFilter{
 				TypesFilter(NetworkTypeMainnet),
-				ChainSelectorFilter(chain_selectors.ETHEREUM_MAINNET.Selector),
+				ChainSelectorFilter(chainsel.ETHEREUM_MAINNET.Selector),
 			},
 			want: NewConfig([]Network{mainnetNetwork1}),
 		},
@@ -342,7 +342,7 @@ func Test_Config_FilterWith(t *testing.T) {
 			name: "combination: filter by testnet and chain selector 1 (no match)",
 			giveFilters: []NetworkFilter{
 				TypesFilter(NetworkTypeTestnet),
-				ChainSelectorFilter(chain_selectors.ETHEREUM_MAINNET.Selector),
+				ChainSelectorFilter(chainsel.ETHEREUM_MAINNET.Selector),
 			},
 			want: NewConfig([]Network{}),
 		},
@@ -485,7 +485,7 @@ func Test_ChainFamilyFilter(t *testing.T) {
 
 	network := Network{
 		Type:          NetworkTypeMainnet,
-		ChainSelector: chain_selectors.TEST_1000.Selector, // EVM
+		ChainSelector: chainsel.TEST_1000.Selector, // EVM
 	}
 
 	tests := []struct {
@@ -496,19 +496,19 @@ func Test_ChainFamilyFilter(t *testing.T) {
 	}{
 		{
 			name:        "matching EVM family",
-			giveFamily:  chain_selectors.FamilyEVM,
+			giveFamily:  chainsel.FamilyEVM,
 			giveNetwork: network,
 			want:        true,
 		},
 		{
 			name:        "does not match EVM family",
-			giveFamily:  chain_selectors.FamilySolana,
+			giveFamily:  chainsel.FamilySolana,
 			giveNetwork: network,
 			want:        false,
 		},
 		{
 			name:       "chain selector does not have family",
-			giveFamily: chain_selectors.FamilyEVM,
+			giveFamily: chainsel.FamilyEVM,
 			giveNetwork: Network{
 				ChainSelector: 999999999999999999, // Non-existent chain selector
 			},

--- a/engine/cld/config/network/network.go
+++ b/engine/cld/config/network/network.go
@@ -3,7 +3,7 @@ package network
 import (
 	"errors"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 )
 
 // NetworkType represents the type of network, which can either be mainnet or testnet.
@@ -25,12 +25,12 @@ type Network struct {
 
 // ChainFamily returns the family of the network based on its chain selector.
 func (n *Network) ChainFamily() (string, error) {
-	return chain_selectors.GetSelectorFamily(n.ChainSelector)
+	return chainsel.GetSelectorFamily(n.ChainSelector)
 }
 
 // ChainID returns the chain ID as a string based on the chain selector.
 func (n *Network) ChainID() (string, error) {
-	return chain_selectors.GetChainIDFromSelector(n.ChainSelector)
+	return chainsel.GetChainIDFromSelector(n.ChainSelector)
 }
 
 // Validate validates the network configuration to ensure that all required fields are set.

--- a/engine/cld/config/network/network_test.go
+++ b/engine/cld/config/network/network_test.go
@@ -3,7 +3,7 @@ package network
 import (
 	"testing"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -11,17 +11,17 @@ import (
 func Test_Network_ChainFamily(t *testing.T) {
 	t.Parallel()
 
-	network := Network{ChainSelector: chain_selectors.ETHEREUM_MAINNET.Selector}
+	network := Network{ChainSelector: chainsel.ETHEREUM_MAINNET.Selector}
 	got, err := network.ChainFamily()
 	require.NoError(t, err)
 
-	assert.Equal(t, chain_selectors.FamilyEVM, got)
+	assert.Equal(t, chainsel.FamilyEVM, got)
 }
 
 func Test_Network_ChainID(t *testing.T) {
 	t.Parallel()
 
-	network := Network{ChainSelector: chain_selectors.ETHEREUM_MAINNET.Selector}
+	network := Network{ChainSelector: chainsel.ETHEREUM_MAINNET.Selector}
 	got, err := network.ChainID()
 	require.NoError(t, err)
 
@@ -63,7 +63,7 @@ func Test_Network_Validate(t *testing.T) {
 
 			network := &Network{
 				Type:          NetworkTypeMainnet,
-				ChainSelector: chain_selectors.ETHEREUM_MAINNET.Selector,
+				ChainSelector: chainsel.ETHEREUM_MAINNET.Selector,
 				RPCs:          []RPC{{RPCName: "test_rpc", HTTPURL: "https://test.rpc", WSURL: "wss://test.rpc"}},
 			}
 

--- a/experimental/proposalutils/analyze.go
+++ b/experimental/proposalutils/analyze.go
@@ -14,11 +14,11 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	mcmslib "github.com/smartcontractkit/mcms"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
 const (
@@ -65,7 +65,7 @@ func ContextGet[T any](ctx *ArgumentContext, key string) (T, error) {
 	return ctxElem, nil
 }
 
-func NewArgumentContext(addresses cldf.AddressesByChain) *ArgumentContext {
+func NewArgumentContext(addresses deployment.AddressesByChain) *ArgumentContext {
 	return &ArgumentContext{
 		Ctx: map[string]any{
 			"AddressesByChain": addresses,
@@ -184,7 +184,7 @@ type AddressArgument struct {
 
 // Annotation returns only the annotation if known, otherwise "".
 func (a AddressArgument) Annotation(ctx *ArgumentContext) string {
-	addresses, err := ContextGet[cldf.AddressesByChain](ctx, "AddressesByChain")
+	addresses, err := ContextGet[deployment.AddressesByChain](ctx, "AddressesByChain")
 	if err != nil {
 		return ""
 	}
@@ -443,15 +443,15 @@ func indentStringWith(s string, indent string) string {
 }
 
 func GetChainNameBySelector(selector uint64) (string, error) {
-	chainID, err := chain_selectors.GetChainIDFromSelector(selector)
+	chainID, err := chainsel.GetChainIDFromSelector(selector)
 	if err != nil {
 		return "", err
 	}
-	family, err := chain_selectors.GetSelectorFamily(selector)
+	family, err := chainsel.GetSelectorFamily(selector)
 	if err != nil {
 		return "", err
 	}
-	chainInfo, err := chain_selectors.GetChainDetailsByChainIDAndFamily(chainID, family)
+	chainInfo, err := chainsel.GetChainDetailsByChainIDAndFamily(chainID, family)
 	if err != nil {
 		return "", err
 	}

--- a/offchain/jd/dry_run_client.go
+++ b/offchain/jd/dry_run_client.go
@@ -5,7 +5,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	cldf_offchain "github.com/smartcontractkit/chainlink-deployments-framework/offchain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/offchain"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	csav1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/csa"
@@ -17,14 +17,14 @@ import (
 // Read operations are forwarded to the real backend, while write operations are ignored.
 type DryRunJobDistributor struct {
 	// Used for read-only commands
-	realBackend cldf_offchain.Client
+	realBackend offchain.Client
 	lggr        logger.Logger
 }
 
-var _ cldf_offchain.Client = (*DryRunJobDistributor)(nil)
+var _ offchain.Client = (*DryRunJobDistributor)(nil)
 
 // NewDryRunJobDistributor creates a new DryRunJobDistributor.
-func NewDryRunJobDistributor(realBackend cldf_offchain.Client, lggr logger.Logger) *DryRunJobDistributor {
+func NewDryRunJobDistributor(realBackend offchain.Client, lggr logger.Logger) *DryRunJobDistributor {
 	return &DryRunJobDistributor{
 		realBackend: realBackend,
 		lggr:        lggr,

--- a/offchain/jd/provider/ctf_provider.go
+++ b/offchain/jd/provider/ctf_provider.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	csav1 "github.com/smartcontractkit/chainlink-protos/job-distributor/v1/csa"
-	ctf_jd "github.com/smartcontractkit/chainlink-testing-framework/framework/components/jd"
+	ctfjd "github.com/smartcontractkit/chainlink-testing-framework/framework/components/jd"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/postgres"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/offchain"
@@ -102,7 +102,7 @@ func (p *CTFOffchainProvider) Initialize(ctx context.Context) (offchain.Client, 
 	}
 
 	// Create JD input configuration from provider config
-	jdInput := &ctf_jd.Input{
+	jdInput := &ctfjd.Input{
 		Image:            p.config.Image,
 		GRPCPort:         p.config.GRPCPort,
 		WSRPCPort:        p.config.WSRPCPort,
@@ -114,7 +114,7 @@ func (p *CTFOffchainProvider) Initialize(ctx context.Context) (offchain.Client, 
 	}
 
 	// Create the JD container using CTF
-	jdOutput, err := ctf_jd.NewJD(jdInput)
+	jdOutput, err := ctfjd.NewJD(jdInput)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cleaning import aliases.

- Removes underscores and framework prefixes within framework code.
- Rule of thumb use max 2 words phrases for imports to be readable.
- Shorten import aliases names where valid.
- For conflicting names for imports you can add `f` as prefix to mitigate issue or just use two words from package path, whatever makes more sense.