### PR TITLE
[CLD-606]: feat(chain): addr string to bytes conversion

### DIFF
--- a/.changeset/neat-cases-dig.md
+++ b/.changeset/neat-cases-dig.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat(chain): add support for converting string address to bytes for each chain

--- a/chain/aptos/addrconv.go
+++ b/chain/aptos/addrconv.go
@@ -1,0 +1,34 @@
+package aptos
+
+import (
+	"fmt"
+
+	aptoslib "github.com/aptos-labs/aptos-go-sdk"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+)
+
+// AddressToBytes converts an Aptos address string to bytes.
+// Aptos addresses can be in various formats (short, long, with/without 0x prefix) but are normalized to 32 bytes.
+func AddressToBytes(address string) ([]byte, error) {
+	var addr aptoslib.AccountAddress
+	err := addr.ParseStringRelaxed(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Aptos address format: %s, error: %w", address, err)
+	}
+
+	return addr[:], nil
+}
+
+// AddressConverter implements address conversion for Aptos chains.
+// This struct implements the AddressConverter interface.
+type AddressConverter struct{}
+
+// ConvertToBytes converts an Aptos address string to bytes.
+func (a AddressConverter) ConvertToBytes(address string) ([]byte, error) {
+	return AddressToBytes(address)
+}
+
+// Supports returns true if this converter supports the given chain family.
+func (a AddressConverter) Supports(family string) bool {
+	return family == chain_selectors.FamilyAptos
+}

--- a/chain/aptos/addrconv_test.go
+++ b/chain/aptos/addrconv_test.go
@@ -1,0 +1,168 @@
+package aptos
+
+import (
+	"testing"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddressToBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			address  string
+			expected []byte
+		}{
+			{
+				name:    "valid short address",
+				address: "0x1",
+				expected: func() []byte {
+					expected := make([]byte, 32)
+					expected[31] = 0x01
+
+					return expected
+				}(),
+			},
+			{
+				name:    "valid full address",
+				address: "0x0000000000000000000000000000000000000000000000000000000000000001",
+				expected: func() []byte {
+					expected := make([]byte, 32)
+					expected[31] = 0x01
+
+					return expected
+				}(),
+			},
+			{
+				name:    "valid address without 0x prefix",
+				address: "1",
+				expected: func() []byte {
+					expected := make([]byte, 32)
+					expected[31] = 0x01
+
+					return expected
+				}(),
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := AddressToBytes(tt.address)
+
+				require.NoError(t, err)
+				assert.Len(t, result, 32)
+				assert.Equal(t, tt.expected, result)
+			})
+		}
+	})
+
+	t.Run("invalid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{
+				name:    "invalid hex characters",
+				address: "invalid",
+			},
+			{
+				name:    "empty address",
+				address: "",
+			},
+			{
+				name:    "invalid hex with 0x prefix",
+				address: "0xGG",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := AddressToBytes(tt.address)
+				require.Error(t, err, "Expected error for address: %s", tt.address)
+				assert.Nil(t, result)
+			})
+		}
+	})
+
+	t.Run("address normalization", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{name: "short form", address: "0x1"},
+			{name: "padded short form", address: "0x01"},
+			{name: "medium padded form", address: "0x0001"},
+			{name: "full form", address: "0x0000000000000000000000000000000000000000000000000000000000000001"},
+			{name: "no prefix", address: "1"},
+		}
+
+		var results [][]byte
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) { //nolint:paralleltest // Cannot use t.Parallel() here because tests share the results slice
+				result, err := AddressToBytes(tt.address)
+				require.NoError(t, err, "Failed to convert address: %s", tt.address)
+				results = append(results, result)
+			})
+		}
+
+		// All should produce the same result
+		t.Run("all forms produce same result", func(t *testing.T) { //nolint:paralleltest // Cannot use t.Parallel() here because it depends on results from previous tests
+			for i := 1; i < len(results); i++ {
+				assert.Equal(t, results[0], results[i], "All address formats should produce the same result")
+			}
+		})
+	})
+
+	t.Run("consistent results", func(t *testing.T) {
+		t.Parallel()
+
+		address := "0x1"
+
+		result1, err1 := AddressToBytes(address)
+		require.NoError(t, err1)
+
+		result2, err2 := AddressToBytes(address)
+		require.NoError(t, err2)
+
+		assert.Equal(t, result1, result2, "Expected consistent results for the same address")
+	})
+}
+
+func TestAddressConverter(t *testing.T) {
+	t.Parallel()
+
+	converter := AddressConverter{}
+
+	t.Run("Supports", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, converter.Supports(chain_selectors.FamilyAptos))
+		assert.False(t, converter.Supports(chain_selectors.FamilyEVM))
+		assert.False(t, converter.Supports(chain_selectors.FamilySolana))
+	})
+
+	t.Run("ConvertToBytes", func(t *testing.T) {
+		t.Parallel()
+
+		address := "0x1"
+		expected := make([]byte, 32)
+		expected[31] = 0x01
+
+		result, err := converter.ConvertToBytes(address)
+		require.NoError(t, err)
+		assert.Equal(t, expected, result)
+	})
+}

