### PR TITLE
TON: connection with liteserver url

### DIFF
--- a/chain/ton/provider/ctf_provider.go
+++ b/chain/ton/provider/ctf_provider.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/xssnick/tonutils-go/address"
-	"github.com/xssnick/tonutils-go/liteclient"
 	"github.com/xssnick/tonutils-go/tlb"
 	"github.com/xssnick/tonutils-go/ton"
 	"github.com/xssnick/tonutils-go/ton/wallet"
@@ -121,7 +120,7 @@ func (p *CTFChainProvider) startContainer(chainID string) (string, *ton.APIClien
 			Type:    blockchain.TypeTon,
 			ChainID: chainID,
 			Port:    strconv.Itoa(port),
-			Image:   "ghcr.io/neodix42/mylocalton-docker:dev", // as of 11th Aug 2025, the tag 'latest' image used by default fails to startup. Override it with the 'dev' image
+			Image:   "ghcr.io/neodix42/mylocalton-docker:v3.7",
 		})
 		if rerr != nil {
 			// Return the ports to freeport to avoid leaking them during retries
@@ -144,19 +143,15 @@ func (p *CTFChainProvider) startContainer(chainID string) (string, *ton.APIClien
 	)
 	require.NoError(p.t, err, "Failed to start CTF Ton container after %d attempts", attempts)
 
-	// get local config from simple http server in genesis node
-	cfg, err := liteclient.GetConfigFromUrl(p.t.Context(), fmt.Sprintf("http://%s/localhost.global.config.json", url))
-	require.NoError(p.t, err)
+	connectionPool, err := getConnectionPoolFromLiteserverURL(p.t.Context(), url)
 
-	// establish connection to the TON node
-	connectionPool := liteclient.NewConnectionPool()
-	err = connectionPool.AddConnectionsFromConfig(p.t.Context(), cfg)
 	require.NoError(p.t, err)
 	client := ton.NewAPIClient(connectionPool, ton.ProofCheckPolicyFast)
-	client.SetTrustedBlockFromConfig(cfg)
 
 	// check connection, CTFv2 handles the readiness
-	checkConnection(p.t, client)
+	mb := checkConnection(p.t, client)
+	// set starting point to verify master block proofs chain
+	client.SetTrustedBlock(mb)
 
 	return url, client
 }
@@ -202,12 +197,15 @@ func fundTonWallets(t *testing.T, client ton.APIClientWrapped, recipients []*add
 	// we don't wait for the transaction to be confirmed here, as it may take some time
 }
 
