### PR TITLE
chore: disallow importing from chainlink core repo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,10 @@ linters:
               desc: Use github.com/smartcontractkit/chainlink-common/pkg/logger instead
             - pkg: github.com/pkg/errors
               desc: Use the standard library instead, for example https://pkg.go.dev/fmt#Errorf
+            - pkg: github.com/smartcontractkit/chainlink/v2
+              desc: You must not import this package. There is no alternative.
+            - pkg: github.com/smartcontractkit/chainlink/deployment
+              desc: You must not import this package. There is no alternative.
     goconst:
       min-len: 5
     govet:


### PR DESCRIPTION
Due to circular dependencies and large dependency trees, we disallow importing from the chainlink core repo. This change ensures that the linter will fail if we try to import from the chainlink core repo.