### PR TITLE
fix: update findWorkspaceRoot

### DIFF
--- a/.changeset/two-glasses-read.md
+++ b/.changeset/two-glasses-read.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix: update findWorkspaceRoot to not check for root go.mod

--- a/engine/cld/legacy/cli/commands/durable-pipelines_helper.go
+++ b/engine/cld/legacy/cli/commands/durable-pipelines_helper.go
@@ -61,11 +61,9 @@ func findWorkspaceRoot() (string, error) {
 
 	// Walk up directories looking for the root go.mod
 	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			// Check if this looks like the workspace root by looking for domains/
-			if _, err := os.Stat(filepath.Join(dir, "domains")); err == nil {
-				return dir, nil
-			}
+		// Check if this looks like the workspace root by looking for domains/
+		if _, err := os.Stat(filepath.Join(dir, "domains")); err == nil {
+			return dir, nil
 		}
 
 		parent := filepath.Dir(dir)

--- a/engine/cld/legacy/cli/commands/durable-pipelines_test.go
+++ b/engine/cld/legacy/cli/commands/durable-pipelines_test.go
@@ -172,7 +172,6 @@ func TestNewDurablePipelineInputGenerateCmd(t *testing.T) {
 	require.NoError(t, os.MkdirAll(inputsDir, 0755))
 
 	// Mock workspace root discovery
-	require.NoError(t, os.WriteFile(filepath.Join(workspaceRoot, "go.mod"), []byte("module test"), 0644)) //nolint:gosec
 	require.NoError(t, os.MkdirAll(filepath.Join(workspaceRoot, "domains"), 0755))
 
 	// Set up the test to run from within the workspace
@@ -724,7 +723,6 @@ changesets:
 	require.NoError(t, os.WriteFile(inputsFilePath, []byte(mockInputContent), 0644)) //nolint:gosec
 
 	// Mock workspace root discovery
-	require.NoError(t, os.WriteFile(filepath.Join(workspaceRoot, "go.mod"), []byte("module test"), 0644)) //nolint:gosec
 	require.NoError(t, os.MkdirAll(filepath.Join(workspaceRoot, "domains"), 0755))
 
 	// Set up the test to run from within the workspace
@@ -825,7 +823,6 @@ changesets:
 	require.NoError(t, os.WriteFile(yamlFilePath, []byte(yamlContent), 0644)) //nolint:gosec
 
 	// Mock workspace root discovery
-	require.NoError(t, os.WriteFile(filepath.Join(workspaceRoot, "go.mod"), []byte("module test"), 0644)) //nolint:gosec
 	require.NoError(t, os.MkdirAll(filepath.Join(workspaceRoot, "domains"), 0755))
 
 	// Set up the test to run from within the workspace
@@ -1030,7 +1027,6 @@ changesets:
 	require.NoError(t, os.WriteFile(yamlFilePath, []byte(yamlContent), 0644)) //nolint:gosec
 
 	// Mock workspace root discovery
-	require.NoError(t, os.WriteFile(filepath.Join(workspaceRoot, "go.mod"), []byte("module test"), 0644)) //nolint:gosec
 	require.NoError(t, os.MkdirAll(filepath.Join(workspaceRoot, "domains"), 0755))
 
 	// Set up the test to run from within the workspace
@@ -1109,7 +1105,6 @@ func TestSetDurablePipelineInputFromYAML_ChainOverrideTypes(t *testing.T) {
 	require.NoError(t, os.MkdirAll(inputsDir, 0755))
 
 	// Mock workspace root discovery
-	require.NoError(t, os.WriteFile(filepath.Join(workspaceRoot, "go.mod"), []byte("module test"), 0644)) //nolint:gosec
 	require.NoError(t, os.MkdirAll(filepath.Join(workspaceRoot, "domains"), 0755))
 
 	// Set up the test to run from within the workspace
@@ -1264,7 +1259,6 @@ func TestSetDurablePipelineInputFromYAML_ChainSelectorKeys(t *testing.T) {
 	require.NoError(t, os.MkdirAll(inputsDir, 0755))
 
 	// Mock workspace root discovery
-	require.NoError(t, os.WriteFile(filepath.Join(workspaceRoot, "go.mod"), []byte("module test"), 0644)) //nolint:gosec
 	require.NoError(t, os.MkdirAll(filepath.Join(workspaceRoot, "domains"), 0755))
 
 	// Change to the workspace root directory to test relative path resolution


### PR DESCRIPTION
findWorkspaceRoot assumes root has a go.mod , this is no longer the case as we have now removed the root go mod in CLD. Removing that assumption.