### PR TITLE
feat(mcms): query Timelock contract for CallProxy address

### DIFF
--- a/.changeset/clear-coats-judge.md
+++ b/.changeset/clear-coats-judge.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+feat(mcms): query Timelock contract for CallProxy address

--- a/engine/cld/legacy/cli/mcmsv2/mcms_v2_test.go
+++ b/engine/cld/legacy/cli/mcmsv2/mcms_v2_test.go
@@ -3,22 +3,32 @@ package mcmsv2
 import (
 	"context"
 	"errors"
+	"fmt"
+	"maps"
+	"math/big"
 	"os"
+	"slices"
 	"testing"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/mcms"
 	"github.com/smartcontractkit/mcms/sdk"
+	mcmsevmbindings "github.com/smartcontractkit/mcms/sdk/evm/bindings"
 	mocksdk "github.com/smartcontractkit/mcms/sdk/mocks"
 	"github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
 
+	datastore "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
-
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/domain"
-
+	testenv "github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	testruntime "github.com/smartcontractkit/chainlink-deployments-framework/engine/test/runtime"
 	"github.com/smartcontractkit/chainlink-deployments-framework/experimental/analyzer"
+	fpointer "github.com/smartcontractkit/chainlink-deployments-framework/internal/pointer"
 )
 
 // nolint:paralleltest // uses and modifies files
@@ -37,7 +47,7 @@ func TestMCMSv2CommandFlagParsing(t *testing.T) {
 		wantExecErr  string
 		wantParseErr string
 	}
