### PR TITLE
ci: run go mod download on push

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           use-go-cache: true # this will setup the go cache
           only-modules: true
+      - name: Run go mod download
+        run: go mod download
 
   cd-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION

I noticed in my previous PR, i forgot to download the go module so it can be cached. We need to run go mod download in order to download the go modules for caching.