### PR TITLE
fix(geth-prov-test): pack tests into less consuming way

### DIFF
--- a/chain/evm/provider/ctf_geth_provider_test.go
+++ b/chain/evm/provider/ctf_geth_provider_test.go
@@ -228,9 +228,8 @@ func TestCTFGethChainProvider_Initialize_And_WS(t *testing.T) {
 	require.Empty(t, evmChain.Users)
 
 	// Idempotence: second init returns same chain instance behavior (no crash / no re-spin)
-	bc2, err2 := p.Initialize(ctx)
+	_, err2 := p.Initialize(ctx)
 	require.NoError(t, err2)
-	_ = bc2 // intentionally not asserting pointer identity to avoid brittle checks
 
 	// WS connectivity & subscription (CTF exposes WS on same host:port; swap scheme)
 	wsURL := strings.Replace(httpURL, "http://", "ws://", 1)


### PR DESCRIPTION
Containers: down from ~14 to 3 per run 

How it’s packed now:
- One test covers init + HTTP/WS.
- One test covers AdditionalAccounts creation, funding, and idempotent re-Initialize.
- One test covers cleanup with a fixed port (prod-like path).

Coverage: functionally the same as before; we only dropped the redundant “maximum user accounts” test.