### PR TITLE
fix: get delay for advancing time from the proposal instead of constant

### DIFF
--- a/.changeset/pretty-days-draw.md
+++ b/.changeset/pretty-days-draw.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+get delay for advancing time from the proposal instead of constant value

--- a/engine/cld/legacy/cli/mcmsv2/mcms_v2.go
+++ b/engine/cld/legacy/cli/mcmsv2/mcms_v2.go
@@ -51,7 +51,6 @@ const (
 	proposalKindFlag        = "proposalKind"
 	indexFlag               = "index"
 	forkFlag                = "fork"
-	defaultAdvanceTime      = 36000 // In seconds - defaulting to 10 hours
 	defaultProposalValidity = 72 * time.Hour
 )
 
@@ -666,7 +665,8 @@ func buildExecuteForkCommand(lggr logger.Logger, domain cldf_domain.Domain, prop
 			}
 			lggr.Info("MCMs execute() success")
 			lggr.Info("Waiting for the chain to be mined before executing timelock chain command")
-			if err = anvilClient.EVMIncreaseTime(defaultAdvanceTime); err != nil {
+
+			if err = anvilClient.EVMIncreaseTime(uint64(cfg.timelockProposal.Delay.Seconds())); err != nil {
 				return fmt.Errorf("failed to increase time: %w", err)
 			}
 			if err = anvilClient.AnvilMine([]interface{}{1}); err != nil {


### PR DESCRIPTION
This pull request updates how the time delay for advancing the blockchain is determined in the Chainlink deployments framework. Instead of using a hardcoded constant, the delay is now dynamically retrieved from the proposal configuration, improving flexibility and accuracy.

**Improvements to time advancement logic:**

* The default constant `defaultAdvanceTime` was removed from `mcms_v2.go`, so time advancement no longer relies on a fixed value.
* The code now uses the delay specified in `cfg.timelockProposal.Delay` when calling `anvilClient.EVMIncreaseTime`, ensuring the time advancement matches the proposal's requirements.

**Documentation update:**

* The `.changeset/pretty-days-draw.md` file documents this change, noting that the delay for advancing time is now obtained from the proposal rather than a constant value.