### PR TITLE
[CLD-584]: feat: enhance OnlyLoadChainsFor to support loading no chains

### DIFF
--- a/.changeset/few-candies-poke.md
+++ b/.changeset/few-candies-poke.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat: enhance OnlyLoadChainsFor to support loading no chains when no chains is provided, eg OnlyLoadChainsFor()

--- a/engine/cld/chains/chains.go
+++ b/engine/cld/chains/chains.go
@@ -34,6 +34,10 @@ func LoadChains(
 	cfg *config.Config,
 	chainselToLoad []uint64,
 ) (fchain.BlockChains, error) {
+	if len(chainselToLoad) == 0 {
+		lggr.Info("No chain selectors provided, skipping chain loading")
+		return fchain.NewBlockChains(map[uint64]fchain.BlockChain{}), nil
+	}
 	chainLoaders := newChainLoaders(lggr, cfg.Networks, cfg.Env.Onchain)
 
 	// Define a result struct to hold chain loading results

--- a/engine/cld/changeset/registry.go
+++ b/engine/cld/changeset/registry.go
@@ -164,17 +164,21 @@ type ChangesetOption func(*ChangesetConfig)
 
 // ChangesetConfig holds configuration options for a changeset
 type ChangesetConfig struct {
-	ChainsToLoad      []uint64
+	ChainsToLoad      []uint64 // nil = load all chains, empty = load no chains, populated = load specific chains
 	WithoutJD         bool
 	OperationRegistry *foperations.OperationRegistry
 }
 
 // OnlyLoadChainsFor will configure the environment to load only the specified chains.
-// By default, if option is not specified, all chains are loaded.
-// This is useful for changesets that are only applicable to a subset of chains.
+// By default, if this option is not specified, all chains are loaded.
+// If user provide empty or nil value, eg OnlyLoadChainsFor(), no chains will be loaded.
 func OnlyLoadChainsFor(chainselectors ...uint64) ChangesetOption {
 	return func(o *ChangesetConfig) {
-		o.ChainsToLoad = chainselectors
+		if chainselectors == nil {
+			o.ChainsToLoad = []uint64{} // Ensure we have an empty slice, not nil
+		} else {
+			o.ChainsToLoad = chainselectors
+		}
 	}
 }
 

--- a/engine/cld/changeset/registry_test.go
+++ b/engine/cld/changeset/registry_test.go
@@ -254,6 +254,17 @@ func Test_Changesets_GetChangesetOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "a changeset with OnlyLoadChainsFor empty (load no chains)",
+			setup: func(r *ChangesetsRegistry) {
+				r.Add("0003_cap_reg", noopChangeset{}, OnlyLoadChainsFor())
+			},
+			giveKey: "0003_cap_reg",
+			want: ChangesetConfig{
+				ChainsToLoad: []uint64{},
+				WithoutJD:    false,
+			},
+		},
+		{
 			name: "a changeset with WithoutJD option",
 			setup: func(r *ChangesetsRegistry) {
 				r.Add("0003_cap_reg", noopChangeset{}, WithoutJD())

--- a/engine/cld/environment/environment.go
+++ b/engine/cld/environment/environment.go
@@ -70,7 +70,7 @@ func Load(
 	// default - loads all chains
 	chainSelectorsToLoad := slices.Collect(maps.Keys(addressesByChain))
 
-	if loadcfg.migrationString != "" && len(loadcfg.chainSelectorsToLoad) > 0 {
+	if loadcfg.migrationString != "" && loadcfg.chainSelectorsToLoad != nil {
 		lggr.Infow("Override: loading migration chains", "migration", loadcfg.migrationString, "chains", loadcfg.chainSelectorsToLoad)
 		chainSelectorsToLoad = loadcfg.chainSelectorsToLoad
 	}

--- a/engine/cld/environment/options.go
+++ b/engine/cld/environment/options.go
@@ -25,7 +25,8 @@ type LoadConfig struct {
 	migrationString string
 
 	// chainSelectorsToLoad specifies which chain selectors to load when using
-	// OnlyLoadChainsFor. If empty, all chains are loaded by default.
+	// OnlyLoadChainsFor.
+	// nil = load all chains, empty = load no chains, populated = load specific chains
 	chainSelectorsToLoad []uint64
 
 	// withoutJD determines whether to skip Job Distributor initialization.
@@ -121,12 +122,18 @@ func WithoutJD() LoadEnvironmentOption {
 // required for a specific migration. This can significantly reduce loading time
 // and resource usage when working with environments that support many chains.
 //
-// By default, all available chains in the environment are loaded. This option
-// allows you to specify exactly which chains are needed.
+// By default, if this option is not specified, all chains are loaded.
+// If chainsSelectors is set to nil or empty, no chains will be loaded.
 func OnlyLoadChainsFor(migrationKey string, chainsSelectors []uint64) LoadEnvironmentOption {
 	return func(o *LoadConfig) {
 		o.migrationString = migrationKey
-		o.chainSelectorsToLoad = chainsSelectors
+		if chainsSelectors == nil {
+			// Ensure we have an empty slice, not nil, this indicates option is provided but
+			// no chains should be loaded
+			o.chainSelectorsToLoad = []uint64{}
+		} else {
+			o.chainSelectorsToLoad = chainsSelectors
+		}
 	}
 }
 

--- a/engine/cld/environment/options_test.go
+++ b/engine/cld/environment/options_test.go
@@ -63,6 +63,18 @@ func Test_OnlyLoadChainsFor(t *testing.T) {
 
 	assert.Equal(t, migrationKey, opts.migrationString)
 	assert.Equal(t, chainSelectors, opts.chainSelectorsToLoad)
+
+	// Test with nil chainSelectors
+	opts = &LoadConfig{}
+	option = OnlyLoadChainsFor(migrationKey, nil)
+	option(opts)
+	assert.Equal(t, []uint64{}, opts.chainSelectorsToLoad)
+
+	// Test with empty chainSelectors
+	opts = &LoadConfig{}
+	option = OnlyLoadChainsFor(migrationKey, []uint64{})
+	option(opts)
+	assert.Equal(t, []uint64{}, opts.chainSelectorsToLoad)
 }
 
 func Test_WithOperationRegistry(t *testing.T) {

--- a/engine/cld/legacy/cli/commands/durable-pipelines_test.go
+++ b/engine/cld/legacy/cli/commands/durable-pipelines_test.go
@@ -1192,7 +1192,7 @@ changesets:
     chainOverrides: []`,
 			changesetName: "test_changeset",
 			expectError:   false,
-			expectedJSON:  `"message":"test"`, // chainOverrides should be omitted when empty
+			expectedJSON:  `{"chainOverrides":[],"payload":{"message":"test"}}`,
 		},
 		{
 			name: "missing chainOverrides should work",

--- a/engine/cld/legacy/cli/commands/durable_pipeline_yaml.go
+++ b/engine/cld/legacy/cli/commands/durable_pipeline_yaml.go
@@ -71,9 +71,8 @@ func setDurablePipelineInputFromYAML(inputFileName, changesetName string, domain
 		return fmt.Errorf("failed to convert payload to JSON-safe format: %w", err)
 	}
 
-	// Extract chain overrides (optional)
-	var chainOverrides []uint64
-	if chainOverridesRaw, exists := changesetMap["chainOverrides"]; exists && chainOverridesRaw != nil {
+	chainOverridesRaw, exists := changesetMap["chainOverrides"]
+	if exists && chainOverridesRaw != nil {
 		if chainOverridesList, ok := chainOverridesRaw.([]any); ok {
 			for _, override := range chainOverridesList {
 				switch v := override.(type) {
@@ -81,14 +80,12 @@ func setDurablePipelineInputFromYAML(inputFileName, changesetName string, domain
 					if v < 0 {
 						return fmt.Errorf("chain override value must be non-negative, got: %d", v)
 					}
-					chainOverrides = append(chainOverrides, uint64(v))
 				case int64:
 					if v < 0 {
 						return fmt.Errorf("chain override value must be non-negative, got: %d", v)
 					}
-					chainOverrides = append(chainOverrides, uint64(v))
 				case uint64:
-					chainOverrides = append(chainOverrides, v)
+					// no need to do any checks here
 				default:
 					return fmt.Errorf("chain override value must be an integer, got type %T with value: %v", override, override)
 				}
@@ -100,8 +97,8 @@ func setDurablePipelineInputFromYAML(inputFileName, changesetName string, domain
 	inputJSON := map[string]any{
 		"payload": jsonSafePayload,
 	}
-	if len(chainOverrides) > 0 {
-		inputJSON["chainOverrides"] = chainOverrides
+	if exists {
+		inputJSON["chainOverrides"] = chainOverridesRaw
 	}
 
 	// Convert to JSON


### PR DESCRIPTION
As part of a support request, users have changeset which only manipulates JD and does not require any on chain activity, they want to tell CLD not to load any chains. By updating `OnlyLoadChainsFor` to support accepting empty or [] slice, CLD will then skip any chain loading process.

```yaml
environment: testnet
domain: exemplar
changesets:
  deploy_link_token:
    chainOverrides: [] # this is tell CLD to skip loading any chains
    payload:
      - 5224473277236331295
```

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-584