### PR TITLE
fix: prioritize chain-selectors updates in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,25 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: '/'
+    directory: "/"
     schedule:
       interval: weekly
   - package-ecosystem: gomod
-    directory: '/'
+    directory: "/"
+    schedule:
+      interval: daily
+    # High priority configuration for chain-selectors
+    allow:
+      - dependency-name: "github.com/smartcontractkit/chain-selectors"
+    open-pull-requests-limit: 1
+  - package-ecosystem: gomod
+    directory: "/"
     schedule:
       interval: weekly
+    # General Go module updates with lower priority
+    ignore:
+      - dependency-name: "github.com/smartcontractkit/chain-selectors"
+    open-pull-requests-limit: 9
   - package-ecosystem: npm
     directory: "/"
     schedule:


### PR DESCRIPTION
I noticed usually not using chain-selector latest version can cause pipeline failures on CLD because the new chain is not recognised .
What happens then user will have to manually come to CLDF and update the chainsel package and then perform a release. If we have a PR ready by dependabot, then this can smooth out the experience.

- Add dedicated high-priority configuration for chain-selectors package
- Ensure chain-selectors always gets a PR even when hitting PR limits
- Split gomod updates into two configurations:
  - Priority: chain-selectors only (limit: 1 PR)
  - General: all other Go modules (limit: 9 PRs)