### PR TITLE
feat(operations): introduce AsUntypedRelaxed

### DIFF
--- a/.changeset/full-doors-peel.md
+++ b/.changeset/full-doors-peel.md
@@ -1,0 +1,6 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat(operations): introduce AsUntypedRelaxed
+

--- a/operations/operation.go
+++ b/operations/operation.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sync"
 
@@ -111,6 +112,41 @@ func (o *Operation[IN, OUT, DEP]) AsUntyped() *Operation[any, any, any] {
 				var ok bool
 				if typedInput, ok = input.(IN); !ok {
 					return nil, errors.New("input type mismatch")
+				}
+			}
+
+			var typedDeps DEP
+			if deps != nil {
+				var ok bool
+				if typedDeps, ok = deps.(DEP); !ok {
+					return nil, errors.New("dependencies type mismatch")
+				}
+			}
+
+			return o.handler(b, typedDeps, typedInput)
+		},
+	}
+}
+
+// AsUntypedRelaxed converts the operation to an untyped operation with relaxed input type checking.
+// This is useful when inputs come from YAML unmarshaling and result in map[string]any.
+// It uses JSON marshaling/unmarshaling to convert compatible types when direct type assertion fails.
+// Warning: The input and output types will be converted to `any`, so type safety is lost.
+func (o *Operation[IN, OUT, DEP]) AsUntypedRelaxed() *Operation[any, any, any] {
+	return &Operation[any, any, any]{
+		def: o.def,
+		handler: func(b Bundle, deps any, input any) (any, error) {
+			var typedInput IN
+			if input != nil {
+				var ok bool
+				if typedInput, ok = input.(IN); !ok {
+					inputBytes, err := json.Marshal(input)
+					if err != nil {
+						return nil, errors.New("input type mismatch: failed to marshal input for conversion")
+					}
+					if err := json.Unmarshal(inputBytes, &typedInput); err != nil {
+						return nil, errors.New("input type mismatch: failed to convert input to expected type")
+					}
 				}
 			}
 


### PR DESCRIPTION
This addresses the issue where YAML-unmarshaled inputs (map[string]any) 
would fail type assertion in AsUntyped operations when unmarshaled from YAML file. Users can now explicitly 
opt-in to marshaling conversion when needed with `AsUntypedRelaxed`

# Long explanation

## Problem

The `AsUntyped()` method was failing with "input type mismatch" errors when inputs came from YAML unmarshaling, even when the data was structurally compatible with the expected input type.

### Root Cause

When unmarshaling YAML in Go, the result is typically `map[string]interface{}` for objects, even if the original data came from a well-defined struct. The original `AsUntyped()` implementation used strict type assertion:

```go
if typedInput, ok = input.(IN); !ok {
    return nil, errors.New("input type mismatch")
}
```

This would fail because `map[string]interface{}` and the expected struct type `IN` are different types in Go's type system, despite containing identical data.

### Example Scenario

```go
type OpInput struct {
    A int
    B int
}

yamlData := `
A: 10
B: 20
`

var yamlInput interface{}
yaml.Unmarshal([]byte(yamlData), &yamlInput)
// yamlInput is now map[string]interface{}{"A": 10, "B": 20}

// This fails in AsUntyped()
typedInput, ok := yamlInput.(OpInput) // false! Different types
```

## Solution

###  AsUntypedRelaxed

Added `AsUntypedRelaxed()` function

```go
// Default: strict type safety (existing behavior)
untypedOp := typedOp.AsUntyped()

// With marshaling: handles YAML-unmarshaled inputs
untypedOp := typedOp. AsUntypedRelaxed)
```

### JSON Round-Trip Conversion

When `AsUntypedRelaxed` is used and direct type assertion fails, we use JSON marshaling/unmarshaling to convert between compatible types:

```go
// If direct assertion fails and marshaling is enabled
inputBytes, err := json.Marshal(input)           // map[string]interface{} → JSON
json.Unmarshal(inputBytes, &typedInput)          // JSON → OpInput struct
```