### PR TITLE
refactor: remove deployer seed from ton and tron chains

### DIFF
--- a/.changeset/swift-pans-smell.md
+++ b/.changeset/swift-pans-smell.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+Remove DeployerSeed field from Tron and Ton Chain

--- a/chain/ton/ton_chain.go
+++ b/chain/ton/ton_chain.go
@@ -17,5 +17,4 @@ type Chain struct {
 	Wallet        *wallet.Wallet   // Wallet abstraction (signing, sending)
 	WalletAddress *address.Address // Address of deployer wallet
 	URL           string           // Liteserver URL
-	DeployerSeed  string           // Optional: mnemonic or raw seed
 }

--- a/chain/tron/tron_chain.go
+++ b/chain/tron/tron_chain.go
@@ -42,7 +42,6 @@ type Chain struct {
 	SignHash      func(ctx context.Context, txHash []byte) ([]byte, error) // Function for signing transaction hashes
 	Address       address.Address                                          // Address of the account used for transactions
 	URL           string                                                   // Optional: Client URL
-	DeployerSeed  string                                                   // Optional: mnemonic or raw seed
 
 	// SendAndConfirm provides a utility function to send a transaction and waits for confirmation.
 	SendAndConfirm func(ctx context.Context, tx *common.Transaction, opts *ConfirmRetryOptions) (*soliditynode.TransactionInfo, error)


### PR DESCRIPTION
This removes the deployer seed from the ton and tron chains with the intent to reduce potential leaks of private keys.