### PR TITLE
fix: disable jd on fork env

### DIFF
--- a/.changeset/hungry-eels-clap.md
+++ b/.changeset/hungry-eels-clap.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+disable jd in fork env

--- a/engine/cld/legacy/cli/mcmsv2/mcms_v2.go
+++ b/engine/cld/legacy/cli/mcmsv2/mcms_v2.go
@@ -1108,6 +1108,7 @@ func newCfgv2(lggr logger.Logger, cmd *cobra.Command, domain cldf_domain.Domain,
 			cldfenvironment.WithLogger(lggr),
 			cldfenvironment.OnlyLoadChainsFor(cfgSelectors),
 			cldfenvironment.WithAnvilKeyAsDeployer(),
+			cldfenvironment.WithoutJD(),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load forked environment: %w", err)


### PR DESCRIPTION
Dont think this should be enable for fork testing.