--- a/chain/evm/addrconv.go
+++ b/chain/evm/addrconv.go
@@ -1,0 +1,34 @@
+package evm
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+)
+
+// AddressToBytes converts an EVM address string to bytes.
+// EVM addresses are hex strings (with or without 0x prefix) representing 20 bytes.
+func AddressToBytes(address string) ([]byte, error) {
+	if !common.IsHexAddress(address) {
+		return nil, fmt.Errorf("invalid EVM address format: %s", address)
+	}
+
+	addr := common.HexToAddress(address)
+
+	return addr.Bytes(), nil
+}
+
+// AddressConverter implements address conversion for EVM-compatible chains.
+// This struct implements the AddressConverter strategy interface.
+type AddressConverter struct{}
+
+// ConvertToBytes converts an EVM address string to bytes.
+func (e AddressConverter) ConvertToBytes(address string) ([]byte, error) {
+	return AddressToBytes(address)
+}
+
+// Supports returns true if this converter supports the given chain family.
+func (e AddressConverter) Supports(family string) bool {
+	return family == chain_selectors.FamilyEVM
+}

--- a/chain/evm/addrconv_test.go
+++ b/chain/evm/addrconv_test.go
@@ -1,0 +1,143 @@
+package evm
+
+import (
+	"testing"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddressToBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		address       string
+		expectedLen   int
+		expectedBytes []byte
+		shouldSucceed bool
+		description   string
+	}{
+		{
+			name:          "valid address with 0x prefix",
+			address:       "0x742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8",
+			expectedLen:   20,
+			expectedBytes: []byte{0x74, 0x2d, 0x35, 0xcc, 0x66, 0x34, 0xc0, 0x53, 0x29, 0x25, 0xa3, 0xb8, 0xd4, 0xc8, 0xc1, 0xb8, 0xc4, 0xc8, 0xc1, 0xb8},
+			shouldSucceed: true,
+			description:   "should convert valid hex address with 0x prefix to bytes",
+		},
+		{
+			name:          "valid address without 0x prefix",
+			address:       "742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8",
+			expectedLen:   20,
+			shouldSucceed: true,
+			description:   "should convert valid hex address without 0x prefix to bytes",
+		},
+		{
+			name:          "zero address",
+			address:       "0x0000000000000000000000000000000000000000",
+			expectedLen:   20,
+			expectedBytes: make([]byte, 20), // All zeros
+			shouldSucceed: true,
+			description:   "should convert zero address to 20 zero bytes",
+		},
+		{
+			name:          "invalid - too short",
+			address:       "0x123",
+			shouldSucceed: false,
+			description:   "should reject address that is too short",
+		},
+		{
+			name:          "invalid - invalid hex characters",
+			address:       "742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8XX",
+			shouldSucceed: false,
+			description:   "should reject address with invalid hex characters",
+		},
+		{
+			name:          "invalid - empty string",
+			address:       "",
+			shouldSucceed: false,
+			description:   "should reject empty address string",
+		},
+		{
+			name:          "invalid - non-hex string",
+			address:       "invalid",
+			shouldSucceed: false,
+			description:   "should reject non-hex address string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := AddressToBytes(tt.address)
+
+			if tt.shouldSucceed {
+				require.NoError(t, err, tt.description)
+				assert.Len(t, result, tt.expectedLen, "Expected length %d for address %s", tt.expectedLen, tt.address)
+
+				if tt.expectedBytes != nil {
+					assert.Equal(t, tt.expectedBytes, result, "Expected specific bytes for address %s", tt.address)
+				}
+			} else {
+				require.Error(t, err, tt.description)
+				assert.Nil(t, result, "Expected nil result for invalid address %s", tt.address)
+			}
+		})
+	}
+
+	t.Run("case sensitivity", func(t *testing.T) {
+		t.Parallel()
+
+		// EVM addresses should be case-insensitive
+		addr1 := "0x742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8"
+		addr2 := "0x742D35CC6634C0532925A3B8D4C8C1B8C4C8C1B8"
+
+		result1, err1 := AddressToBytes(addr1)
+		result2, err2 := AddressToBytes(addr2)
+
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		assert.Equal(t, result1, result2, "EVM addresses should be case-insensitive")
+	})
+
+	t.Run("consistent results", func(t *testing.T) {
+		t.Parallel()
+
+		address := "0x742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8"
+
+		result1, err1 := AddressToBytes(address)
+		require.NoError(t, err1)
+
+		result2, err2 := AddressToBytes(address)
+		require.NoError(t, err2)
+
+		assert.Equal(t, result1, result2, "Expected consistent results for the same address")
+	})
+}
+
+func TestAddressConverter(t *testing.T) {
+	t.Parallel()
+
+	converter := AddressConverter{}
+
+	t.Run("Supports", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, converter.Supports(chain_selectors.FamilyEVM))
+		assert.False(t, converter.Supports(chain_selectors.FamilySolana))
+		assert.False(t, converter.Supports(chain_selectors.FamilyAptos))
+	})
+
+	t.Run("ConvertToBytes", func(t *testing.T) {
+		t.Parallel()
+
+		address := "0x742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8"
+		expected := []byte{0x74, 0x2d, 0x35, 0xcc, 0x66, 0x34, 0xc0, 0x53, 0x29, 0x25, 0xa3, 0xb8, 0xd4, 0xc8, 0xc1, 0xb8, 0xc4, 0xc8, 0xc1, 0xb8}
+
+		result, err := converter.ConvertToBytes(address)
+		require.NoError(t, err)
+		assert.Equal(t, expected, result)
+	})
+}