-	var tests = []test{
+	tests := []test{
 		{
 			name: "check-quorum",
 			args: []string{"check-quorum", "-e", "staging", "-p", "testdata/proposal.json", "-k", "TimelockProposal", "-s", "16015286601757825753"},
@@ -317,6 +327,201 @@ func TestGetProposalSigners(t *testing.T) {
 					chainSelector: tt.expectedSigners,
 				}, result)
 			}
+		})
+	}
+}
+
+//nolint:paralleltest
+func Test_timelockExecuteOptions(t *testing.T) {
+	loader := testenv.NewLoader()
+	env, err := loader.Load(t.Context(), testenv.WithEVMSimulatedN(t, 1))
+	require.NoError(t, err)
+
+	err = os.MkdirAll("domains/exemplar", 0o700)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll("domains") })
+
+	lggr := logger.Test(t)
+	exemplarDomain := domain.MustGetDomain("exemplar")
+	chain := slices.Collect(maps.Values(env.BlockChains.EVMChains()))[0]
+	callProxyAddress := common.Address{}
+	timelockAddress := common.Address{}
+
+	changeset := cldf.CreateChangeSet(
+		func(e cldf.Environment, config struct{}) (cldf.ChangesetOutput, error) {
+			ds := datastore.NewMemoryDataStore()
+			ab := cldf.NewMemoryAddressBook()
+			var tx *ethtypes.Transaction
+
+			// deploy call proxy
+			callProxyAddress, tx, _, err = mcmsevmbindings.DeployCallProxy(chain.DeployerKey, chain.Client, common.Address{})
+			require.NoError(t, err)
+			err = ds.Addresses().Add(datastore.AddressRef{
+				Address:       callProxyAddress.Hex(),
+				ChainSelector: chain.Selector,
+				Type:          "CallProxy",
+				Version:       semver.MustParse("1.0.0"),
+			})
+			require.NoError(t, err)
+			err = ab.Save(chain.Selector, callProxyAddress.Hex(), cldf.MustTypeAndVersionFromString("CallProxy 1.0.0"))
+			require.NoError(t, err)
+			_, err = chain.Confirm(tx)
+			require.NoError(t, err)
+
+			// deploy timelock
+			timelockAddress, tx, _, err = mcmsevmbindings.DeployRBACTimelock(chain.DeployerKey, chain.Client, big.NewInt(0),
+				chain.DeployerKey.From,
+				nil,                                // proposers
+				[]common.Address{callProxyAddress}, // executors
+				nil,                                // bypassers
+				nil,                                // cancellers
+			)
+			require.NoError(t, err)
+			err = ds.Addresses().Add(datastore.AddressRef{
+				Address:       timelockAddress.Hex(),
+				ChainSelector: chain.Selector,
+				Type:          "RBACTimelock",
+				Version:       semver.MustParse("1.0.0"),
+			})
+			require.NoError(t, err)
+			err = ab.Save(chain.Selector, timelockAddress.Hex(), cldf.MustTypeAndVersionFromString("RBACTimelock 1.0.0"))
+			require.NoError(t, err)
+			_, err = chain.Confirm(tx)
+			require.NoError(t, err)
+
+			return cldf.ChangesetOutput{AddressBook: ab, DataStore: ds}, nil
+		},
+		func(e cldf.Environment, config struct{}) error { return nil }, // verify,
+	)
+	task := testruntime.ChangesetTask(changeset, struct{}{})
+	runtime := testruntime.NewFromEnvironment(*env)
+	err = runtime.Exec(task)
+	require.NoError(t, err)
+	env = fpointer.To(runtime.Environment())
+
+	errorContains := func(msg string) func(t *testing.T, opts []mcms.Option, err error) {
+		return func(t *testing.T, opts []mcms.Option, err error) {
+			t.Helper()
+			require.ErrorContains(t, err, msg)
+		}
+	}
+
+	tests := []struct {
+		name   string
+		cfg    *cfgv2
+		assert func(t *testing.T, opts []mcms.Option, err error)
+		// want    []mcms.Option
+		// wantErr string
+	}{
+		{
+			name: "empty options for Solana",
+			cfg:  &cfgv2{chainSelector: chainsel.SOLANA_MAINNET.Selector},
+			assert: func(t *testing.T, opts []mcms.Option, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Empty(t, opts)
+			},
+		},
+		{
+			name: "empty options for Aptos",
+			cfg:  &cfgv2{chainSelector: chainsel.APTOS_MAINNET.Selector},
+			assert: func(t *testing.T, opts []mcms.Option, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Empty(t, opts)
+			},
+		},
+		{
+			name: "empty options for Sui",
+			cfg:  &cfgv2{chainSelector: chainsel.SUI_MAINNET.Selector},
+			assert: func(t *testing.T, opts []mcms.Option, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Empty(t, opts)
+			},
+		},
+		{
+			name: "CallProxy option added for EVM when addresses is in DataStore",
+			cfg: &cfgv2{
+				chainSelector: chain.Selector,
+				env:           *env,
+				blockchains:   env.BlockChains,
+				timelockProposal: &mcms.TimelockProposal{
+					TimelockAddresses: map[types.ChainSelector]string{
+						types.ChainSelector(chain.Selector): timelockAddress.Hex(),
+					},
+				},
+			},
+			assert: func(t *testing.T, opts []mcms.Option, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Len(t, opts, 1)
+			},
+		},
+		{
+			name: "CallProxy option added when addresses is in AddressBook",
+			cfg: &cfgv2{
+				chainSelector: chain.Selector,
+				blockchains:   env.BlockChains,
+				env: func() cldf.Environment {
+					modifiedEnv := *env
+					modifiedEnv.DataStore = datastore.NewMemoryDataStore().Seal()
+
+					return modifiedEnv
+				}(),
+				timelockProposal: &mcms.TimelockProposal{
+					TimelockAddresses: map[types.ChainSelector]string{
+						types.ChainSelector(chain.Selector): timelockAddress.Hex(),
+					},
+				},
+			},
+			assert: func(t *testing.T, opts []mcms.Option, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Len(t, opts, 1)
+			},
+		},
+		{
+			name: "failure: no timelock addresses for chain",
+			cfg: &cfgv2{
+				chainSelector: chain.Selector,
+				env:           *env,
+				blockchains:   env.BlockChains,
+				timelockProposal: &mcms.TimelockProposal{
+					TimelockAddresses: map[types.ChainSelector]string{
+						types.ChainSelector(1): timelockAddress.Hex(),
+					},
+				},
+			},
+			assert: errorContains(fmt.Sprintf("failed to find timelock address for chain selector %d", chain.Selector)),
+		},
+		{
+			name: "failure: address not found in DataStore or AddressBook",
+			cfg: &cfgv2{
+				chainSelector: chain.Selector,
+				blockchains:   env.BlockChains,
+				env: func() cldf.Environment {
+					modifiedEnv := *env
+					modifiedEnv.DataStore = datastore.NewMemoryDataStore().Seal()
+					modifiedEnv.ExistingAddresses = cldf.NewMemoryAddressBook() //nolint:staticcheck
+
+					return modifiedEnv
+				}(),
+				timelockProposal: &mcms.TimelockProposal{
+					TimelockAddresses: map[types.ChainSelector]string{
+						types.ChainSelector(chain.Selector): timelockAddress.Hex(),
+					},
+				},
+			},
+			assert: errorContains(fmt.Sprintf("failed to find call proxy contract for timelock %v", timelockAddress.Hex())),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := timelockExecuteOptions(t.Context(), lggr, exemplarDomain, tt.cfg)
+			tt.assert(t, got, err)
 		})
 	}
 }


### PR DESCRIPTION
This PR fixes two issues:

1. the mcms CLI did not search for the CallProxy address in the DataStore, which meant domains that use _only_ the DataStore would see errors when executing a few subcommands.

2. we now query the timelock contract for the CallProxy address, which allows us to handle the case where multiple CallProxy contracts are in the DataStore for the same chain. 

[DX-1999](https://smartcontract-it.atlassian.net/browse/DX-1999)

[DX-1999]: https://smartcontract-it.atlassian.net/browse/DX-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