### PR TITLE
chore: switch from chainlink-catalog to op-catalog protos

### DIFF
--- a/datastore/catalog/remote/address_ref_store.go
+++ b/datastore/catalog/remote/address_ref_store.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
-	pb "github.com/smartcontractkit/chainlink-protos/chainlink-catalog/v1/datastore"
+	pb "github.com/smartcontractkit/chainlink-protos/op-catalog/v1/datastore"
 )
 
 type catalogAddressRefStoreConfig struct {

--- a/datastore/catalog/remote/address_ref_store_test.go
+++ b/datastore/catalog/remote/address_ref_store_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
-	pb "github.com/smartcontractkit/chainlink-protos/chainlink-catalog/v1/datastore"
+	pb "github.com/smartcontractkit/chainlink-protos/op-catalog/v1/datastore"
 )
 
 const (

--- a/datastore/catalog/remote/chain_metadata_store.go
+++ b/datastore/catalog/remote/chain_metadata_store.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
-	pb "github.com/smartcontractkit/chainlink-protos/chainlink-catalog/v1/datastore"
+	pb "github.com/smartcontractkit/chainlink-protos/op-catalog/v1/datastore"
 )
 
 type catalogChainMetadataStoreConfig struct {

--- a/datastore/catalog/remote/chain_metadata_store_test.go
+++ b/datastore/catalog/remote/chain_metadata_store_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
-	pb "github.com/smartcontractkit/chainlink-protos/chainlink-catalog/v1/datastore"
+	pb "github.com/smartcontractkit/chainlink-protos/op-catalog/v1/datastore"
 )
 
 const (

--- a/datastore/catalog/remote/contract_metadata_store.go
+++ b/datastore/catalog/remote/contract_metadata_store.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
-	pb "github.com/smartcontractkit/chainlink-protos/chainlink-catalog/v1/datastore"
+	pb "github.com/smartcontractkit/chainlink-protos/op-catalog/v1/datastore"
 )
 
 type catalogContractMetadataStoreConfig struct {

--- a/datastore/catalog/remote/contract_metadata_store_test.go
+++ b/datastore/catalog/remote/contract_metadata_store_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
-	pb "github.com/smartcontractkit/chainlink-protos/chainlink-catalog/v1/datastore"
+	pb "github.com/smartcontractkit/chainlink-protos/op-catalog/v1/datastore"
 )
 
 const (

--- a/datastore/catalog/remote/datastore.go
+++ b/datastore/catalog/remote/datastore.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
-	pb "github.com/smartcontractkit/chainlink-protos/chainlink-catalog/v1/datastore"
+	pb "github.com/smartcontractkit/chainlink-protos/op-catalog/v1/datastore"
 )
 
 type CatalogDataStoreConfig struct {

--- a/datastore/catalog/remote/env_metadata_store.go
+++ b/datastore/catalog/remote/env_metadata_store.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
-	pb "github.com/smartcontractkit/chainlink-protos/chainlink-catalog/v1/datastore"
+	pb "github.com/smartcontractkit/chainlink-protos/op-catalog/v1/datastore"
 )
 
 type catalogEnvMetadataStoreConfig struct {

--- a/datastore/catalog/remote/env_metadata_store_test.go
+++ b/datastore/catalog/remote/env_metadata_store_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
-	pb "github.com/smartcontractkit/chainlink-protos/chainlink-catalog/v1/datastore"
+	pb "github.com/smartcontractkit/chainlink-protos/op-catalog/v1/datastore"
 )
 
 const (

--- a/datastore/catalog/remote/grpc.go
+++ b/datastore/catalog/remote/grpc.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
-	pb "github.com/smartcontractkit/chainlink-protos/chainlink-catalog/v1/datastore"
+	pb "github.com/smartcontractkit/chainlink-protos/op-catalog/v1/datastore"
 )
 
 type CatalogClient struct {

--- a/datastore/catalog/remote/utils.go
+++ b/datastore/catalog/remote/utils.go
@@ -3,7 +3,7 @@ package remote
 import (
 	"fmt"
 
-	pb "github.com/smartcontractkit/chainlink-protos/chainlink-catalog/v1/datastore"
+	pb "github.com/smartcontractkit/chainlink-protos/op-catalog/v1/datastore"
 )
 
 func ThrowAndCatch(

--- a/go.mod
+++ b/go.mod
@@ -35,8 +35,8 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a
 	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250815142532-64e0a7965958
-	github.com/smartcontractkit/chainlink-protos/chainlink-catalog v0.0.2
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0
+	github.com/smartcontractkit/chainlink-protos/op-catalog v0.0.1
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.30
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335

--- a/go.sum
+++ b/go.sum
@@ -699,10 +699,10 @@ github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1 h1:ca2z5OXgn
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.1/go.mod h1:NZv/qKYGFRnkjOYBouajnDfFoZ+WDa6H2KNmSf1dnKc=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250806152407-159881c7589c h1:QaImySzrLcGzQc4wCF2yDqqb73jA3+9EIqybgx8zT4w=
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250806152407-159881c7589c/go.mod h1:U1UAbPhy6D7Qz0wHKGPoQO+dpR0hsYjgUz8xwRrmKwI=
-github.com/smartcontractkit/chainlink-protos/chainlink-catalog v0.0.2 h1:Q4CSRUXkNUwo75r3XR3PGGrXv5wsuWK3QzqLq2GmevU=
-github.com/smartcontractkit/chainlink-protos/chainlink-catalog v0.0.2/go.mod h1:BZ/xrJ6n/j5K4ptJyIk+L1dUup1eXXQpRKcgBYvugpE=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0 h1:/bhoALRzNXZkdzxBkNM505pMofNy0K0eW1nCzXw+AUI=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
+github.com/smartcontractkit/chainlink-protos/op-catalog v0.0.1 h1:YIj/UUb+4nLWuR1A4oeVJFKS+oLIdyvwmKpg1m4lHiY=
+github.com/smartcontractkit/chainlink-protos/op-catalog v0.0.1/go.mod h1:kYKweMUUgAL+JfW+4WV5FoQuoTKj7RbTC9J+2abq0Pw=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f h1:7saUNbu+edzDgRPedNFfTsx5+5RL40r1r0pgISoh8Hs=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f/go.mod h1:CTR5agBB07sCpRltBkHmnkCZ+g8sXRafCJge/Hqr7aM=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.30 h1:mDxJnEl5jKs3FLHKIjwtCFEP4ihKhFS6yuPDNcC0EDM=


### PR DESCRIPTION
- Update go.mod to use github.com/smartcontractkit/chainlink-protos/op-catalog v0.0.1
- Replace all chainlink-catalog imports with op-catalog imports in datastore/catalog/remote/