--- a/chain/solana/addrconv.go
+++ b/chain/solana/addrconv.go
@@ -1,0 +1,33 @@
+package solana
+
+import (
+	"fmt"
+
+	sollib "github.com/gagliardetto/solana-go"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+)
+
+// AddressToBytes converts a Solana address string to bytes.
+// Solana addresses are base58-encoded public keys (32 bytes).
+func AddressToBytes(address string) ([]byte, error) {
+	pubkey, err := sollib.PublicKeyFromBase58(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Solana address format: %s, error: %w", address, err)
+	}
+
+	return pubkey.Bytes(), nil
+}
+
+// AddressConverter implements address conversion for Solana chains.
+// This struct implements the AddressConverter strategy interface.
+type AddressConverter struct{}
+
+// ConvertToBytes converts a Solana address string to bytes.
+func (s AddressConverter) ConvertToBytes(address string) ([]byte, error) {
+	return AddressToBytes(address)
+}
+
+// Supports returns true if this converter supports the given chain family.
+func (s AddressConverter) Supports(family string) bool {
+	return family == chain_selectors.FamilySolana
+}

--- a/chain/solana/addrconv_test.go
+++ b/chain/solana/addrconv_test.go
@@ -1,0 +1,113 @@
+package solana
+
+import (
+	"testing"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddressToBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		address       string
+		expectedLen   int
+		shouldSucceed bool
+		description   string
+	}{
+		{
+			name:          "valid system program address",
+			address:       "11111111111111111111111111111112", // System program
+			expectedLen:   32,
+			shouldSucceed: true,
+			description:   "should convert system program address to 32 bytes",
+		},
+		{
+			name:          "valid token program address",
+			address:       "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", // Token program
+			expectedLen:   32,
+			shouldSucceed: true,
+			description:   "should convert token program address to 32 bytes",
+		},
+		{
+			name:          "invalid - non-base58 string",
+			address:       "invalid",
+			shouldSucceed: false,
+			description:   "should reject non-base58 address string",
+		},
+		{
+			name:          "invalid - empty string",
+			address:       "",
+			shouldSucceed: false,
+			description:   "should reject empty address string",
+		},
+		{
+			name:          "invalid - too short",
+			address:       "123",
+			shouldSucceed: false,
+			description:   "should reject address that is too short",
+		},
+		{
+			name:          "invalid - invalid base58 characters",
+			address:       "InvalidBase58Characters!",
+			shouldSucceed: false,
+			description:   "should reject address with invalid base58 characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := AddressToBytes(tt.address)
+
+			if tt.shouldSucceed {
+				require.NoError(t, err, tt.description)
+				assert.Len(t, result, tt.expectedLen, "Expected length %d for address %s", tt.expectedLen, tt.address)
+			} else {
+				require.Error(t, err, tt.description)
+				assert.Nil(t, result, "Expected nil result for invalid address %s", tt.address)
+			}
+		})
+	}
+
+	t.Run("consistent results", func(t *testing.T) {
+		t.Parallel()
+
+		address := "11111111111111111111111111111112"
+
+		result1, err1 := AddressToBytes(address)
+		require.NoError(t, err1)
+
+		result2, err2 := AddressToBytes(address)
+		require.NoError(t, err2)
+
+		assert.Equal(t, result1, result2, "Expected consistent results for the same address")
+	})
+}
+
+func TestAddressConverter(t *testing.T) {
+	t.Parallel()
+
+	converter := AddressConverter{}
+
+	t.Run("Supports", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, converter.Supports(chain_selectors.FamilySolana))
+		assert.False(t, converter.Supports(chain_selectors.FamilyEVM))
+		assert.False(t, converter.Supports(chain_selectors.FamilyAptos))
+	})
+
+	t.Run("ConvertToBytes", func(t *testing.T) {
+		t.Parallel()
+
+		address := "11111111111111111111111111111112"
+
+		result, err := converter.ConvertToBytes(address)
+		require.NoError(t, err)
+		assert.Len(t, result, 32)
+	})
+}

