### PR TITLE
fix(OnlyLoadChainsFor)!: remove migration name parameter for environment option

### DIFF
--- a/.changeset/two-ducks-ring.md
+++ b/.changeset/two-ducks-ring.md
@@ -1,0 +1,21 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix(OnlyLoadChainsFor)!: remove migration name parameter for environment option
+
+BREAKING CHANGE: The `environment` option in `OnlyLoadChainsFor` no longer accepts a migration name parameter. The name parameter was only used for logging which is not necessary.
+
+### Usage Migration
+
+**Before:**
+
+```go
+environment.OnlyLoadChainsFor("analyze-proposal", chainSelectors), cldfenvironment.WithoutJD())
+```
+
+**After:**
+
+```go
+environment.OnlyLoadChainsFor(chainSelectors), cldfenvironment.WithoutJD())
+```

--- a/engine/cld/environment/environment.go
+++ b/engine/cld/environment/environment.go
@@ -70,8 +70,8 @@ func Load(
 	// default - loads all chains
 	chainSelectorsToLoad := slices.Collect(maps.Keys(addressesByChain))
 
-	if loadcfg.migrationString != "" && loadcfg.chainSelectorsToLoad != nil {
-		lggr.Infow("Override: loading migration chains", "migration", loadcfg.migrationString, "chains", loadcfg.chainSelectorsToLoad)
+	if loadcfg.chainSelectorsToLoad != nil {
+		lggr.Infow("Override: loading chains", "chains", loadcfg.chainSelectorsToLoad)
 		chainSelectorsToLoad = loadcfg.chainSelectorsToLoad
 	}
 

--- a/engine/cld/environment/options.go
+++ b/engine/cld/environment/options.go
@@ -19,11 +19,6 @@ type LoadConfig struct {
 	// Defaults to operations.NewOperationRegistry() if not specified.
 	operationRegistry *operations.OperationRegistry
 
-	// migrationString identifies a specific migration when using OnlyLoadChainsFor.
-	// Used in conjunction with chainSelectorsToLoad to limit environment loading
-	// to specific chains for a particular migration.
-	migrationString string
-
 	// chainSelectorsToLoad specifies which chain selectors to load when using
 	// OnlyLoadChainsFor.
 	// nil = load all chains, empty = load no chains, populated = load specific chains
@@ -124,9 +119,8 @@ func WithoutJD() LoadEnvironmentOption {
 //
 // By default, if this option is not specified, all chains are loaded.
 // If chainsSelectors is set to nil or empty, no chains will be loaded.
-func OnlyLoadChainsFor(migrationKey string, chainsSelectors []uint64) LoadEnvironmentOption {
+func OnlyLoadChainsFor(chainsSelectors []uint64) LoadEnvironmentOption {
 	return func(o *LoadConfig) {
-		o.migrationString = migrationKey
 		if chainsSelectors == nil {
 			// Ensure we have an empty slice, not nil, this indicates option is provided but
 			// no chains should be loaded

--- a/engine/cld/environment/options_test.go
+++ b/engine/cld/environment/options_test.go
@@ -52,27 +52,24 @@ func Test_OnlyLoadChainsFor(t *testing.T) {
 	t.Parallel()
 
 	opts := &LoadConfig{}
-	assert.Empty(t, opts.migrationString)
 	assert.Nil(t, opts.chainSelectorsToLoad)
 
-	migrationKey := "test_migration"
 	chainSelectors := []uint64{1, 2, 3}
 
-	option := OnlyLoadChainsFor(migrationKey, chainSelectors)
+	option := OnlyLoadChainsFor(chainSelectors)
 	option(opts)
 
-	assert.Equal(t, migrationKey, opts.migrationString)
 	assert.Equal(t, chainSelectors, opts.chainSelectorsToLoad)
 
 	// Test with nil chainSelectors
 	opts = &LoadConfig{}
-	option = OnlyLoadChainsFor(migrationKey, nil)
+	option = OnlyLoadChainsFor(nil)
 	option(opts)
 	assert.Equal(t, []uint64{}, opts.chainSelectorsToLoad)
 
 	// Test with empty chainSelectors
 	opts = &LoadConfig{}
-	option = OnlyLoadChainsFor(migrationKey, []uint64{})
+	option = OnlyLoadChainsFor([]uint64{})
 	option(opts)
 	assert.Equal(t, []uint64{}, opts.chainSelectorsToLoad)
 }

--- a/engine/cld/legacy/cli/commands/migration_helper.go
+++ b/engine/cld/legacy/cli/commands/migration_helper.go
@@ -45,7 +45,7 @@ func configureEnvironmentOptions(
 		return nil, err
 	}
 	if chainOverrides != nil {
-		envOptions = append(envOptions, environment.OnlyLoadChainsFor(migrationStr, chainOverrides))
+		envOptions = append(envOptions, environment.OnlyLoadChainsFor(chainOverrides))
 	}
 
 	if migrationOptions.WithoutJD {

--- a/engine/cld/legacy/cli/mcmsv2/mcms_v2.go
+++ b/engine/cld/legacy/cli/mcmsv2/mcms_v2.go
@@ -1079,7 +1079,7 @@ func newCfgv2(lggr logger.Logger, cmd *cobra.Command, domain cldf_domain.Domain,
 		// Load Environment and proposal ctx (for error decoding and proposal analysis)
 		env, err := cldfenvironment.Load(cmd.Context(), domain, cfg.envStr,
 			cldfenvironment.WithLogger(lggr),
-			cldfenvironment.OnlyLoadChainsFor("analyze-proposal", chainSelectors), cldfenvironment.WithoutJD())
+			cldfenvironment.OnlyLoadChainsFor(chainSelectors), cldfenvironment.WithoutJD())
 		if err != nil {
 			return nil, fmt.Errorf("error loading environment: %w", err)
 		}
@@ -1100,7 +1100,7 @@ func newCfgv2(lggr logger.Logger, cmd *cobra.Command, domain cldf_domain.Domain,
 			flags.environmentStr,
 			nil,
 			cldfenvironment.WithLogger(lggr),
-			cldfenvironment.OnlyLoadChainsFor("fork-test", cfgSelectors),
+			cldfenvironment.OnlyLoadChainsFor(cfgSelectors),
 			cldfenvironment.WithAnvilKeyAsDeployer(),
 		)
 		if err != nil {


### PR DESCRIPTION
The environment option OnlyLoadChainsFor [first parameter](https://github.com/smartcontractkit/chainlink-deployments-framework/blob/c2417566058ff4dd502a17d9b28242e26968406a/engine/cld/environment/options.go#L122-L122) is not needed as it is use for logging the migration name which can be removed.

This cleans up the interface as currently users are forced to provide a migration name even when they are not running a migration but just want to load environment eg mcms [here](https://github.com/smartcontractkit/chainlink-deployments-framework/blob/c2417566058ff4dd502a17d9b28242e26968406a/engine/cld/legacy/cli/mcmsv2/mcms_v2.go#L1082-L1082)

NOTE: This is a BREAKING CHANGE, i will perform the upgrade on CLD once this is merged.

### Usage Migration

**Before:**

```go
environment.OnlyLoadChainsFor("analyze-proposal", chainSelectors), cldfenvironment.WithoutJD())
```

**After:**

```go
environment.OnlyLoadChainsFor(chainSelectors), cldfenvironment.WithoutJD())
```

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-632