### PR TITLE
chore: update op-catalog to v0.0.3

### DIFF
--- a/datastore/catalog/remote/grpc.go
+++ b/datastore/catalog/remote/grpc.go
@@ -11,7 +11,7 @@ import (
 )
 
 type CatalogClient struct {
-	protoClient pb.DeploymentsDatastoreClient
+	protoClient pb.DatastoreClient
 	// ctx is cached here, because we need the context that created the client, not the current
 	// call stack context. This is different than the go norm, but because we need a long-lived
 	// comms session to the gRPC server, anything cancelling that context (such as a test ending)
@@ -63,7 +63,7 @@ func NewCatalogClient(ctx context.Context, cfg CatalogConfig) (*CatalogClient, e
 	}
 	client := CatalogClient{
 		ctx:         ctx,
-		protoClient: pb.NewDeploymentsDatastoreClient(conn),
+		protoClient: pb.NewDatastoreClient(conn),
 	}
 
 	return &client, err

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250805210128-7f8a0f403c3a
 	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250815142532-64e0a7965958
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0
-	github.com/smartcontractkit/chainlink-protos/op-catalog v0.0.1
+	github.com/smartcontractkit/chainlink-protos/op-catalog v0.0.3
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.30
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335

--- a/go.sum
+++ b/go.sum
@@ -701,8 +701,8 @@ github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250806152407-15
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250806152407-159881c7589c/go.mod h1:U1UAbPhy6D7Qz0wHKGPoQO+dpR0hsYjgUz8xwRrmKwI=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0 h1:/bhoALRzNXZkdzxBkNM505pMofNy0K0eW1nCzXw+AUI=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0/go.mod h1:/dVVLXrsp+V0AbcYGJo3XMzKg3CkELsweA/TTopCsKE=
-github.com/smartcontractkit/chainlink-protos/op-catalog v0.0.1 h1:YIj/UUb+4nLWuR1A4oeVJFKS+oLIdyvwmKpg1m4lHiY=
-github.com/smartcontractkit/chainlink-protos/op-catalog v0.0.1/go.mod h1:kYKweMUUgAL+JfW+4WV5FoQuoTKj7RbTC9J+2abq0Pw=
+github.com/smartcontractkit/chainlink-protos/op-catalog v0.0.3 h1:SMY7IlrOmsjonbx9YzmLPYa65vuUyVep67zFtSwMiuI=
+github.com/smartcontractkit/chainlink-protos/op-catalog v0.0.3/go.mod h1:kYKweMUUgAL+JfW+4WV5FoQuoTKj7RbTC9J+2abq0Pw=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f h1:7saUNbu+edzDgRPedNFfTsx5+5RL40r1r0pgISoh8Hs=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20250916193659-4becc28a467f/go.mod h1:CTR5agBB07sCpRltBkHmnkCZ+g8sXRafCJge/Hqr7aM=
 github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.30 h1:mDxJnEl5jKs3FLHKIjwtCFEP4ihKhFS6yuPDNcC0EDM=


### PR DESCRIPTION
- Update github.com/smartcontractkit/chainlink-protos/op-catalog from v0.0.1 to v0.0.3
- DeploymentsDatastoreClient -> DatastoreClient
- NewDeploymentsDatastoreClient -> NewDatastoreClient