--- a/chain/sui/addrconv.go
+++ b/chain/sui/addrconv.go
@@ -1,0 +1,42 @@
+package sui
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+)
+
+// AddressToBytes converts a Sui address string to bytes.
+// Sui addresses are hex strings typically prefixed with "0x" (32 bytes).
+func AddressToBytes(address string) ([]byte, error) {
+	// Remove "0x" prefix if present
+	address = strings.TrimPrefix(address, "0x")
+
+	// Sui addresses should be 64 hex characters (32 bytes)
+	if len(address) != 64 {
+		return nil, fmt.Errorf("invalid Sui address format: expected 64 hex characters, got %d", len(address))
+	}
+
+	addressBytes, err := hex.DecodeString(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Sui address format: %s, error: %w", address, err)
+	}
+
+	return addressBytes, nil
+}
+
+// AddressConverter implements address conversion for Sui chains.
+// This struct implements the AddressConverter strategy interface.
+type AddressConverter struct{}
+
+// ConvertToBytes converts a Sui address string to bytes.
+func (s AddressConverter) ConvertToBytes(address string) ([]byte, error) {
+	return AddressToBytes(address)
+}
+
+// Supports returns true if this converter supports the given chain family.
+func (s AddressConverter) Supports(family string) bool {
+	return family == chain_selectors.FamilySui
+}

--- a/chain/sui/addrconv_test.go
+++ b/chain/sui/addrconv_test.go
@@ -1,0 +1,111 @@
+package sui
+
+import (
+	"testing"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddressToBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{
+				name:    "valid address with 0x prefix",
+				address: "0xa402ce953053607dffcdfec89406c579c8d8ddb9c90e01b7aa28f5f1538ac289",
+			},
+			{
+				name:    "valid address without 0x prefix",
+				address: "a402ce953053607dffcdfec89406c579c8d8ddb9c90e01b7aa28f5f1538ac289",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := AddressToBytes(tt.address)
+
+				require.NoError(t, err)
+				assert.Len(t, result, 32)
+			})
+		}
+	})
+
+	t.Run("invalid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{
+				name:    "invalid - too short",
+				address: "0x123",
+			},
+			{
+				name:    "invalid - too long",
+				address: "0xa402ce953053607dffcdfec89406c579c8d8ddb9c90e01b7aa28f5f1538ac289aa",
+			},
+			{
+				name:    "invalid - non-hex characters",
+				address: "invalid",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := AddressToBytes(tt.address)
+				require.Error(t, err, "Expected error for address: %s", tt.address)
+				assert.Nil(t, result)
+			})
+		}
+	})
+
+	t.Run("consistent results", func(t *testing.T) {
+		t.Parallel()
+
+		address := "0xa402ce953053607dffcdfec89406c579c8d8ddb9c90e01b7aa28f5f1538ac289"
+
+		result1, err1 := AddressToBytes(address)
+		require.NoError(t, err1)
+
+		result2, err2 := AddressToBytes(address)
+		require.NoError(t, err2)
+
+		assert.Equal(t, result1, result2, "Expected consistent results for the same address")
+	})
+}
+
+func TestAddressConverter(t *testing.T) {
+	t.Parallel()
+
+	converter := AddressConverter{}
+
+	t.Run("Supports", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, converter.Supports(chain_selectors.FamilySui))
+		assert.False(t, converter.Supports(chain_selectors.FamilyEVM))
+		assert.False(t, converter.Supports(chain_selectors.FamilySolana))
+	})
+
+	t.Run("ConvertToBytes", func(t *testing.T) {
+		t.Parallel()
+
+		address := "0xa402ce953053607dffcdfec89406c579c8d8ddb9c90e01b7aa28f5f1538ac289"
+
+		result, err := converter.ConvertToBytes(address)
+		require.NoError(t, err)
+		assert.Len(t, result, 32)
+	})
+}

