### PR TITLE
[CLD-715]: fix(catalog/memory): update db controller to accept context

### DIFF
--- a/.changeset/great-wasps-lie.md
+++ b/.changeset/great-wasps-lie.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix: update db controller to accept context

--- a/datastore/catalog/memory/address_ref_store.go
+++ b/datastore/catalog/memory/address_ref_store.go
@@ -57,7 +57,7 @@ func newCatalogAddressRefStore(t *testing.T, config MemoryDataStoreConfig, db *d
 	}
 }
 
-func (s *memoryAddressRefStore) Get(_ context.Context, key datastore.AddressRefKey, options ...datastore.GetOption) (datastore.AddressRef, error) {
+func (s *memoryAddressRefStore) Get(ctx context.Context, key datastore.AddressRefKey, options ...datastore.GetOption) (datastore.AddressRef, error) {
 	ignoreTransactions := false
 	for _, option := range options {
 		switch option {
@@ -71,7 +71,7 @@ func (s *memoryAddressRefStore) Get(_ context.Context, key datastore.AddressRefK
 	} else {
 		db = s.db
 	}
-	rows, err := db.Query(query_ADDRESS_REFERENCE_BY_ID, key.ChainSelector(), key.Type().String(), key.Version().String(), key.Qualifier())
+	rows, err := db.QueryContext(ctx, query_ADDRESS_REFERENCE_BY_ID, key.ChainSelector(), key.Type().String(), key.Version().String(), key.Qualifier())
 	defer func(rows *sql.Rows) {
 		if rows != nil {
 			_ = rows.Close()
@@ -107,8 +107,8 @@ func (s *memoryAddressRefStore) Get(_ context.Context, key datastore.AddressRefK
 }
 
 // Fetch returns a copy of all AddressRefs in the catalog.
-func (s *memoryAddressRefStore) Fetch(_ context.Context) ([]datastore.AddressRef, error) {
-	rows, err := s.db.Query(query_ALL_ADDRESS_REFERENCES)
+func (s *memoryAddressRefStore) Fetch(ctx context.Context) ([]datastore.AddressRef, error) {
+	rows, err := s.db.QueryContext(ctx, query_ALL_ADDRESS_REFERENCES)
 	defer func(rows *sql.Rows) {
 		if rows != nil {
 			_ = rows.Close()
@@ -171,8 +171,9 @@ func (s *memoryAddressRefStore) Update(ctx context.Context, r datastore.AddressR
 	return s.edit(ctx, query_UPDATE_ADDRESS_REFERENCE, r)
 }
 
-func (s *memoryAddressRefStore) edit(_ context.Context, qry string, r datastore.AddressRef) error {
-	result, err := s.db.Exec(
+func (s *memoryAddressRefStore) edit(ctx context.Context, qry string, r datastore.AddressRef) error {
+	result, err := s.db.ExecContext(
+		ctx,
 		qry,
 		r.ChainSelector,
 		r.Type.String(),

--- a/datastore/catalog/memory/chain_metadata_store.go
+++ b/datastore/catalog/memory/chain_metadata_store.go
@@ -50,7 +50,7 @@ func newCatalogChainMetadataStore(t *testing.T, config MemoryDataStoreConfig, db
 	}
 }
 
-func (s *memoryChainMetadataStore) Get(_ context.Context, key datastore.ChainMetadataKey, options ...datastore.GetOption) (datastore.ChainMetadata, error) {
+func (s *memoryChainMetadataStore) Get(ctx context.Context, key datastore.ChainMetadataKey, options ...datastore.GetOption) (datastore.ChainMetadata, error) {
 	ignoreTransactions := false
 	for _, option := range options {
 		switch option {
@@ -65,7 +65,7 @@ func (s *memoryChainMetadataStore) Get(_ context.Context, key datastore.ChainMet
 		db = s.db
 	}
 
-	rows, err := db.Query(query_CHAIN_METADATA_BY_ID, key.ChainSelector())
+	rows, err := db.QueryContext(ctx, query_CHAIN_METADATA_BY_ID, key.ChainSelector())
 	defer func(rows *sql.Rows) {
 		if rows != nil {
 			_ = rows.Close()
@@ -107,8 +107,8 @@ func (s *memoryChainMetadataStore) Get(_ context.Context, key datastore.ChainMet
 }
 
 // Fetch returns a copy of all ChainMetadata in the catalog.
-func (s *memoryChainMetadataStore) Fetch(_ context.Context) ([]datastore.ChainMetadata, error) {
-	rows, err := s.db.Query(query_ALL_CHAIN_METADATA)
+func (s *memoryChainMetadataStore) Fetch(ctx context.Context) ([]datastore.ChainMetadata, error) {
+	rows, err := s.db.QueryContext(ctx, query_ALL_CHAIN_METADATA)
 	defer func(rows *sql.Rows) {
 		if rows != nil {
 			_ = rows.Close()
@@ -249,7 +249,7 @@ func (s *memoryChainMetadataStore) Delete(_ context.Context, _ datastore.ChainMe
 	return errors.New("delete operation not supported for catalog chain metadata store")
 }
 
-func (s *memoryChainMetadataStore) edit(_ context.Context, qry string, r datastore.ChainMetadata) error {
+func (s *memoryChainMetadataStore) edit(ctx context.Context, qry string, r datastore.ChainMetadata) error {
 	// Serialize metadata to JSON
 	var metadataJSON string
 	if r.Metadata != nil {
@@ -260,7 +260,7 @@ func (s *memoryChainMetadataStore) edit(_ context.Context, qry string, r datasto
 		metadataJSON = string(metadataBytes)
 	}
 
-	result, err := s.db.Exec(qry, r.ChainSelector, metadataJSON)
+	result, err := s.db.ExecContext(ctx, qry, r.ChainSelector, metadataJSON)
 	if err != nil {
 		return err
 	}

--- a/datastore/catalog/memory/contract_metadata_store.go
+++ b/datastore/catalog/memory/contract_metadata_store.go
@@ -50,7 +50,7 @@ func newCatalogContractMetadataStore(t *testing.T, config MemoryDataStoreConfig,
 	}
 }
 
-func (s *memoryContractMetadataStore) Get(_ context.Context, key datastore.ContractMetadataKey, options ...datastore.GetOption) (datastore.ContractMetadata, error) {
+func (s *memoryContractMetadataStore) Get(ctx context.Context, key datastore.ContractMetadataKey, options ...datastore.GetOption) (datastore.ContractMetadata, error) {
 	ignoreTransactions := false
 	for _, option := range options {
 		switch option {
@@ -65,7 +65,7 @@ func (s *memoryContractMetadataStore) Get(_ context.Context, key datastore.Contr
 		db = s.db
 	}
 
-	rows, err := db.Query(query_CONTRACT_METADATA_BY_ID, key.ChainSelector(), key.Address())
+	rows, err := db.QueryContext(ctx, query_CONTRACT_METADATA_BY_ID, key.ChainSelector(), key.Address())
 	defer func(rows *sql.Rows) {
 		if rows != nil {
 			_ = rows.Close()
@@ -107,8 +107,8 @@ func (s *memoryContractMetadataStore) Get(_ context.Context, key datastore.Contr
 }
 
 // Fetch returns a copy of all ContractMetadata in the catalog.
-func (s *memoryContractMetadataStore) Fetch(_ context.Context) ([]datastore.ContractMetadata, error) {
-	rows, err := s.db.Query(query_ALL_CONTRACT_METADATA)
+func (s *memoryContractMetadataStore) Fetch(ctx context.Context) ([]datastore.ContractMetadata, error) {
+	rows, err := s.db.QueryContext(ctx, query_ALL_CONTRACT_METADATA)
 	defer func(rows *sql.Rows) {
 		if rows != nil {
 			_ = rows.Close()
@@ -251,7 +251,7 @@ func (s *memoryContractMetadataStore) Delete(_ context.Context, _ datastore.Cont
 	return errors.New("delete operation not supported for catalog contract metadata store")
 }
 
-func (s *memoryContractMetadataStore) edit(_ context.Context, qry string, r datastore.ContractMetadata) error {
+func (s *memoryContractMetadataStore) edit(ctx context.Context, qry string, r datastore.ContractMetadata) error {
 	// Serialize metadata to JSON
 	var metadataJSON string
 	if r.Metadata != nil {
@@ -262,7 +262,7 @@ func (s *memoryContractMetadataStore) edit(_ context.Context, qry string, r data
 		metadataJSON = string(metadataBytes)
 	}
 
-	result, err := s.db.Exec(qry, r.ChainSelector, r.Address, metadataJSON)
+	result, err := s.db.ExecContext(ctx, qry, r.ChainSelector, r.Address, metadataJSON)
 	if err != nil {
 		return err
 	}

--- a/datastore/catalog/memory/datastore.go
+++ b/datastore/catalog/memory/datastore.go
@@ -48,10 +48,10 @@ func NewMemoryDataStore(t *testing.T, config MemoryDataStoreConfig) *memoryDataS
 	require.NoError(t, err)
 	ctrl := newDbController(pg.DB)
 
-	require.NoError(t, ctrl.Fixture(sCHEMA_ADDRESS_REFERENCES))
-	require.NoError(t, ctrl.Fixture(sCHEMA_CONTRACT_METADATA))
-	require.NoError(t, ctrl.Fixture(sCHEMA_CHAIN_METADATA))
-	require.NoError(t, ctrl.Fixture(sCHEMA_ENVIRONMENT_METADATA))
+	require.NoError(t, ctrl.Fixture(t.Context(), sCHEMA_ADDRESS_REFERENCES))
+	require.NoError(t, ctrl.Fixture(t.Context(), sCHEMA_CONTRACT_METADATA))
+	require.NoError(t, ctrl.Fixture(t.Context(), sCHEMA_CHAIN_METADATA))
+	require.NoError(t, ctrl.Fixture(t.Context(), sCHEMA_ENVIRONMENT_METADATA))
 
 	return &memoryDataStore{
 		t:                     t,
@@ -71,7 +71,7 @@ func (m *memoryDataStore) Close() {
 }
 
 func (m memoryDataStore) WithTransaction(ctx context.Context, fn datastore.TransactionLogic) (err error) {
-	err = m.db.Begin()
+	err = m.db.Begin(ctx)
 	require.NoError(m.t, err)
 
 	var txerr error

--- a/datastore/catalog/memory/db_controller_test.go
+++ b/datastore/catalog/memory/db_controller_test.go
@@ -14,15 +14,15 @@ func TestNewControllerCommit(t *testing.T) {
 	defer stop()
 
 	ctrl := newDbController(db)
-	err := ctrl.Begin()
+	err := ctrl.Begin(t.Context())
 	require.NoError(t, err)
-	_, err = ctrl.Exec("CREATE TABLE IF NOT EXISTS test(a int)")
+	_, err = ctrl.ExecContext(t.Context(), "CREATE TABLE IF NOT EXISTS test(a int)")
 	require.NoError(t, err)
-	_, err = ctrl.Exec("INSERT INTO test (a) VALUES (1)")
+	_, err = ctrl.ExecContext(t.Context(), "INSERT INTO test (a) VALUES (1)")
 	require.NoError(t, err)
 
 	t.Run("Check inserted values", func(t *testing.T) { //nolint:paralleltest // Cannot run in parallel due to shared database state
-		rows, err2 := ctrl.Query("SELECT * FROM test")
+		rows, err2 := ctrl.QueryContext(t.Context(), "SELECT * FROM test")
 		defer func(rows *sql.Rows) {
 			if rows != nil {
 				assert.NoError(t, rows.Close())
@@ -48,7 +48,7 @@ func TestNewControllerCommit(t *testing.T) {
 	assert.Nil(t, ctrl.tx)
 
 	t.Run("Check inserted values (post-commit)", func(t *testing.T) { //nolint:paralleltest // Cannot run in parallel due to shared database state
-		rows, err2 := ctrl.Query("SELECT * FROM test")
+		rows, err2 := ctrl.QueryContext(t.Context(), "SELECT * FROM test")
 		defer func(rows *sql.Rows) {
 			if rows != nil {
 				assert.NoError(t, rows.Close())
@@ -71,15 +71,15 @@ func TestNewControllerRollback(t *testing.T) {
 	defer stop()
 
 	ctrl := newDbController(db)
-	err := ctrl.Begin()
+	err := ctrl.Begin(t.Context())
 	require.NoError(t, err)
-	_, err = ctrl.Exec("CREATE TABLE IF NOT EXISTS test(a int)")
+	_, err = ctrl.ExecContext(t.Context(), "CREATE TABLE IF NOT EXISTS test(a int)")
 	require.NoError(t, err)
-	_, err = ctrl.Exec("INSERT INTO test (a) VALUES (1)")
+	_, err = ctrl.ExecContext(t.Context(), "INSERT INTO test (a) VALUES (1)")
 	require.NoError(t, err)
 
 	t.Run("Check inserted values", func(t *testing.T) { //nolint:paralleltest // Cannot run in parallel due to shared database state
-		rows, err2 := ctrl.Query("SELECT * FROM test")
+		rows, err2 := ctrl.QueryContext(t.Context(), "SELECT * FROM test")
 		defer func(rows *sql.Rows) {
 			if rows != nil {
 				assert.NoError(t, rows.Close())
@@ -105,7 +105,7 @@ func TestNewControllerRollback(t *testing.T) {
 	assert.Nil(t, ctrl.tx)
 
 	t.Run("Check inserted values (post-rollback)", func(t *testing.T) { //nolint:paralleltest // Cannot run in parallel due to shared database state
-		_, err2 := ctrl.Query("SELECT * FROM test")
+		_, err2 := ctrl.QueryContext(t.Context(), "SELECT * FROM test")
 		require.ErrorContains(t, err2, `"test" does not exist`)
 	})
 }

--- a/datastore/catalog/memory/env_metadata_store.go
+++ b/datastore/catalog/memory/env_metadata_store.go
@@ -44,7 +44,7 @@ func newCatalogEnvMetadataStore(t *testing.T, config MemoryDataStoreConfig, db *
 	}
 }
 
-func (s *memoryEnvMetadataStore) Get(_ context.Context, options ...datastore.GetOption) (datastore.EnvMetadata, error) {
+func (s *memoryEnvMetadataStore) Get(ctx context.Context, options ...datastore.GetOption) (datastore.EnvMetadata, error) {
 	ignoreTransactions := false
 	for _, option := range options {
 		switch option {
@@ -59,7 +59,7 @@ func (s *memoryEnvMetadataStore) Get(_ context.Context, options ...datastore.Get
 		db = s.db
 	}
 
-	rows, err := db.Query(query_ENV_METADATA_GET, envMetadataID)
+	rows, err := db.QueryContext(ctx, query_ENV_METADATA_GET, envMetadataID)
 	defer func(rows *sql.Rows) {
 		if rows != nil {
 			_ = rows.Close()
@@ -137,7 +137,7 @@ func (s *memoryEnvMetadataStore) Set(ctx context.Context, metadata any, opts ...
 	return s.edit(ctx, record)
 }
 
-func (s *memoryEnvMetadataStore) edit(_ context.Context, r datastore.EnvMetadata) error {
+func (s *memoryEnvMetadataStore) edit(ctx context.Context, r datastore.EnvMetadata) error {
 	// Serialize metadata to JSON
 	var metadataJSON string
 	if r.Metadata != nil {
@@ -148,7 +148,7 @@ func (s *memoryEnvMetadataStore) edit(_ context.Context, r datastore.EnvMetadata
 		metadataJSON = string(metadataBytes)
 	}
 
-	result, err := s.db.Exec(query_ENV_METADATA_SET, envMetadataID, metadataJSON)
+	result, err := s.db.ExecContext(ctx, query_ENV_METADATA_SET, envMetadataID, metadataJSON)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously we have to use context.TODO, we should pass it in the context from the upstream instead.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-715