### PR TITLE
fix: salt override for mcms

### DIFF
--- a/.changeset/cuddly-tips-look.md
+++ b/.changeset/cuddly-tips-look.md
@@ -1,0 +1,9 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+Fixes test engine MCMS execution when multiple proposals have the same `validUntil` timestamp.
+
+A salt override is added to each timelock proposal persisted to the state to ensure unique operation
+IDs in test environments where multiple proposals may have identical timestamps. This salt is used
+in the hashing algorithm to determine the root of the merkle tree.

--- a/engine/test/runtime/state_test.go
+++ b/engine/test/runtime/state_test.go
@@ -137,6 +137,7 @@ func TestState_MergeChangesetOutput(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, "TimelockProposal", timelockProposal["kind"])
 				assert.Equal(t, "Test Timelock Proposal", timelockProposal["description"])
+				assert.NotNil(t, timelockProposal["salt"])
 			},
 		},
 		{


### PR DESCRIPTION
This fixes the salt override for mcms by adding a random salt override to each timelock proposal persisted to the state to ensure unique operation IDs in test environments where multiple proposals may have identical timestamps. This salt is used in the hashing algorithm to determine the root of the merkle tree.