### PR TITLE
support proto serialization

### DIFF
--- a/operations/validation.go
+++ b/operations/validation.go
@@ -30,7 +30,7 @@ func IsSerializable(lggr logger.Logger, v any) bool {
 
 func isProtoMessage(v reflect.Value) bool {
 	protoMsgType := reflect.TypeOf((*proto.Message)(nil)).Elem()
-	return v.Type().Implements(protoMsgType)
+	return v.Type().Implements(protoMsgType) || reflect.PointerTo(v.Type()).Implements(protoMsgType)
 }
 
 func isValueSerializable(lggr logger.Logger, v reflect.Value) bool {

--- a/operations/validation.go
+++ b/operations/validation.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"reflect"
 
+	"github.com/gogo/protobuf/proto"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
@@ -11,6 +13,7 @@ import (
 // For idempotency and reporting purposes, we need to ensure that the value can be marshaled and unmarshaled
 // without losing information.
 // If the value implements json.Marshaler and json.Unmarshaler, it is assumed to be serializable.
+// If the value is a protobuf message, it is also considered serializable.
 func IsSerializable(lggr logger.Logger, v any) bool {
 	if !isValueSerializable(lggr, reflect.ValueOf(v)) {
 		return false
@@ -25,9 +28,17 @@ func IsSerializable(lggr logger.Logger, v any) bool {
 	return true
 }
 
+func isProtoMessage(v reflect.Value) bool {
+	protoMsgType := reflect.TypeOf((*proto.Message)(nil)).Elem()
+	return v.Type().Implements(protoMsgType)
+}
+
 func isValueSerializable(lggr logger.Logger, v reflect.Value) bool {
 	// Handle nil values
 	if !v.IsValid() {
+		return true
+	}
+	if isProtoMessage(v) {
 		return true
 	}
 

--- a/operations/validation_test.go
+++ b/operations/validation_test.go
@@ -154,9 +154,19 @@ func Test_IsSerializable(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "should serialize proto message",
+			name: "should serialize proto message pointer",
 			// this is arbitrary proto message just to test the code path
 			v: &pb.AddressReferenceEditResponse{
+				Record: &pb.AddressReference{
+					Domain: "anything",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "should serialize proto message value",
+			// this is arbitrary proto message just to test the code path
+			v: pb.AddressReferenceEditResponse{
 				Record: &pb.AddressReference{
 					Domain: "anything",
 				},

--- a/operations/validation_test.go
+++ b/operations/validation_test.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	chainsel "github.com/smartcontractkit/chain-selectors"
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	mcmslib "github.com/smartcontractkit/mcms"
 	"github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	pb "github.com/smartcontractkit/chainlink-protos/op-catalog/v1/datastore"
 )
 
 func Test_IsSerializable(t *testing.T) {
@@ -149,6 +151,16 @@ func Test_IsSerializable(t *testing.T) {
 		{
 			name: "should serialize Datastore AddressRef",
 			v:    datastore.AddressRef{},
+			want: true,
+		},
+		{
+			name: "should serialize proto message",
+			// this is arbitrary proto message just to test the code path
+			v: &pb.AddressReferenceEditResponse{
+				Record: &pb.AddressReference{
+					Domain: "anything",
+				},
+			},
 			want: true,
 		},
 	}


### PR DESCRIPTION
I want to record responses from the JD in the operation report, and it's failing on IsSerializable.

All proto messages are, by defn, serializable, so add support