--- a/chain/ton/addrconv.go
+++ b/chain/ton/addrconv.go
@@ -1,0 +1,34 @@
+package ton
+
+import (
+	"fmt"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/xssnick/tonutils-go/address"
+)
+
+// AddressToBytes converts a TON address string to bytes.
+// TON addresses can be in various formats but are normalized to 32 bytes.
+func AddressToBytes(addressStr string) ([]byte, error) {
+	addr, err := address.ParseAddr(addressStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid TON address format: %s, error: %w", addressStr, err)
+	}
+
+	// Return the raw 32-byte address data
+	return addr.Data(), nil
+}
+
+// AddressConverter implements address conversion for TON chains.
+// This struct implements the AddressConverter strategy interface.
+type AddressConverter struct{}
+
+// ConvertToBytes converts a TON address string to bytes.
+func (t AddressConverter) ConvertToBytes(address string) ([]byte, error) {
+	return AddressToBytes(address)
+}
+
+// Supports returns true if this converter supports the given chain family.
+func (t AddressConverter) Supports(family string) bool {
+	return family == chain_selectors.FamilyTon
+}

--- a/chain/ton/addrconv_test.go
+++ b/chain/ton/addrconv_test.go
@@ -1,0 +1,104 @@
+package ton
+
+import (
+	"testing"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddressToBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{
+				name:    "valid TON address",
+				address: "EQAAAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHx2j",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := AddressToBytes(tt.address)
+
+				require.NoError(t, err, "Should successfully parse valid TON address: %s", tt.address)
+				assert.Len(t, result, 32, "TON address should produce 32 bytes")
+				assert.NotNil(t, result)
+			})
+		}
+	})
+
+	t.Run("invalid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{
+				name:    "invalid - non-base64 string",
+				address: "invalid",
+			},
+			{
+				name:    "invalid - empty string",
+				address: "",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := AddressToBytes(tt.address)
+				require.Error(t, err, "Expected error for address: %s", tt.address)
+				assert.Nil(t, result)
+			})
+		}
+	})
+
+	t.Run("consistent results", func(t *testing.T) {
+		t.Parallel()
+
+		address := "EQAAAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHx2j"
+
+		result1, err1 := AddressToBytes(address)
+		require.NoError(t, err1)
+
+		result2, err2 := AddressToBytes(address)
+		require.NoError(t, err2)
+
+		assert.Equal(t, result1, result2, "Expected consistent results for the same address")
+	})
+}
+
+func TestAddressConverter(t *testing.T) {
+	t.Parallel()
+
+	converter := AddressConverter{}
+
+	t.Run("Supports", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, converter.Supports(chain_selectors.FamilyTon))
+		assert.False(t, converter.Supports(chain_selectors.FamilyEVM))
+		assert.False(t, converter.Supports(chain_selectors.FamilySolana))
+	})
+
+	t.Run("ConvertToBytes", func(t *testing.T) {
+		t.Parallel()
+
+		address := "EQAAAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHx2j"
+
+		result, err := converter.ConvertToBytes(address)
+		require.NoError(t, err)
+		assert.Len(t, result, 32)
+	})
+}

--- a/chain/tron/addrconv.go
+++ b/chain/tron/addrconv.go
@@ -1,0 +1,33 @@
+package tron
+
+import (
+	"fmt"
+
+	"github.com/fbsobreira/gotron-sdk/pkg/address"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+)
+
+// AddressToBytes converts a Tron address string to bytes.
+// Tron addresses can be in base58 format (like "TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH").
+func AddressToBytes(addressStr string) ([]byte, error) {
+	addr, err := address.Base58ToAddress(addressStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Tron address format: %s, error: %w", addressStr, err)
+	}
+
+	return addr.Bytes(), nil
+}
+
+// AddressConverter implements address conversion for Tron chains.
+// This struct implements the AddressConverter strategy interface.
+type AddressConverter struct{}
+
+// ConvertToBytes converts a Tron address string to bytes.
+func (t AddressConverter) ConvertToBytes(address string) ([]byte, error) {
+	return AddressToBytes(address)
+}
+
+// Supports returns true if this converter supports the given chain family.
+func (t AddressConverter) Supports(family string) bool {
+	return family == chain_selectors.FamilyTron
+}

