### PR TITLE
feat!: add environment.New convenience method and remove testing.T de…

### DIFF
--- a/.changeset/wide-signs-sell.md
+++ b/.changeset/wide-signs-sell.md
@@ -1,0 +1,15 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+Adds new convenience method `environment.New` to the test engine to bring up a new test environment
+
+The `environment.New` method is a wrapper around the environment loading struct and allows the user
+to load a new environment without having to instantiate the `Loader` struct themselves.
+
+The `testing.T` argument has been removed and it's dependencies have been replaced with:
+
+- A `context.Context` argument to the `Load` and `New` functions
+- A new functional option `WithLogger` which overrides the default noop logger.
+
+While this is a breaking change, the test environment is still in development and is not in actual usage yet.

--- a/engine/test/environment/components.go
+++ b/engine/test/environment/components.go
@@ -3,6 +3,8 @@ package environment
 import (
 	"sync"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	fchain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 )
 
@@ -11,12 +13,14 @@ type components struct {
 	mu sync.Mutex
 
 	Chains []fchain.BlockChain
+	Logger logger.Logger
 }
 
 // newComponents creates a new components instance.
 func newComponents() *components {
 	return &components{
 		Chains: make([]fchain.BlockChain, 0),
+		Logger: logger.Nop(),
 	}
 }
 

--- a/engine/test/environment/environment_test.go
+++ b/engine/test/environment/environment_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	chainselectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/stretchr/testify/require"
 
 	fchain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
@@ -16,6 +17,14 @@ import (
 	fchainton "github.com/smartcontractkit/chainlink-deployments-framework/chain/ton"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/onchain"
 )
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	env, err := New(t.Context(), WithLogger(logger.Test(t)))
+	require.NoError(t, err)
+	require.NotNil(t, env)
+}
 
 func TestLoader_Load_Options(t *testing.T) {
 	t.Parallel()
@@ -70,7 +79,7 @@ func TestLoader_Load_Options(t *testing.T) {
 			t.Parallel()
 
 			loader := NewLoader()
-			env, err := loader.Load(t, tt.opts...)
+			env, err := loader.Load(t.Context(), tt.opts...)
 
 			if len(tt.wantErrContains) > 0 {
 				require.Error(t, err)
@@ -84,6 +93,17 @@ func TestLoader_Load_Options(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLoader_Load_LoggerOption(t *testing.T) {
+	t.Parallel()
+	lggr := logger.Test(t)
+
+	loader := NewLoader()
+	env, err := loader.Load(t.Context(), WithLogger(lggr))
+	require.NoError(t, err)
+	require.NotNil(t, env)
+	require.Equal(t, lggr, env.Logger)
 }
 
 func TestLoader_Load_ChainOptions(t *testing.T) { //nolint:paralleltest // We are replacing local variables here, so we can't run tests in parallel.
@@ -189,7 +209,7 @@ func TestLoader_Load_ChainOptions(t *testing.T) { //nolint:paralleltest // We ar
 	for _, tt := range tests { //nolint:paralleltest // We are replacing local variables here, so we can't run tests in parallel.
 		t.Run(tt.name, func(t *testing.T) {
 			loader := NewLoader()
-			env, err := loader.Load(t, tt.opts...)
+			env, err := loader.Load(t.Context(), tt.opts...)
 			require.NoError(t, err)
 			require.NotNil(t, env)
 			require.Len(t, maps.Collect(env.BlockChains.All()), tt.wantBlockChainsLen)

--- a/engine/test/environment/options.go
+++ b/engine/test/environment/options.go
@@ -3,6 +3,8 @@ package environment
 import (
 	"testing"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/onchain"
 )
 
@@ -110,6 +112,14 @@ func WithZKSyncContainerN(t *testing.T, n int) LoadOpt {
 	t.Helper()
 
 	return withChainLoaderN(t, newZKSyncContainerLoader(), n)
+}
+
+// WithLogger sets the logger for the environment.
+func WithLogger(lggr logger.Logger) LoadOpt {
+	return func(cmps *components) error {
+		cmps.Logger = lggr
+		return nil
+	}
 }
 
 // withChainLoader creates a LoadOpt that loads chains using the provided loader and selectors.


### PR DESCRIPTION
…pendency

Add `environment.New()` convenience method that wraps the environment loader, eliminating the need to manually instantiate the `Loader` struct.

BREAKING CHANGES:
- Remove `testing.T` parameter from `Load` and `New` functions
- Add `context.Context` parameter to `Load` and `New` functions
- Add `WithLogger` functional option to override the default noop logger

Note: Breaking changes are acceptable as the test environment is still in development.