### PR TITLE
[CLD-634]: test: separate unit and provider tests

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -38,20 +38,42 @@ jobs:
       actions: read
     steps:
       - name: Build and test
-        uses: smartcontractkit/.github/actions/ci-test-go@eeb76b5870e3c17856d5a60fd064a053c023b5f5 # ci-test-go@1.0.0
+        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        with:
+          # disable the checkptr runtime check due a false positive in github.com/xssnick/tonutils-go
+          # causing tests in ci to fail "fatal error: checkptr: pointer arithmetic result points to invalid allocation"
+          # https://github.com/xssnick/tonutils-go/issues/310
+          # Exclude provider packages which use Docker containers
+          go-test-cmd: go test -race -gcflags=all=-d=checkptr=0 -coverprofile=coverage.txt $(go list ./... | grep -v '/provider')
+          use-go-cache: true
+          artifact-name: unit-tests
+
+  ci-test-provider:
+    name: Provider Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Build and test provider packages
+        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
         with:
           # disable the checkptr runtime check due a false positive in github.com/xssnick/tonutils-go
           # causing tests in ci to fail "fatal error: checkptr: pointer arithmetic result points to invalid allocation"
           # https://github.com/xssnick/tonutils-go/issues/310
           # -p 2 -parallel 3 = 2 packages, 3 tests max = 6 containers max
-          go-test-cmd: go test -race -gcflags=all=-d=checkptr=0 -p 2 -parallel 3 -coverprofile=coverage.txt $(go list ./...)
+          # Only run provider packages which use Docker containers
+          go-test-cmd: go test -race -gcflags=all=-d=checkptr=0 -p 2 -parallel 3 -coverprofile=coverage.txt $(go list ./... | grep '/provider')
           use-go-cache: true
+          artifact-name: provider-tests
 
   sonarqube:
     name: Sonar Scan
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
-    needs: [ci-test, ci-lint-misc, ci-lint]
+    needs: [ci-test, ci-test-provider, ci-lint-misc, ci-lint]
     steps:
       - name: Scan with Sonarqube
         uses: smartcontractkit/.github/actions/ci-sonarqube-go@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # ci-sonarqube-go@0.3.1


### PR DESCRIPTION
In order to reduce tests execution time, i broken the original test step into 2, one for normal tests and the other for provider tests (with docker containers). By running both parallely, tests should finish faster.

Originally the test runs for around 5 minutes, now since we broken it down into 2 , the provider tests take 3 min and the non provider tests take 1 min , so max of both of them is 3.5 min, so we shave off ~1.5-2 minutes through my initial observation.

<img width="907" height="148" alt="Screenshot 2025-09-16 at 11 39 40 pm" src="https://github.com/user-attachments/assets/f6eb5e03-eafe-4477-8974-8c447be7baaa" />

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-634