--- a/chain/tron/addrconv_test.go
+++ b/chain/tron/addrconv_test.go
@@ -1,0 +1,110 @@
+package tron
+
+import (
+	"testing"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddressToBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name        string
+			address     string
+			description string
+		}{
+			{
+				name:        "valid TRON address",
+				address:     "TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH",
+				description: "Standard TRON address in base58 format",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := AddressToBytes(tt.address)
+
+				require.NoError(t, err, "Should successfully parse valid TRON address: %s (%s)", tt.address, tt.description)
+				assert.Len(t, result, 21, "TRON address should produce 21 bytes")
+				assert.NotNil(t, result)
+			})
+		}
+	})
+
+	t.Run("invalid addresses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name    string
+			address string
+		}{
+			{
+				name:    "invalid - non-base58 string",
+				address: "invalid",
+			},
+			{
+				name:    "invalid - empty string",
+				address: "",
+			},
+			{
+				name:    "invalid - wrong format",
+				address: "0x742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				result, err := AddressToBytes(tt.address)
+				require.Error(t, err, "Expected error for address: %s", tt.address)
+				assert.Nil(t, result)
+			})
+		}
+	})
+
+	t.Run("consistent results", func(t *testing.T) {
+		t.Parallel()
+
+		address := "TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH"
+
+		result1, err1 := AddressToBytes(address)
+		require.NoError(t, err1)
+
+		result2, err2 := AddressToBytes(address)
+		require.NoError(t, err2)
+
+		assert.Equal(t, result1, result2, "Expected consistent results for the same address")
+	})
+}
+
+func TestAddressConverter(t *testing.T) {
+	t.Parallel()
+
+	converter := AddressConverter{}
+
+	t.Run("Supports", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, converter.Supports(chain_selectors.FamilyTron))
+		assert.False(t, converter.Supports(chain_selectors.FamilyEVM))
+		assert.False(t, converter.Supports(chain_selectors.FamilySolana))
+	})
+
+	t.Run("ConvertToBytes", func(t *testing.T) {
+		t.Parallel()
+
+		address := "TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH"
+
+		result, err := converter.ConvertToBytes(address)
+		require.NoError(t, err)
+		assert.Len(t, result, 21)
+	})
+}

--- a/chain/utils/addrconv/addrconv.go
+++ b/chain/utils/addrconv/addrconv.go
@@ -1,0 +1,11 @@
+package addrconv
+
+// Converter defines the strategy interface for address conversion.
+// Each chain family implements this interface to provide its specific address conversion logic.
+type Converter interface {
+	// ConvertToBytes converts an address string to bytes according to the chain's format
+	ConvertToBytes(address string) ([]byte, error)
+
+	// Supports returns true if this converter supports the given chain family
+	Supports(family string) bool
+}

