### PR TITLE
[CLD-672]: fix(catalog/memory): remove dep on testing.T

### DIFF
--- a/.changeset/stale-planets-reply.md
+++ b/.changeset/stale-planets-reply.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix(catalog/memory): remove dependency on testing.T

--- a/datastore/catalog/memory/address_ref_store.go
+++ b/datastore/catalog/memory/address_ref_store.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"testing"
 
 	"github.com/lib/pq"
 
@@ -39,7 +38,6 @@ const (
 )
 
 type memoryAddressRefStore struct {
-	t      *testing.T
 	config MemoryDataStoreConfig
 	db     *dbController
 }
@@ -47,11 +45,8 @@ type memoryAddressRefStore struct {
 // Ensure memoryAddressRefStore implements the V2 interface
 var _ datastore.MutableRefStoreV2[datastore.AddressRefKey, datastore.AddressRef] = &memoryAddressRefStore{}
 
-func newCatalogAddressRefStore(t *testing.T, config MemoryDataStoreConfig, db *dbController) *memoryAddressRefStore {
-	t.Helper()
-
+func newCatalogAddressRefStore(config MemoryDataStoreConfig, db *dbController) *memoryAddressRefStore {
 	return &memoryAddressRefStore{
-		t:      t,
 		config: config,
 		db:     db,
 	}

--- a/datastore/catalog/memory/address_ref_store_test.go
+++ b/datastore/catalog/memory/address_ref_store_test.go
@@ -450,10 +450,11 @@ func setupTestStore(t *testing.T) (*memoryAddressRefStore, func()) {
 		Domain:      "test_domain",
 		Environment: "catalog_testing",
 	}
-	store := NewMemoryDataStore(t, config)
+	store, err := NewMemoryDataStore(config)
+	require.NoError(t, err)
 
 	return store.Addresses().(*memoryAddressRefStore), func() {
-		store.Close()
+		require.NoError(t, store.Close())
 	}
 }
 

--- a/datastore/catalog/memory/chain_metadata_store.go
+++ b/datastore/catalog/memory/chain_metadata_store.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"testing"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 )
@@ -32,7 +31,6 @@ const (
 )
 
 type memoryChainMetadataStore struct {
-	t      *testing.T
 	config MemoryDataStoreConfig
 	db     *dbController
 }
@@ -40,11 +38,8 @@ type memoryChainMetadataStore struct {
 // Ensure memoryChainMetadataStore implements the V2 interface
 var _ datastore.MutableStoreV2[datastore.ChainMetadataKey, datastore.ChainMetadata] = &memoryChainMetadataStore{}
 
-func newCatalogChainMetadataStore(t *testing.T, config MemoryDataStoreConfig, db *dbController) *memoryChainMetadataStore {
-	t.Helper()
-
+func newCatalogChainMetadataStore(config MemoryDataStoreConfig, db *dbController) *memoryChainMetadataStore {
 	return &memoryChainMetadataStore{
-		t:      t,
 		config: config,
 		db:     db,
 	}

--- a/datastore/catalog/memory/chain_metadata_store_test.go
+++ b/datastore/catalog/memory/chain_metadata_store_test.go
@@ -20,10 +20,11 @@ func setupChainMetadataTestStore(t *testing.T) (*memoryDataStore, func()) {
 		Domain:      "test_domain",
 		Environment: "catalog_testing",
 	}
-	store := NewMemoryDataStore(t, config)
+	store, err := NewMemoryDataStore(config)
+	require.NoError(t, err)
 
 	return store, func() {
-		store.Close()
+		require.NoError(t, store.Close())
 	}
 }
 

--- a/datastore/catalog/memory/contract_metadata_store.go
+++ b/datastore/catalog/memory/contract_metadata_store.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"testing"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 )
@@ -32,7 +31,6 @@ const (
 )
 
 type memoryContractMetadataStore struct {
-	t      *testing.T
 	config MemoryDataStoreConfig
 	db     *dbController
 }
@@ -40,11 +38,8 @@ type memoryContractMetadataStore struct {
 // Ensure memoryContractMetadataStore implements the V2 interface
 var _ datastore.MutableStoreV2[datastore.ContractMetadataKey, datastore.ContractMetadata] = &memoryContractMetadataStore{}
 
-func newCatalogContractMetadataStore(t *testing.T, config MemoryDataStoreConfig, db *dbController) *memoryContractMetadataStore {
-	t.Helper()
-
+func newCatalogContractMetadataStore(config MemoryDataStoreConfig, db *dbController) *memoryContractMetadataStore {
 	return &memoryContractMetadataStore{
-		t:      t,
 		config: config,
 		db:     db,
 	}

--- a/datastore/catalog/memory/contract_metadata_store_test.go
+++ b/datastore/catalog/memory/contract_metadata_store_test.go
@@ -20,10 +20,11 @@ func setupContractMetadataTestStore(t *testing.T) (*memoryDataStore, func()) {
 		Domain:      "test_domain",
 		Environment: "catalog_testing",
 	}
-	store := NewMemoryDataStore(t, config)
+	store, err := NewMemoryDataStore(config)
+	require.NoError(t, err)
 
 	return store, func() {
-		store.Close()
+		require.NoError(t, store.Close())
 	}
 }
 

--- a/datastore/catalog/memory/datstore_test.go
+++ b/datastore/catalog/memory/datstore_test.go
@@ -4,13 +4,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMemoryDatastore(t *testing.T) {
 	t.Parallel()
 
 	config := MemoryDataStoreConfig{}
-	store := NewMemoryDataStore(t, config)
-	defer store.Close()
+	store, err := NewMemoryDataStore(config)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, store.Close())
+	}()
 	assert.NotNil(t, store)
 }

--- a/datastore/catalog/memory/env_metadata_store.go
+++ b/datastore/catalog/memory/env_metadata_store.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"testing"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 )
@@ -26,7 +25,6 @@ const (
 )
 
 type memoryEnvMetadataStore struct {
-	t      *testing.T
 	config MemoryDataStoreConfig
 	db     *dbController
 }
@@ -34,11 +32,8 @@ type memoryEnvMetadataStore struct {
 // Ensure memoryEnvMetadataStore implements the V2 interface
 var _ datastore.MutableUnaryStoreV2[datastore.EnvMetadata] = &memoryEnvMetadataStore{}
 
-func newCatalogEnvMetadataStore(t *testing.T, config MemoryDataStoreConfig, db *dbController) *memoryEnvMetadataStore {
-	t.Helper()
-
+func newCatalogEnvMetadataStore(config MemoryDataStoreConfig, db *dbController) *memoryEnvMetadataStore {
 	return &memoryEnvMetadataStore{
-		t:      t,
 		config: config,
 		db:     db,
 	}

--- a/datastore/catalog/memory/env_metadata_store_test.go
+++ b/datastore/catalog/memory/env_metadata_store_test.go
@@ -17,10 +17,11 @@ func setupEnvMetadataTestStore(t *testing.T) (*memoryDataStore, func()) {
 		Domain:      "test_domain",
 		Environment: "catalog_testing",
 	}
-	store := NewMemoryDataStore(t, config)
+	store, err := NewMemoryDataStore(config)
+	require.NoError(t, err)
 
 	return store, func() {
-		store.Close()
+		require.NoError(t, store.Close())
 	}
 }
 


### PR DESCRIPTION
In order to use catalog memory datastorage in the test runtime, we have to decouple the dependecy on testing.T for catalog memory because test run time does not have a dependency on testing.T.

I also feel like if user want to use memory catalog , they should not need to depend on testing.T

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-672