### PR TITLE
feat: Add `runtime.New()` convenience function for runtime init

### DIFF
--- a/.changeset/ninety-doors-move.md
+++ b/.changeset/ninety-doors-move.md
@@ -1,0 +1,7 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+Add `runtime.New()` convenience function for runtime initialization
+
+Provides a simpler way to create runtime instances using functional options for environment configuration.

--- a/engine/test/runtime/options.go
+++ b/engine/test/runtime/options.go
@@ -1,0 +1,19 @@
+package runtime
+
+import "github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+
+// runtimeConfig is the configuration for initializing the runtime.
+type runtimeConfig struct {
+	envOpts []environment.LoadOpt
+}
+
+// RuntimeOption is a functional option type for configuring runtime.
+type RuntimeOption func(*runtimeConfig)
+
+// WithEnvironmentOptions adds environment options to the runtime. This is used to load the
+// environment with the given options.
+func WithEnvOpts(opts ...environment.LoadOpt) RuntimeOption {
+	return func(c *runtimeConfig) {
+		c.envOpts = opts
+	}
+}

--- a/engine/test/runtime/options_test.go
+++ b/engine/test/runtime/options_test.go
@@ -1,0 +1,23 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+)
+
+func TestWithEnvOpts(t *testing.T) {
+	t.Parallel()
+
+	cfg := &runtimeConfig{}
+	opts := []environment.LoadOpt{
+		environment.WithLogger(logger.Test(t)),
+	}
+
+	WithEnvOpts(opts...)(cfg)
+
+	require.Equal(t, opts, cfg.envOpts)
+}

--- a/engine/test/runtime/runtime.go
+++ b/engine/test/runtime/runtime.go
@@ -1,9 +1,12 @@
 package runtime
 
 import (
+	"context"
+	"fmt"
 	"sync"
 
 	fdeployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 )
 
 // Runtime provides an execution environment for running tasks in tests.
@@ -20,6 +23,21 @@ type Runtime struct {
 
 	state      *State                  // Accumulated state from task executions
 	currentEnv fdeployment.Environment // Current environment with latest state applied
+}
+
+// New creates a new Runtime instance initialized with the given options.
+func New(ctx context.Context, opts ...RuntimeOption) (*Runtime, error) {
+	var cfg runtimeConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	env, err := environment.New(ctx, cfg.envOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create environment: %w", err)
+	}
+
+	return NewFromEnvironment(*env), nil
 }
 
 // NewFromEnvironment creates a new Runtime instance initialized with the given environment.

--- a/engine/test/runtime/runtime_test.go
+++ b/engine/test/runtime/runtime_test.go
@@ -15,7 +15,22 @@ import (
 
 	fdatastore "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	fdeployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 )
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	lggr := logger.Test(t)
+
+	runtime, err := New(t.Context(), WithEnvOpts(
+		environment.WithLogger(lggr),
+	))
+	require.NoError(t, err)
+	require.NotNil(t, runtime)
+
+	require.Equal(t, lggr, runtime.currentEnv.Logger)
+}
 
 func TestNewFromEnvironment(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Provides a simpler way to create runtime instances using functional options for environment configuration.