--- a/chain/utils/addrconv/doc.go
+++ b/chain/utils/addrconv/doc.go
@@ -1,0 +1,143 @@
+/*
+Package addrconv provides utilities for converting blockchain addresses to bytes across different chain families.
+
+This package implements the Strategy pattern to handle address conversion for various blockchain networks
+including EVM, Solana, Aptos, Sui, TON, and TRON. It automatically detects the appropriate converter
+based on the chain family and handles the conversion seamlessly.
+
+# Basic Usage
+
+The package provides a single function for address conversion:
+
+- ToBytes - converts addresses using a family string
+
+# Converting with Blockchain Interface
+
+When you have a blockchain object that implements the chain.BlockChain interface,
+you can extract the family and use it with ToBytes:
+
+	package main
+
+	import (
+		"fmt"
+		"log"
+
+		"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+		"github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+		"github.com/smartcontractkit/chainlink-deployments-framework/chain/utils/addrconv"
+		chain_selectors "github.com/smartcontractkit/chain-selectors"
+	)
+
+	func main() {
+		// Create blockchain objects
+		ethChain := evm.Chain{Selector: chain_selectors.ETHEREUM_MAINNET.Selector}
+		solChain := solana.Chain{Selector: chain_selectors.SOLANA_MAINNET.Selector}
+
+		// Convert addresses using the blockchain family
+		ethAddress := "0x742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8"
+		bytes, err := addrconv.ToBytes(ethChain.Family(), ethAddress)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Printf("EVM Address: %s\n", ethAddress)
+		fmt.Printf("Bytes: %x\n", bytes)
+		fmt.Printf("Length: %d bytes\n\n", len(bytes))
+
+		// Convert Solana address
+		solAddress := "11111111111111111111111111111112"
+		bytes, err = addrconv.ToBytes(solChain.Family(), solAddress)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Printf("Solana Address: %s\n", solAddress)
+		fmt.Printf("Bytes: %x\n", bytes)
+		fmt.Printf("Length: %d bytes\n", len(bytes))
+	}
+
+# Converting with Family Strings
+
+	package main
+
+	import (
+		"fmt"
+		"log"
+
+		"github.com/smartcontractkit/chainlink-deployments-framework/chain/utils/addrconv"
+		chain_selectors "github.com/smartcontractkit/chain-selectors"
+	)
+
+	func main() {
+		examples := []struct {
+			family  string
+			addr    string
+			desc    string
+		}{
+			{
+				family: chain_selectors.FamilyEVM,
+				addr:   "0x742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8",
+				desc:   "Ethereum address",
+			},
+			{
+				family: chain_selectors.FamilySolana,
+				addr:   "11111111111111111111111111111112",
+				desc:   "Solana System Program",
+			},
+			{
+				family: chain_selectors.FamilyAptos,
+				addr:   "0x1",
+				desc:   "Aptos framework account",
+			},
+		}
+
+		for _, example := range examples {
+			bytes, err := addrconv.ToBytes(example.family, example.addr)
+			if err != nil {
+				log.Printf("Error converting %s: %v", example.desc, err)
+				continue
+			}
+
+			fmt.Printf("%s (%s):\n", example.desc, example.family)
+			fmt.Printf("  Address: %s\n", example.addr)
+			fmt.Printf("  Bytes: %x\n", bytes)
+			fmt.Printf("  Length: %d bytes\n\n", len(bytes))
+		}
+	}
+
+# Supported Chain Families
+
+The package supports the following blockchain families:
+
+	EVM (Ethereum Virtual Machine):
+	  - Family: chain_selectors.FamilyEVM
+	  - Address format: 0x prefixed hex (20 bytes)
+	  - Examples: Ethereum, Polygon, BSC, Avalanche
+	  - Sample: "0x742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8"
+
+	Solana:
+	  - Family: chain_selectors.FamilySolana
+	  - Address format: Base58 encoded (32 bytes)
+	  - Sample: "11111111111111111111111111111112"
+
+	Aptos:
+	  - Family: chain_selectors.FamilyAptos
+	  - Address format: 0x prefixed hex, variable length (32 bytes normalized)
+	  - Samples: "0x1", "0x0000...0001"
+
+	Sui:
+	  - Family: chain_selectors.FamilySui
+	  - Address format: 0x prefixed hex (32 bytes)
+	  - Sample: "0xa402ce953053607dffcdfec89406c579c8d8ddb9c90e01b7aa28f5f1538ac289"
+
+	TON:
+	  - Family: chain_selectors.FamilyTon
+	  - Address format: Base64 encoded (32 bytes)
+	  - Sample: "EQAAAQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHx2j"
+
+	TRON:
+	  - Family: chain_selectors.FamilyTron
+	  - Address format: Base58 encoded (21 bytes)
+	  - Sample: "TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH"
+*/
+package addrconv

--- a/chain/utils/addrconv/registry.go
+++ b/chain/utils/addrconv/registry.go
@@ -1,0 +1,71 @@
+package addrconv
+
+import (
+	"fmt"
+	"sync"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/sui"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/ton"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/tron"
+)
+
+var (
+	defaultRegistryOnce sync.Once
+	defaultRegistry     *addressConverterRegistry
+)
+
+func registry() *addressConverterRegistry {
+	defaultRegistryOnce.Do(func() {
+		defaultRegistry = newAddressConverterRegistry()
+	})
+
+	return defaultRegistry
+}
+
+// ToBytes converts an address string to bytes based on the chain family.
+//
+// Usage:
+//
+//	bytes, err := addrconv.ToBytes("evm", "0x742d35Cc...")
+func ToBytes(family, address string) ([]byte, error) {
+	return registry().convertAddressByFamily(family, address)
+}
+
+// addressConverterRegistry manages address conversion strategies for different chain families.
+// It uses the strategy pattern to delegate address conversion to the appropriate implementation.
+type addressConverterRegistry struct {
+	converters map[string]Converter
+}
+
+// newAddressConverterRegistry creates a new registry with all supported chain converters pre-registered.
+func newAddressConverterRegistry() *addressConverterRegistry {
+	registry := &addressConverterRegistry{
+		converters: make(map[string]Converter),
+	}
+
+	// Register all supported converters using constants
+	registry.converters[chain_selectors.FamilyEVM] = evm.AddressConverter{}
+	registry.converters[chain_selectors.FamilySolana] = solana.AddressConverter{}
+	registry.converters[chain_selectors.FamilyAptos] = aptos.AddressConverter{}
+	registry.converters[chain_selectors.FamilySui] = sui.AddressConverter{}
+	registry.converters[chain_selectors.FamilyTon] = ton.AddressConverter{}
+	registry.converters[chain_selectors.FamilyTron] = tron.AddressConverter{}
+
+	return registry
+}
+
+// convertAddressByFamily converts an address string to bytes using the family name.
+func (r *addressConverterRegistry) convertAddressByFamily(family, address string) ([]byte, error) {
+	converter, exists := r.converters[family]
+
+	if !exists {
+		return nil, fmt.Errorf("no address converter registered for family: %s", family)
+	}
+
+	return converter.ConvertToBytes(address)
+}

