### PR TITLE
feat(cli): introduce chains args for state cmd

### DIFF
--- a/engine/cld/legacy/cli/commands/state_test.go
+++ b/engine/cld/legacy/cli/commands/state_test.go
@@ -54,6 +54,11 @@ func TestNewStateGenerateCmd_Metadata(t *testing.T) {
 	require.NotNil(t, s)
 	require.Equal(t, "s", s.Shorthand)
 	require.Empty(t, s.Value.String())
+
+	c := cmd.Flags().Lookup("chains")
+	require.NotNil(t, c)
+	require.Equal(t, "c", c.Shorthand)
+	require.Empty(t, c.Value.String())
 }
 
 func TestStateGenerate_MissingEnvFails(t *testing.T) {


### PR DESCRIPTION
Introduce a new chain argument for state cmd which takes in a list of chain selectors, these chain selectors allow user to specify which chains to load/update instead of by default loading/updating all the chains in the state.

This list of chains to update will be passed into the `ViewState` function which domain devs implements, by using this list, they can update their logic to only load the required chains, also dev will have to handle the merging in the `ViewState` function too.