-func checkConnection(t *testing.T, client *ton.APIClient) {
+func checkConnection(t *testing.T, client *ton.APIClient) *ton.BlockIDExt {
 	t.Helper()
 
+	var masterchainBlock *ton.BlockIDExt
 	err := retry.Do(func() error {
 		// check connection, CTFv2 handles the readiness
-		_, err := client.GetMasterchainInfo(t.Context())
+		var err error
+		masterchainBlock, err = client.GetMasterchainInfo(t.Context())
+
 		return err
 	},
 		retry.Context(t.Context()),
@@ -215,8 +213,10 @@ func checkConnection(t *testing.T, client *ton.APIClient) {
 		retry.Delay(1*time.Second),
 		retry.DelayType(retry.FixedDelay),
 	)
-
 	require.NoError(t, err, "TON network not ready")
+
+	// return masterchain block for setting trusted block
+	return masterchainBlock
 }
 
 // Name returns the name of the CTFChainProvider.

--- a/chain/ton/provider/rpc_provider_test.go
+++ b/chain/ton/provider/rpc_provider_test.go
@@ -20,24 +20,24 @@ func Test_RPCChainProviderConfig_validate(t *testing.T) {
 		{
 			name: "valid config (empty wallet version uses default)",
 			giveConfigFunc: func(c *RPCChainProviderConfig) {
-				c.HTTPURL = "http://localhost:8080/config.json"
+				c.HTTPURL = "liteserver://publickey@localhost:8080"
 				c.WSURL = "ws://localhost:8080"
 				c.DeployerSignerGen = PrivateKeyRandom()
 				c.WalletVersion = ""
 			},
 		},
 		{
-			name: "missing http url",
+			name: "missing liteserver url",
 			giveConfigFunc: func(c *RPCChainProviderConfig) {
 				c.HTTPURL = ""
 				c.DeployerSignerGen = PrivateKeyRandom()
 			},
-			wantErr: "rpc url is required",
+			wantErr: "liteserver url is required",
 		},
 		{
 			name: "missing deployer signer generator",
 			giveConfigFunc: func(c *RPCChainProviderConfig) {
-				c.HTTPURL = "http://localhost:8080/config.json"
+				c.HTTPURL = "liteserver://publickey@localhost:8080"
 				c.DeployerSignerGen = nil
 			},
 			wantErr: "deployer signer generator is required",
@@ -45,7 +45,7 @@ func Test_RPCChainProviderConfig_validate(t *testing.T) {
 		{
 			name: "unsupported wallet version",
 			giveConfigFunc: func(c *RPCChainProviderConfig) {
-				c.HTTPURL = "http://localhost:8080/config.json"
+				c.HTTPURL = "liteserver://publickey@localhost:8080"
 				c.DeployerSignerGen = PrivateKeyRandom()
 				c.WalletVersion = "V9R9"
 			},
@@ -99,21 +99,21 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 				t.Helper()
 				return RPCChainProviderConfig{} // invalid
 			},
-			wantErr: "rpc url is required",
+			wantErr: "liteserver url is required",
 		},
 		{
-			name:         "fails to retrieve ton network config (bad URL)",
+			name:         "fails to connect to liteserver (bad URL)",
 			giveSelector: selector,
 			giveConfigFunc: func(t *testing.T) RPCChainProviderConfig {
 				t.Helper()
 				return RPCChainProviderConfig{
-					HTTPURL:           "http://127.0.0.1:0/not-a-config.json",
+					HTTPURL:           "liteserver://invalidkey@127.0.0.1:0",
 					WSURL:             "",
 					DeployerSignerGen: PrivateKeyRandom(),
 					WalletVersion:     "",
 				}
 			},
-			wantErr: "failed to retrieve ton network config",
+			wantErr: "failed to connect to liteserver",
 		},
 		{
 			name:         "fails to generate private key",
@@ -121,7 +121,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 			giveConfigFunc: func(t *testing.T) RPCChainProviderConfig {
 				t.Helper()
 				return RPCChainProviderConfig{
-					HTTPURL:           "https://ton-blockchain.github.io/testnet-global.config.json", // will fail before keygen if URL is good; keep bad URL to avoid network
+					HTTPURL:           "liteserver://validkey@127.0.0.1:0", // will fail before keygen if URL is good; keep bad URL to avoid network
 					DeployerSignerGen: PrivateKeyFromRaw("invalid-key"),
 				}
 			},
@@ -133,7 +133,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 			giveConfigFunc: func(t *testing.T) RPCChainProviderConfig {
 				t.Helper()
 				return RPCChainProviderConfig{
-					HTTPURL:           "https://ton-blockchain.github.io/testnet-global.config.json",
+					HTTPURL:           "liteserver://Pk9K5wQLvlFapDT6BVBuSXg3yh7GHjV5IFsAJqPGvxQ=@13.232.131.210:46995",
 					DeployerSignerGen: PrivateKeyFromRaw("0b1f7dbb19112fdac53344cf49731e41bfc420ac6a71d38c89fb38d04a6563d99aa3d1fa430550e8de5171ec55453b4e048c1701cadfa56726d489c56d67bab3"),
 				}
 			},

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250815142532-64e0a7965958
 	github.com/smartcontractkit/chainlink-protos/chainlink-catalog v0.0.2
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0
-	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.15
+	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.22
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335
 	github.com/smartcontractkit/freeport v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -699,6 +699,8 @@ github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0 h1:/bhoALRz
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.15 h1:OyX2Z68z6VDY4aadqMXjwSTE/0misA5fk8Iq710nxkk=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.15/go.mod h1:gdW2dlrvHcTawMCtAIXQYZcZ9Ggx16L55kA7wONvzJ4=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.22 h1:lEOpD67s0t84zOcEwgGKjZu2/Any1F9wtJMk8HXLxdY=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.22/go.mod h1:gdW2dlrvHcTawMCtAIXQYZcZ9Ggx16L55kA7wONvzJ4=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 h1:ZJ/8Jx6Be5//TyjPi1pS1uotnmcYq5vVkSyISIymSj8=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335 h1:7bxYNrPpygn8PUSBiEKn8riMd7CXMi/4bjTy0fHhcrY=


### PR DESCRIPTION
This PR updates TON provider's behavior to directly use the `liteserver://` connection string.
This PR also bumps CTF/TON to use the updated MyLocalTON Image([v3.7](https://github.com/neodix42/mylocalton-docker/releases)) in testing environment

Related PRs:
- https://github.com/smartcontractkit/chainlink-ton/pull/155
- https://github.com/smartcontractkit/chainlink-testing-framework/pull/2089