--- a/chain/utils/addrconv/registry_test.go
+++ b/chain/utils/addrconv/registry_test.go
@@ -1,0 +1,122 @@
+package addrconv
+
+import (
+	"testing"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAddressConverterRegistry(t *testing.T) {
+	t.Parallel()
+
+	registry := newAddressConverterRegistry()
+
+	// Test that registry is properly initialized
+	require.NotNil(t, registry)
+	require.NotNil(t, registry.converters)
+
+	// Test that all expected converters are registered with correct functionality
+	expectedFamilies := []string{
+		chain_selectors.FamilyEVM,
+		chain_selectors.FamilySolana,
+		chain_selectors.FamilyAptos,
+		chain_selectors.FamilySui,
+		chain_selectors.FamilyTon,
+		chain_selectors.FamilyTron,
+	}
+
+	for _, family := range expectedFamilies {
+		t.Run(family, func(t *testing.T) {
+			t.Parallel()
+
+			converter, exists := registry.converters[family]
+			assert.True(t, exists, "Converter for family %s should be registered", family)
+			assert.NotNil(t, converter, "Converter for family %s should not be nil", family)
+
+			// Verify the converter actually supports its registered family
+			assert.True(t, converter.Supports(family), "Converter should support its own family %s", family)
+		})
+	}
+
+	// Test that the correct number of converters are registered
+	assert.Len(t, registry.converters, len(expectedFamilies))
+}
+
+func TestAddressToBytes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		family         string
+		address        string
+		expectedLength int
+		shouldError    bool
+		errorContains  string
+	}{
+		{
+			name:           "EVM family conversion",
+			family:         chain_selectors.FamilyEVM,
+			address:        "0x742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8",
+			expectedLength: 20,
+			shouldError:    false,
+		},
+		{
+			name:           "Solana family conversion",
+			family:         chain_selectors.FamilySolana,
+			address:        "11111111111111111111111111111112",
+			expectedLength: 32,
+			shouldError:    false,
+		},
+		{
+			name:           "Aptos family conversion",
+			family:         chain_selectors.FamilyAptos,
+			address:        "0x1",
+			expectedLength: 32,
+			shouldError:    false,
+		},
+		{
+			name:          "Unsupported family",
+			family:        "unknown",
+			address:       "0x742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8",
+			shouldError:   true,
+			errorContains: "no address converter registered for family: unknown",
+		},
+		{
+			name:          "Invalid address",
+			family:        chain_selectors.FamilyEVM,
+			address:       "invalid",
+			shouldError:   true,
+			errorContains: "invalid EVM address format",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			bytes, err := ToBytes(tc.family, tc.address)
+
+			if tc.shouldError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errorContains)
+				assert.Nil(t, bytes)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, bytes)
+				assert.Len(t, bytes, tc.expectedLength)
+			}
+		})
+	}
+}
+
+func TestRegistrySingleton(t *testing.T) {
+	t.Parallel()
+
+	// Test that registry() returns the same instance
+	registry1 := registry()
+	registry2 := registry()
+
+	assert.Same(t, registry1, registry2, "registry() should return the same singleton instance")
+}


### PR DESCRIPTION
Context: https://chainlink-core.slack.com/archives/C08QF1BEW4T/p1756934131485399

Design thoughts:
Initially i went with [this design](https://github.com/smartcontractkit/chainlink-deployments-framework/pull/376) where i introduced the AddressToBytes method to the blockchain interface. However i didn quite like this approach because `AddressToBytes` feels out of place in the blockchain interface (it could be its own interface, and to convert address, we dont need the `chain` struct) and this also forces all implementations of blockchain to implement `AddressToBytes`. 

So i went with the approach in this PR, introducing a new interface call AddressConverter and using the strategy pattern for each chain to provide the conversion functionality. This decouples the Address conversion logic from the Blockchain interface.


This commit adds support for converting string address to bytes for each of the supported chain.

### ToBytes
```
		ethChain := e.BlockChains.EVMChains()[0]
		bytes, err := address.ToBytesForFamily(ethChain.Family(), "0x742d35Cc6634C0532925a3b8D4c8C1B8c4c8C1B8")
```


JIRA: https://smartcontract-it.atlassian.net/browse/CLD-606