### PR TITLE
Add more conversion options in Untyped Ops 

### DIFF
--- a/.changeset/beige-feet-itch.md
+++ b/.changeset/beige-feet-itch.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+Add more conversion options in Operations AsUntyped


### PR DESCRIPTION
Adds more options in the `AsUntyped` handler type conversion to consider values that match the type, but aren't strictly of that type