### PR TITLE
feat: populate Config attribute in hook params

### DIFF
--- a/.changeset/yummy-buckets-prove.md
+++ b/.changeset/yummy-buckets-prove.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix: populate Config attribute in hook params

--- a/engine/cld/changeset/common.go
+++ b/engine/cld/changeset/common.go
@@ -296,10 +296,6 @@ func (ccs ChangeSetImpl[C]) Apply(env fdeployment.Environment) (fdeployment.Chan
 }
 
 func (ccs ChangeSetImpl[C]) applyWithInput(env fdeployment.Environment, input any) (fdeployment.ChangesetOutput, error) {
-	if input == nil || reflect.ValueOf(input).IsZero() {
-		return ccs.Apply(env)
-	}
-
 	cInput, ok := input.(C)
 	if !ok {
 		return fdeployment.ChangesetOutput{}, fmt.Errorf("invalid input type: expected %T but got %T", *new(C), input)

--- a/engine/cld/changeset/common.go
+++ b/engine/cld/changeset/common.go
@@ -296,7 +296,7 @@ func (ccs ChangeSetImpl[C]) Apply(env fdeployment.Environment) (fdeployment.Chan
 }
 
 func (ccs ChangeSetImpl[C]) applyWithInput(env fdeployment.Environment, input any) (fdeployment.ChangesetOutput, error) {
-	if reflect.ValueOf(input).IsZero() {
+	if input == nil || reflect.ValueOf(input).IsZero() {
 		return ccs.Apply(env)
 	}
 

--- a/engine/cld/changeset/common.go
+++ b/engine/cld/changeset/common.go
@@ -32,8 +32,9 @@ type Configurations struct {
 type internalChangeSet interface {
 	noop() // unexported function to prevent arbitrary structs from implementing ChangeSet.
 	Apply(env fdeployment.Environment) (fdeployment.ChangesetOutput, error)
-	applyWithInput(env fdeployment.Environment, inputStr string) (fdeployment.ChangesetOutput, error)
 	Configurations() (Configurations, error)
+	applyWithInput(env fdeployment.Environment, inputStr string) (fdeployment.ChangesetOutput, error)
+	configuration(input string) (any, error)
 }
 
 type ChangeSet internalChangeSet
@@ -333,6 +334,17 @@ func (ccs ChangeSetImpl[C]) Configurations() (Configurations, error) {
 		ConfigResolver:      ccs.ConfigResolver,
 		InputType:           inputType,
 	}, nil
+}
+
+func (ccs ChangeSetImpl[C]) configuration(input string) (any, error) {
+	if input != "" && ccs.configProviderWithInput != nil {
+		return ccs.configProviderWithInput(input)
+	}
+	if ccs.configProvider != nil {
+		return ccs.configProvider()
+	}
+
+	return nil, errors.New("no configuration provider found")
 }
 
 // WithPreHooks appends pre-hooks to this changeset. Multiple calls are additive.

--- a/engine/cld/changeset/common.go
+++ b/engine/cld/changeset/common.go
@@ -296,13 +296,13 @@ func (ccs ChangeSetImpl[C]) Apply(env fdeployment.Environment) (fdeployment.Chan
 }
 
 func (ccs ChangeSetImpl[C]) applyWithInput(env fdeployment.Environment, input any) (fdeployment.ChangesetOutput, error) {
+	if reflect.ValueOf(input).IsZero() {
+		return ccs.Apply(env)
+	}
+
 	cInput, ok := input.(C)
 	if !ok {
 		return fdeployment.ChangesetOutput{}, fmt.Errorf("invalid input type: expected %T but got %T", *new(C), input)
-	}
-
-	if reflect.ValueOf(input).IsZero() {
-		return ccs.Apply(env)
 	}
 
 	if err := ccs.changeset.operation.VerifyPreconditions(env, cInput); err != nil {

--- a/engine/cld/changeset/common.go
+++ b/engine/cld/changeset/common.go
@@ -33,8 +33,8 @@ type internalChangeSet interface {
 	noop() // unexported function to prevent arbitrary structs from implementing ChangeSet.
 	Apply(env fdeployment.Environment) (fdeployment.ChangesetOutput, error)
 	Configurations() (Configurations, error)
-	applyWithInput(env fdeployment.Environment, inputStr string) (fdeployment.ChangesetOutput, error)
-	configuration(input string) (any, error)
+	applyWithInput(env fdeployment.Environment, input any) (fdeployment.ChangesetOutput, error)
+	resolvedInput(input string) (any, error)
 }
 
 type ChangeSet internalChangeSet
@@ -295,23 +295,21 @@ func (ccs ChangeSetImpl[C]) Apply(env fdeployment.Environment) (fdeployment.Chan
 	return ccs.changeset.operation.Apply(env, c)
 }
 
-func (ccs ChangeSetImpl[C]) applyWithInput(env fdeployment.Environment, inputStr string) (fdeployment.ChangesetOutput, error) {
-	if inputStr == "" {
-		return ccs.Apply(env)
+func (ccs ChangeSetImpl[C]) applyWithInput(env fdeployment.Environment, input any) (fdeployment.ChangesetOutput, error) {
+	cInput, ok := input.(C)
+	if !ok {
+		return fdeployment.ChangesetOutput{}, fmt.Errorf("invalid input type: expected %T but got %T", *new(C), input)
 	}
-	if ccs.configProviderWithInput == nil {
+
+	if reflect.ValueOf(input).IsZero() {
 		return ccs.Apply(env)
 	}
 
-	c, err := ccs.configProviderWithInput(inputStr)
-	if err != nil {
-		return fdeployment.ChangesetOutput{}, err
-	}
-	if err := ccs.changeset.operation.VerifyPreconditions(env, c); err != nil {
+	if err := ccs.changeset.operation.VerifyPreconditions(env, cInput); err != nil {
 		return fdeployment.ChangesetOutput{}, err
 	}
 
-	return ccs.changeset.operation.Apply(env, c)
+	return ccs.changeset.operation.Apply(env, cInput)
 }
 
 func (ccs ChangeSetImpl[C]) Configurations() (Configurations, error) {
@@ -336,7 +334,7 @@ func (ccs ChangeSetImpl[C]) Configurations() (Configurations, error) {
 	}, nil
 }
 
-func (ccs ChangeSetImpl[C]) configuration(input string) (any, error) {
+func (ccs ChangeSetImpl[C]) resolvedInput(input string) (any, error) {
 	if input != "" && ccs.configProviderWithInput != nil {
 		return ccs.configProviderWithInput(input)
 	}
@@ -344,7 +342,7 @@ func (ccs ChangeSetImpl[C]) configuration(input string) (any, error) {
 		return ccs.configProvider()
 	}
 
-	return nil, errors.New("no configuration provider found")
+	return *new(C), errors.New("no configuration provider found")
 }
 
 // WithPreHooks appends pre-hooks to this changeset. Multiple calls are additive.

--- a/engine/cld/changeset/common_test.go
+++ b/engine/cld/changeset/common_test.go
@@ -926,7 +926,7 @@ func TestConfigurations_ConfigResolverInfo(t *testing.T) {
 	assert.Equal(t, reflect.ValueOf(resolver).Pointer(), reflect.ValueOf(configs.ConfigResolver).Pointer())
 }
 
-func TestChangesetImple_applyWithInput(t *testing.T) {
+func TestChangesetImpl_applyWithInput(t *testing.T) {
 	t.Parallel()
 
 	c := ChangeSetImpl[string]{

--- a/engine/cld/changeset/common_test.go
+++ b/engine/cld/changeset/common_test.go
@@ -876,6 +876,42 @@ func TestWithJSON_UseNumberForAnyPayload(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestChangeSetImpl_configuration(t *testing.T) { //nolint:paralleltest
+	configuredChangeset := Configure(MyChangeSet)
+	input := `{"payload":"config"}`
+
+	t.Run("With", func(t *testing.T) { //nolint:paralleltest
+		got, err := configuredChangeset.With("config").configuration(input)
+		require.NoError(t, err)
+		require.Equal(t, "config", got)
+	})
+
+	t.Run("WithConfigFrom", func(t *testing.T) { //nolint:paralleltest
+		got, err := configuredChangeset.WithConfigFrom(func() (string, error) {
+			return "config", nil
+		}).configuration(input)
+		require.NoError(t, err)
+		require.Equal(t, "config", got)
+	})
+
+	t.Run("WithEnvInput", func(t *testing.T) { //nolint:paralleltest
+		t.Setenv("DURABLE_PIPELINE_INPUT", input)
+		got, err := configuredChangeset.WithEnvInput().configuration(input)
+		require.NoError(t, err)
+		require.Equal(t, "config", got)
+	})
+
+	t.Run("WithConfigResolver", func(t *testing.T) { //nolint:paralleltest
+		t.Setenv("DURABLE_PIPELINE_INPUT", input)
+		resolver := func(input string) (string, error) {
+			return "resolved " + input, nil
+		}
+		got, err := configuredChangeset.WithConfigResolver(resolver).configuration(input)
+		require.NoError(t, err)
+		require.Equal(t, "resolved config", got)
+	})
+}
+
 func TestConfigurations_ConfigResolverInfo(t *testing.T) {
 	t.Parallel()
 

--- a/engine/cld/changeset/common_test.go
+++ b/engine/cld/changeset/common_test.go
@@ -925,3 +925,37 @@ func TestConfigurations_ConfigResolverInfo(t *testing.T) {
 
 	assert.Equal(t, reflect.ValueOf(resolver).Pointer(), reflect.ValueOf(configs.ConfigResolver).Pointer())
 }
+
+func TestChangesetImple_applyWithInput(t *testing.T) {
+	t.Parallel()
+
+	c := ChangeSetImpl[string]{
+		configProvider: func() (string, error) { return "config", nil },
+		changeset:      Configure(MyChangeSet),
+	}
+	tests := []struct {
+		name  string
+		input any
+	}{
+		{
+			name:  "nil input",
+			input: nil,
+		},
+		{
+			name:  "empty input",
+			input: "",
+		},
+		{
+			name:  "non-empty input",
+			input: "input",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := c.applyWithInput(deployment.Environment{}, tt.input) // just check it doesn't panic
+			require.NoError(t, err)
+		})
+	}
+}

--- a/engine/cld/changeset/common_test.go
+++ b/engine/cld/changeset/common_test.go
@@ -925,37 +925,3 @@ func TestConfigurations_ConfigResolverInfo(t *testing.T) {
 
 	assert.Equal(t, reflect.ValueOf(resolver).Pointer(), reflect.ValueOf(configs.ConfigResolver).Pointer())
 }
-
-func TestChangesetImpl_applyWithInput(t *testing.T) {
-	t.Parallel()
-
-	c := ChangeSetImpl[string]{
-		configProvider: func() (string, error) { return "config", nil },
-		changeset:      Configure(MyChangeSet),
-	}
-	tests := []struct {
-		name  string
-		input any
-	}{
-		{
-			name:  "nil input",
-			input: nil,
-		},
-		{
-			name:  "empty input",
-			input: "",
-		},
-		{
-			name:  "non-empty input",
-			input: "input",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			_, err := c.applyWithInput(deployment.Environment{}, tt.input) // just check it doesn't panic
-			require.NoError(t, err)
-		})
-	}
-}

--- a/engine/cld/changeset/common_test.go
+++ b/engine/cld/changeset/common_test.go
@@ -881,7 +881,7 @@ func TestChangeSetImpl_configuration(t *testing.T) { //nolint:paralleltest
 	input := `{"payload":"config"}`
 
 	t.Run("With", func(t *testing.T) { //nolint:paralleltest
-		got, err := configuredChangeset.With("config").configuration(input)
+		got, err := configuredChangeset.With("config").resolvedInput(input)
 		require.NoError(t, err)
 		require.Equal(t, "config", got)
 	})
@@ -889,14 +889,14 @@ func TestChangeSetImpl_configuration(t *testing.T) { //nolint:paralleltest
 	t.Run("WithConfigFrom", func(t *testing.T) { //nolint:paralleltest
 		got, err := configuredChangeset.WithConfigFrom(func() (string, error) {
 			return "config", nil
-		}).configuration(input)
+		}).resolvedInput(input)
 		require.NoError(t, err)
 		require.Equal(t, "config", got)
 	})
 
 	t.Run("WithEnvInput", func(t *testing.T) { //nolint:paralleltest
 		t.Setenv("DURABLE_PIPELINE_INPUT", input)
-		got, err := configuredChangeset.WithEnvInput().configuration(input)
+		got, err := configuredChangeset.WithEnvInput().resolvedInput(input)
 		require.NoError(t, err)
 		require.Equal(t, "config", got)
 	})
@@ -906,7 +906,7 @@ func TestChangeSetImpl_configuration(t *testing.T) { //nolint:paralleltest
 		resolver := func(input string) (string, error) {
 			return "resolved " + input, nil
 		}
-		got, err := configuredChangeset.WithConfigResolver(resolver).configuration(input)
+		got, err := configuredChangeset.WithConfigResolver(resolver).resolvedInput(input)
 		require.NoError(t, err)
 		require.Equal(t, "resolved config", got)
 	})

--- a/engine/cld/changeset/hooks.go
+++ b/engine/cld/changeset/hooks.go
@@ -78,8 +78,11 @@ type PostProposalHookParams struct {
 	Env          ProposalHookEnv
 	ChangesetKey string
 	Proposal     *mcms.TimelockProposal
-	Input        any
+	Config       any
 	Reports      []MCMSTimelockExecuteReport
+
+	// Deprecated: use `Config` instead. Will be removed in a future version.
+	Input any
 }
 
 // PreHookFunc is the signature for functions that run before changeset Apply.

--- a/engine/cld/changeset/mcms.go
+++ b/engine/cld/changeset/mcms.go
@@ -82,7 +82,7 @@ func (*EVMForkContext) ChainFamily() string {
 //  1. Per-changeset post-proposal-hooks
 //  2. Global post-proposal-hooks
 func (r *ChangesetsRegistry) RunProposalHooks(
-	key string, e fdeployment.Environment, proposal *mcms.TimelockProposal, input any,
+	key string, e fdeployment.Environment, proposal *mcms.TimelockProposal, input, config any,
 	reports []MCMSTimelockExecuteReport, forkCtx ForkContext,
 ) error {
 	applySnapshot, err := r.getApplySnapshot(key)
@@ -106,6 +106,7 @@ func (r *ChangesetsRegistry) RunProposalHooks(
 		ChangesetKey: key,
 		Proposal:     proposal,
 		Input:        input,
+		Config:       config,
 		Reports:      reports,
 	}
 

--- a/engine/cld/changeset/mcms_test.go
+++ b/engine/cld/changeset/mcms_test.go
@@ -148,7 +148,7 @@ func Test_RunProposalHooks(t *testing.T) {
 			execLogs := []string{}
 			registry := tt.setup(&execLogs)
 
-			err := registry.RunProposalHooks(tt.key, hookTestEnv(t), &mcms.TimelockProposal{}, nil, nil, nil)
+			err := registry.RunProposalHooks(tt.key, hookTestEnv(t), &mcms.TimelockProposal{}, nil, nil, nil, nil)
 
 			if tt.wantErr == "" {
 				require.NoError(t, err)
@@ -165,6 +165,7 @@ func Test_RunProposalHooks_HookReceivesCorrectParams(t *testing.T) {
 
 	proposal := &mcms.TimelockProposal{}
 	input := "test-input"
+	config := "test-config"
 	reports := []MCMSTimelockExecuteReport{{Type: MCMSTimelockExecuteReportType}}
 
 	var receivedParams PostProposalHookParams
@@ -181,7 +182,7 @@ func Test_RunProposalHooks_HookReceivesCorrectParams(t *testing.T) {
 		}},
 	}
 
-	err := r.RunProposalHooks("test-cs", hookTestEnv(t), proposal, input, reports, nil)
+	err := r.RunProposalHooks("test-cs", hookTestEnv(t), proposal, input, config, reports, nil)
 	require.NoError(t, err)
 
 	expectedParams := PostProposalHookParams{
@@ -189,6 +190,7 @@ func Test_RunProposalHooks_HookReceivesCorrectParams(t *testing.T) {
 		ChangesetKey: "test-cs",
 		Proposal:     proposal,
 		Input:        input,
+		Config:       config,
 		Reports:      reports,
 	}
 	require.Empty(t, cmp.Diff(expectedParams, receivedParams,

--- a/engine/cld/changeset/postprocess.go
+++ b/engine/cld/changeset/postprocess.go
@@ -70,6 +70,10 @@ func (ccs PostProcessingChangeSetImpl[C]) WithPostProposalHooks(hooks ...PostPro
 	return ccs
 }
 
+func (ccs PostProcessingChangeSetImpl[C]) configuration(input string) (any, error) {
+	return ccs.changeset.configuration(input)
+}
+
 func (ccs PostProcessingChangeSetImpl[C]) getPreHooks() []PreHook   { return ccs.preHooks }
 func (ccs PostProcessingChangeSetImpl[C]) getPostHooks() []PostHook { return ccs.postHooks }
 func (ccs PostProcessingChangeSetImpl[C]) getPostProposalHooks() []PostProposalHook {

--- a/engine/cld/changeset/postprocess.go
+++ b/engine/cld/changeset/postprocess.go
@@ -37,10 +37,10 @@ func (ccs PostProcessingChangeSetImpl[C]) Apply(env fdeployment.Environment) (fd
 }
 
 func (ccs PostProcessingChangeSetImpl[C]) applyWithInput(
-	env fdeployment.Environment, inputStr string,
+	env fdeployment.Environment, input any,
 ) (fdeployment.ChangesetOutput, error) {
 	env.Logger.Debugf("Post-processing ChangesetOutput from %T", ccs.changeset.changeset.operation)
-	output, err := ccs.changeset.applyWithInput(env, inputStr)
+	output, err := ccs.changeset.applyWithInput(env, input)
 	if err != nil {
 		return output, err
 	}
@@ -70,8 +70,8 @@ func (ccs PostProcessingChangeSetImpl[C]) WithPostProposalHooks(hooks ...PostPro
 	return ccs
 }
 
-func (ccs PostProcessingChangeSetImpl[C]) configuration(input string) (any, error) {
-	return ccs.changeset.configuration(input)
+func (ccs PostProcessingChangeSetImpl[C]) resolvedInput(input string) (any, error) {
+	return ccs.changeset.resolvedInput(input)
 }
 
 func (ccs PostProcessingChangeSetImpl[C]) getPreHooks() []PreHook   { return ccs.preHooks }

--- a/engine/cld/changeset/postprocess_test.go
+++ b/engine/cld/changeset/postprocess_test.go
@@ -45,3 +45,17 @@ func TestChangesets_PostProcess(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, configs.InputChainOverrides)
 }
+
+func TestChangesets_PostProcess_configuration(t *testing.T) {
+	t.Parallel()
+
+	noopPostProcessor := func(_ fdeployment.Environment, o fdeployment.ChangesetOutput) (fdeployment.ChangesetOutput, error) {
+		return o, nil
+	}
+	input := `{"payload":"config"}`
+
+	got, err := Configure(MyChangeSet).With("config").ThenWith(noopPostProcessor).configuration(input)
+
+	require.NoError(t, err)
+	require.Equal(t, "config", got)
+}

--- a/engine/cld/changeset/postprocess_test.go
+++ b/engine/cld/changeset/postprocess_test.go
@@ -54,7 +54,7 @@ func TestChangesets_PostProcess_configuration(t *testing.T) {
 	}
 	input := `{"payload":"config"}`
 
-	got, err := Configure(MyChangeSet).With("config").ThenWith(noopPostProcessor).configuration(input)
+	got, err := Configure(MyChangeSet).With("config").ThenWith(noopPostProcessor).resolvedInput(input)
 
 	require.NoError(t, err)
 	require.Equal(t, "config", got)

--- a/engine/cld/changeset/registry.go
+++ b/engine/cld/changeset/registry.go
@@ -220,13 +220,7 @@ func (r *ChangesetsRegistry) Apply(
 		}
 	}
 
-	var output fdeployment.ChangesetOutput
-	var applyErr error
-	if cfg.inputStr == "" {
-		output, applyErr = applySnapshot.registryEntry.changeset.Apply(e)
-	} else {
-		output, applyErr = applySnapshot.registryEntry.changeset.applyWithInput(e, resolvedInput)
-	}
+	output, applyErr := applySnapshot.registryEntry.changeset.applyWithInput(e, resolvedInput)
 
 	if cfg.runHooks {
 		err = runPostHooks(e, key, resolvedInput, output, applyErr, applySnapshot)

--- a/engine/cld/changeset/registry.go
+++ b/engine/cld/changeset/registry.go
@@ -358,6 +358,9 @@ func (r *ChangesetsRegistry) GetResolvedInput(key string, input string) (any, er
 	if !ok {
 		return nil, fmt.Errorf("changeset '%s' not found", key)
 	}
+	if entry.IsArchived() {
+		return nil, fmt.Errorf("changeset '%s' is archived at SHA '%s'", key, *entry.gitSHA)
+	}
 
 	return entry.changeset.resolvedInput(input)
 }

--- a/engine/cld/changeset/registry.go
+++ b/engine/cld/changeset/registry.go
@@ -203,102 +203,98 @@ func (r *ChangesetsRegistry) Apply(
 		opt(&cfg)
 	}
 
-	if !cfg.runHooks {
-		entry, err := r.getApplyEntry(key)
-		if err != nil {
-			return fdeployment.ChangesetOutput{}, err
-		}
-
-		changesetConfig, err := entry.changeset.resolvedInput(cfg.inputStr)
-		if err != nil {
-			return fdeployment.ChangesetOutput{}, fmt.Errorf("failed to get changeset configuration: %w", err)
-		}
-
-		return entry.changeset.applyWithInput(e, changesetConfig)
-	}
-
 	applySnapshot, err := r.getApplySnapshot(key)
 	if err != nil {
 		return fdeployment.ChangesetOutput{}, err
 	}
 
-	changesetConfig, err := applySnapshot.registryEntry.changeset.resolvedInput(cfg.inputStr)
+	resolvedInput, err := applySnapshot.registryEntry.changeset.resolvedInput(cfg.inputStr)
 	if err != nil {
 		return fdeployment.ChangesetOutput{}, fmt.Errorf("failed to get changeset configuration: %w", err)
 	}
 
-	hookEnv := HookEnv{
-		Name:   e.Name,
-		Logger: e.Logger,
-	}
-
-	preParams := PreHookParams{
-		Env:          hookEnv,
-		ChangesetKey: key,
-		Config:       changesetConfig,
-	}
-
-	for _, h := range applySnapshot.globalPreHooks {
-		if err := ExecuteHook(e, h.HookDefinition, func(ctx context.Context) error {
-			return h.Func(ctx, preParams)
-		}); err != nil {
-			return fdeployment.ChangesetOutput{}, fmt.Errorf("global pre-hook %q failed: %w", h.Name, err)
+	if cfg.runHooks {
+		err = runPreHooks(e, key, resolvedInput, applySnapshot)
+		if err != nil {
+			return fdeployment.ChangesetOutput{}, err
 		}
 	}
 
-	for _, h := range applySnapshot.registryEntry.preHooks {
-		if err := ExecuteHook(e, h.HookDefinition, func(ctx context.Context) error {
-			return h.Func(ctx, preParams)
-		}); err != nil {
-			return fdeployment.ChangesetOutput{}, fmt.Errorf("pre-hook %q failed: %w", h.Name, err)
-		}
+	var output fdeployment.ChangesetOutput
+	var applyErr error
+	if cfg.inputStr == "" {
+		output, applyErr = applySnapshot.registryEntry.changeset.Apply(e)
+	} else {
+		output, applyErr = applySnapshot.registryEntry.changeset.applyWithInput(e, resolvedInput)
 	}
 
-	output, applyErr := applySnapshot.registryEntry.changeset.applyWithInput(e, changesetConfig)
-
-	postParams := PostHookParams{
-		Env:          hookEnv,
-		ChangesetKey: key,
-		Config:       changesetConfig,
-		Output:       output,
-		Err:          applyErr,
-	}
-
-	for _, h := range applySnapshot.registryEntry.postHooks {
-		if err := ExecuteHook(e, h.HookDefinition, func(ctx context.Context) error {
-			return h.Func(ctx, postParams)
-		}); err != nil {
-			if applyErr != nil {
-				e.Logger.Warnw("post-hook failed after changeset error",
-					"hook", h.Name, "hookErr", err, "changesetErr", applyErr)
-			} else {
-				return output, fmt.Errorf("post-hook %q failed: %w", h.Name, err)
-			}
-		}
-	}
-
-	for _, h := range applySnapshot.globalPostHooks {
-		if err := ExecuteHook(e, h.HookDefinition, func(ctx context.Context) error {
-			return h.Func(ctx, postParams)
-		}); err != nil {
-			if applyErr != nil {
-				e.Logger.Warnw("global post-hook failed after changeset error",
-					"hook", h.Name, "hookErr", err, "changesetErr", applyErr)
-			} else {
-				return output, fmt.Errorf("global post-hook %q failed: %w", h.Name, err)
-			}
+	if cfg.runHooks {
+		err = runPostHooks(e, key, resolvedInput, output, applyErr, applySnapshot)
+		if err != nil {
+			return fdeployment.ChangesetOutput{}, err
 		}
 	}
 
 	return output, applyErr
 }
 
-// getApplyEntry reads and validates a changeset entry under the mutex.
-func (r *ChangesetsRegistry) getApplyEntry(key string) (registryEntry, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+func runPreHooks(e fdeployment.Environment, key string, resolvedInput any, applySnapshot applySnapshot) error {
+	preParams := PreHookParams{
+		Env:          HookEnv{Name: e.Name, Logger: e.Logger},
+		ChangesetKey: key,
+		Config:       resolvedInput,
+	}
 
-	return r.getApplyEntryLocked(key)
+	for _, h := range applySnapshot.globalPreHooks {
+		err := ExecuteHook(e, h.HookDefinition, func(ctx context.Context) error { return h.Func(ctx, preParams) })
+		if err != nil {
+			return fmt.Errorf("global pre-hook %q failed: %w", h.Name, err)
+		}
+	}
+	for _, h := range applySnapshot.registryEntry.preHooks {
+		err := ExecuteHook(e, h.HookDefinition, func(ctx context.Context) error { return h.Func(ctx, preParams) })
+		if err != nil {
+			return fmt.Errorf("changeset pre-hook %q failed: %w", h.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func runPostHooks(
+	e fdeployment.Environment, key string, resolvedInput any, output fdeployment.ChangesetOutput,
+	applyErr error, applySnapshot applySnapshot,
+) error {
+	postParams := PostHookParams{
+		Env:          HookEnv{Name: e.Name, Logger: e.Logger},
+		ChangesetKey: key,
+		Config:       resolvedInput,
+		Output:       output,
+		Err:          applyErr,
+	}
+
+	for _, h := range applySnapshot.registryEntry.postHooks {
+		err := ExecuteHook(e, h.HookDefinition, func(ctx context.Context) error { return h.Func(ctx, postParams) })
+		if err != nil {
+			if applyErr != nil {
+				e.Logger.Warnw("post-hook failed after changeset error", "hook", h.Name, "hookErr", err, "changesetErr", applyErr)
+			} else {
+				return fmt.Errorf("changeset post-hook %q failed: %w", h.Name, err)
+			}
+		}
+	}
+	for _, h := range applySnapshot.globalPostHooks {
+		err := ExecuteHook(e, h.HookDefinition, func(ctx context.Context) error { return h.Func(ctx, postParams) })
+		if err != nil {
+			if applyErr != nil {
+				e.Logger.Warnw("global post-hook failed after changeset error", "hook", h.Name, "hookErr", err, "changesetErr", applyErr)
+			} else {
+				return fmt.Errorf("global post-hook %q failed: %w", h.Name, err)
+			}
+		}
+	}
+
+	return nil
 }
 
 type applySnapshot struct {

--- a/engine/cld/changeset/registry.go
+++ b/engine/cld/changeset/registry.go
@@ -209,7 +209,12 @@ func (r *ChangesetsRegistry) Apply(
 			return fdeployment.ChangesetOutput{}, err
 		}
 
-		return entry.changeset.applyWithInput(e, cfg.inputStr)
+		changesetConfig, err := entry.changeset.resolvedInput(cfg.inputStr)
+		if err != nil {
+			return fdeployment.ChangesetOutput{}, fmt.Errorf("failed to get changeset configuration: %w", err)
+		}
+
+		return entry.changeset.applyWithInput(e, changesetConfig)
 	}
 
 	applySnapshot, err := r.getApplySnapshot(key)
@@ -217,7 +222,7 @@ func (r *ChangesetsRegistry) Apply(
 		return fdeployment.ChangesetOutput{}, err
 	}
 
-	changesetConfig, err := applySnapshot.registryEntry.changeset.configuration(cfg.inputStr)
+	changesetConfig, err := applySnapshot.registryEntry.changeset.resolvedInput(cfg.inputStr)
 	if err != nil {
 		return fdeployment.ChangesetOutput{}, fmt.Errorf("failed to get changeset configuration: %w", err)
 	}
@@ -249,7 +254,7 @@ func (r *ChangesetsRegistry) Apply(
 		}
 	}
 
-	output, applyErr := applySnapshot.registryEntry.changeset.applyWithInput(e, cfg.inputStr)
+	output, applyErr := applySnapshot.registryEntry.changeset.applyWithInput(e, changesetConfig)
 
 	postParams := PostHookParams{
 		Env:          hookEnv,
@@ -346,15 +351,15 @@ func (r *ChangesetsRegistry) GetChangesetOptions(key string) (ChangesetConfig, e
 	return entry.options, nil
 }
 
-// GetConfiguration retrieves the configuration for a changeset.
+// GetResolvedInput retrieves the configuration for a changeset.
 // \"input\" is the optional input string passed to \"registry.Apply()\".
-func (r *ChangesetsRegistry) GetConfiguration(key string, input string) (any, error) {
+func (r *ChangesetsRegistry) GetResolvedInput(key string, input string) (any, error) {
 	entry, ok := r.entries[key]
 	if !ok {
 		return nil, fmt.Errorf("changeset '%s' not found", key)
 	}
 
-	return entry.changeset.configuration(input)
+	return entry.changeset.resolvedInput(input)
 }
 
 // GetConfigurations retrieves the configurations for a changeset.

--- a/engine/cld/changeset/registry.go
+++ b/engine/cld/changeset/registry.go
@@ -217,6 +217,11 @@ func (r *ChangesetsRegistry) Apply(
 		return fdeployment.ChangesetOutput{}, err
 	}
 
+	changesetConfig, err := applySnapshot.registryEntry.changeset.configuration(cfg.inputStr)
+	if err != nil {
+		return fdeployment.ChangesetOutput{}, fmt.Errorf("failed to get changeset configuration: %w", err)
+	}
+
 	hookEnv := HookEnv{
 		Name:   e.Name,
 		Logger: e.Logger,
@@ -225,6 +230,7 @@ func (r *ChangesetsRegistry) Apply(
 	preParams := PreHookParams{
 		Env:          hookEnv,
 		ChangesetKey: key,
+		Config:       changesetConfig,
 	}
 
 	for _, h := range applySnapshot.globalPreHooks {
@@ -248,6 +254,7 @@ func (r *ChangesetsRegistry) Apply(
 	postParams := PostHookParams{
 		Env:          hookEnv,
 		ChangesetKey: key,
+		Config:       changesetConfig,
 		Output:       output,
 		Err:          applyErr,
 	}
@@ -337,6 +344,17 @@ func (r *ChangesetsRegistry) GetChangesetOptions(key string) (ChangesetConfig, e
 	}
 
 	return entry.options, nil
+}
+
+// GetConfiguration retrieves the configuration for a changeset.
+// \"input\" is the optional input string passed to \"registry.Apply()\".
+func (r *ChangesetsRegistry) GetConfiguration(key string, input string) (any, error) {
+	entry, ok := r.entries[key]
+	if !ok {
+		return nil, fmt.Errorf("changeset '%s' not found", key)
+	}
+
+	return entry.changeset.configuration(input)
 }
 
 // GetConfigurations retrieves the configurations for a changeset.

--- a/engine/cld/changeset/registry_test.go
+++ b/engine/cld/changeset/registry_test.go
@@ -26,7 +26,7 @@ func (noopChangeset) Apply(e fdeployment.Environment) (fdeployment.ChangesetOutp
 	return fdeployment.ChangesetOutput{}, nil
 }
 
-func (n noopChangeset) applyWithInput(e fdeployment.Environment, _ string) (fdeployment.ChangesetOutput, error) {
+func (n noopChangeset) applyWithInput(e fdeployment.Environment, _ any) (fdeployment.ChangesetOutput, error) {
 	return n.Apply(e)
 }
 
@@ -36,7 +36,7 @@ func (n noopChangeset) Configurations() (Configurations, error) {
 	}, nil
 }
 
-func (n noopChangeset) configuration(input string) (any, error) {
+func (n noopChangeset) resolvedInput(input string) (any, error) {
 	return n.config, nil
 }
 
@@ -55,7 +55,7 @@ func (r *recordingChangeset) Apply(_ fdeployment.Environment) (fdeployment.Chang
 	return r.output, r.err
 }
 
-func (r *recordingChangeset) applyWithInput(e fdeployment.Environment, _ string) (fdeployment.ChangesetOutput, error) {
+func (r *recordingChangeset) applyWithInput(e fdeployment.Environment, _ any) (fdeployment.ChangesetOutput, error) {
 	return r.Apply(e)
 }
 
@@ -63,7 +63,7 @@ func (*recordingChangeset) Configurations() (Configurations, error) {
 	return Configurations{}, nil
 }
 
-func (r *recordingChangeset) configuration(input string) (any, error) {
+func (r *recordingChangeset) resolvedInput(input string) (any, error) {
 	return r.config, nil
 }
 
@@ -79,7 +79,7 @@ func (o *orderRecordingChangeset) Apply(_ fdeployment.Environment) (fdeployment.
 	return fdeployment.ChangesetOutput{}, nil
 }
 
-func (o *orderRecordingChangeset) applyWithInput(e fdeployment.Environment, _ string) (fdeployment.ChangesetOutput, error) {
+func (o *orderRecordingChangeset) applyWithInput(e fdeployment.Environment, _ any) (fdeployment.ChangesetOutput, error) {
 	return o.Apply(e)
 }
 
@@ -87,7 +87,7 @@ func (*orderRecordingChangeset) Configurations() (Configurations, error) {
 	return Configurations{}, nil
 }
 
-func (*orderRecordingChangeset) configuration(input string) (any, error) {
+func (*orderRecordingChangeset) resolvedInput(input string) (any, error) {
 	return "orderRecordingChangesetConfiguration", nil
 }
 
@@ -1293,7 +1293,7 @@ func Test_WithPostProposalHooks(t *testing.T) {
 	})
 }
 
-func Test_Changesets_GetConfiguration(t *testing.T) {
+func Test_Changesets_GetResolvedInput(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -1347,7 +1347,7 @@ func Test_Changesets_GetConfiguration(t *testing.T) {
 			registry := NewChangesetsRegistry()
 			tt.setup(registry)
 
-			got, err := registry.GetConfiguration(tt.key, tt.input)
+			got, err := registry.GetResolvedInput(tt.key, tt.input)
 
 			if tt.wantErr == "" {
 				require.NoError(t, err)

--- a/engine/cld/changeset/registry_test.go
+++ b/engine/cld/changeset/registry_test.go
@@ -17,6 +17,7 @@ import (
 // Used for testing.
 type noopChangeset struct {
 	chainOverrides []uint64
+	config         any
 }
 
 func (noopChangeset) noop() {}
@@ -35,9 +36,14 @@ func (n noopChangeset) Configurations() (Configurations, error) {
 	}, nil
 }
 
+func (n noopChangeset) configuration(input string) (any, error) {
+	return n.config, nil
+}
+
 // recordingChangeset tracks whether Apply was called and returns configurable output/error.
 type recordingChangeset struct {
 	applyCalled bool
+	config      any
 	output      fdeployment.ChangesetOutput
 	err         error
 }
@@ -55,6 +61,10 @@ func (r *recordingChangeset) applyWithInput(e fdeployment.Environment, _ string)
 
 func (*recordingChangeset) Configurations() (Configurations, error) {
 	return Configurations{}, nil
+}
+
+func (r *recordingChangeset) configuration(input string) (any, error) {
+	return r.config, nil
 }
 
 // orderRecordingChangeset records "apply" calls into its internal order slice for tests.
@@ -75,6 +85,10 @@ func (o *orderRecordingChangeset) applyWithInput(e fdeployment.Environment, _ st
 
 func (*orderRecordingChangeset) Configurations() (Configurations, error) {
 	return Configurations{}, nil
+}
+
+func (*orderRecordingChangeset) configuration(input string) (any, error) {
+	return "orderRecordingChangesetConfiguration", nil
 }
 
 func hookTestEnv(t *testing.T) fdeployment.Environment {
@@ -564,7 +578,57 @@ func Test_Apply_PreHookWarn_ContinuesExecution(t *testing.T) {
 	assert.True(t, cs.applyCalled, "changeset should still run after Warn hook failure")
 }
 
-func Test_Apply_PostHookReceivesOutputAndErr(t *testing.T) {
+func Test_Apply_PreHook_ReceivesParams(t *testing.T) {
+	t.Parallel()
+
+	changeset := &recordingChangeset{config: "test-config"}
+	receivedParams := PreHookParams{}
+	registry := NewChangesetsRegistry()
+	registry.entries["test-cs"] = registryEntry{
+		changeset: changeset,
+		preHooks: []PreHook{{
+			HookDefinition: HookDefinition{Name: "observer", FailurePolicy: Warn},
+			Func: func(_ context.Context, params PreHookParams) error {
+				receivedParams = params
+				return nil
+			},
+		}},
+	}
+
+	_, err := registry.Apply("test-cs", hookTestEnv(t))
+
+	require.NoError(t, err)
+	require.Equal(t, "test-cs", receivedParams.ChangesetKey)
+	require.Equal(t, "test-env", receivedParams.Env.Name)
+	require.Equal(t, "test-config", receivedParams.Config)
+}
+
+func Test_Apply_PreHook_ConfigurationErrorAbortsPipeline(t *testing.T) {
+	t.Parallel()
+
+	changeset := Configure(MyChangeSet).WithConfigFrom(func() (string, error) {
+		return "", errors.New("config unavailable")
+	})
+	registry := NewChangesetsRegistry()
+	registry.SetValidate(false)
+	registry.Add("test-cs", changeset)
+
+	preHookRan := false
+	registry.AddGlobalPreHooks(PreHook{
+		HookDefinition: HookDefinition{Name: "pre-hook"},
+		Func: func(_ context.Context, _ PreHookParams) error {
+			preHookRan = true
+			return nil
+		},
+	})
+
+	_, err := registry.Apply("test-cs", hookTestEnv(t))
+
+	require.ErrorContains(t, err, "failed to get changeset configuration")
+	require.False(t, preHookRan)
+}
+
+func Test_Apply_PostHook_ReceivesParams(t *testing.T) {
 	t.Parallel()
 
 	expectedOutput := fdeployment.ChangesetOutput{}
@@ -572,6 +636,7 @@ func Test_Apply_PostHookReceivesOutputAndErr(t *testing.T) {
 	cs := &recordingChangeset{
 		output: expectedOutput,
 		err:    expectedErr,
+		config: "test-config",
 	}
 
 	var receivedParams PostHookParams
@@ -594,6 +659,7 @@ func Test_Apply_PostHookReceivesOutputAndErr(t *testing.T) {
 	assert.Equal(t, expectedErr, receivedParams.Err)
 	assert.Equal(t, "test-cs", receivedParams.ChangesetKey)
 	assert.Equal(t, "test-env", receivedParams.Env.Name)
+	assert.Equal(t, "test-config", receivedParams.Config)
 }
 
 func Test_Apply_PostHookAbort_AfterSuccessfulApply(t *testing.T) {
@@ -919,7 +985,7 @@ func Test_FluentAPI_HooksExtractedByAdd(t *testing.T) {
 		require.Len(t, entry.postProposalHooks, 1, "Add should extract post-proposal-hooks via hookCarrier")
 		require.Equal(t, "proposal-hook", entry.postProposalHooks[0].Name)
 
-		err := r.RunProposalHooks("test-cs", hookTestEnv(t), nil, "input", nil, nil)
+		err := r.RunProposalHooks("test-cs", hookTestEnv(t), nil, "input", "config", nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, []string{"proposal"}, hookExecutions)
 	})
@@ -940,7 +1006,7 @@ func Test_FluentAPI_HooksExtractedByAdd(t *testing.T) {
 		require.Len(t, entry.postProposalHooks, 1)
 		require.Equal(t, "proposal-hook", entry.postProposalHooks[0].Name)
 
-		err := r.RunProposalHooks("test-cs", hookTestEnv(t), nil, "input", nil, nil)
+		err := r.RunProposalHooks("test-cs", hookTestEnv(t), nil, "input", "config", nil, nil)
 		require.NoError(t, err)
 		require.Equal(t, []string{"proposal"}, hookExecutions)
 	})
@@ -1225,6 +1291,72 @@ func Test_WithPostProposalHooks(t *testing.T) {
 		require.Equal(t, "h1", hooks[0].Name)
 		require.Equal(t, "h2", hooks[1].Name)
 	})
+}
+
+func Test_Changesets_GetConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func(*ChangesetsRegistry)
+		key     string
+		input   string
+		want    any
+		wantErr string
+	}{
+		{
+			name:    "unknown key returns error",
+			setup:   func(r *ChangesetsRegistry) {},
+			key:     "invalid_key",
+			wantErr: "changeset 'invalid_key' not found",
+		},
+		{
+			name: "found key returns config value",
+			setup: func(r *ChangesetsRegistry) {
+				r.Add("0001_cap_reg", noopChangeset{config: "my-config"})
+			},
+			key:  "0001_cap_reg",
+			want: "my-config",
+		},
+		{
+			name: "found key with nil config returns nil",
+			setup: func(r *ChangesetsRegistry) {
+				r.Add("0001_cap_reg", noopChangeset{})
+			},
+			key:  "0001_cap_reg",
+			want: nil,
+		},
+		{
+			name: "configuration error is propagated",
+			setup: func(r *ChangesetsRegistry) {
+				cs := Configure(MyChangeSet).WithConfigFrom(func() (string, error) {
+					return "", errors.New("config unavailable")
+				})
+				r.SetValidate(false)
+				r.Add("0001_cap_reg", cs)
+			},
+			key:     "0001_cap_reg",
+			wantErr: "config unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			registry := NewChangesetsRegistry()
+			tt.setup(registry)
+
+			got, err := registry.GetConfiguration(tt.key, tt.input)
+
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
 }
 
 func Test_Changesets_AddGlobalPostProposalHooks(t *testing.T) {

--- a/engine/cld/commands/mcms/cmd_run_hooks.go
+++ b/engine/cld/commands/mcms/cmd_run_hooks.go
@@ -49,9 +49,10 @@ type proposalMetadata struct {
 }
 
 type changesetMetadata struct {
-	ID    string `json:"id" mapstructure:"id"`
-	Name  string `json:"name" mapstructure:"name"`
-	Input any    `json:"input" mapstructure:"input"`
+	ID     string `json:"id" mapstructure:"id"`
+	Name   string `json:"name" mapstructure:"name"`
+	Input  any    `json:"input" mapstructure:"input"`
+	Config any    `json:"config" mapstructure:"config"`
 }
 
 func newRunProposalHooksCmd(cfg Config) *cobra.Command {
@@ -144,7 +145,7 @@ func runHooksInternal(
 		})
 
 		herr := changesetRegistry.RunProposalHooks(changeset.Name, env, timelockProposal,
-			changeset.Input, changesetReports, forkCtx)
+			changeset.Input, changeset.Config, changesetReports, forkCtx)
 		if herr != nil {
 			return fmt.Errorf("proposal hook for changeset %q failed: %w", changeset.Name, herr)
 		}

--- a/engine/cld/commands/mcms/cmd_run_hooks_test.go
+++ b/engine/cld/commands/mcms/cmd_run_hooks_test.go
@@ -160,10 +160,13 @@ func Test_newRunProposalHooksCmd(t *testing.T) { //nolint:paralleltest
 				require.NoError(t, err)
 				require.Equal(t, 1, testCtx.logs.FilterMessage("test-changeset-post-proposal-hook executed").Len())
 				require.Equal(t, 1, testCtx.logs.FilterMessage("test-changeset-post-proposal-hook; # reports: 1").Len())
+				require.Equal(t, 1, testCtx.logs.FilterMessage("test-changeset-post-proposal-hook; config: map[config-key:config-value]").Len())
 				require.Equal(t, 0, testCtx.logs.FilterMessage("test-changeset-post-proposal-hook; forkctx family: EVM").Len())
 				require.Equal(t, 2, testCtx.logs.FilterMessage("test-global-post-proposal-hook executed").Len())
 				require.Equal(t, 1, testCtx.logs.FilterMessage("test-global-post-proposal-hook; # reports: 1").Len())
 				require.Equal(t, 1, testCtx.logs.FilterMessage("test-global-post-proposal-hook; # reports: 0").Len())
+				require.Equal(t, 1, testCtx.logs.FilterMessage("test-global-post-proposal-hook; config: map[config-key:config-value]").Len())
+				require.Equal(t, 1, testCtx.logs.FilterMessage("test-global-post-proposal-hook; config: map[]").Len())
 				require.Equal(t, 0, testCtx.logs.FilterMessage("test-global-post-proposal-hook; forkctx family: EVM").Len())
 			},
 		},
@@ -243,13 +246,17 @@ var testProposalWithChangesetsJSON = []byte(`{
 				"id": "30377e5d-d431-4c27-ac79-31ced49fffc0",
 				"name": "001_test_changeset",
 				"input": {
-					"key": "value"
+					"input-key": "input-value"
+				},
+				"config": {
+					"config-key": "config-value"
 				}
 			},
 			{
 				"id": "df1fbe75-5009-4561-b936-d3c1c6762c98",
 				"name": "002_test_changeset",
-				"input": {}
+				"input": {},
+				"config": {}
 			}
 		]
 	},
@@ -347,6 +354,7 @@ func loadChangesets(envName string) (*changeset.ChangesetsRegistry, error) {
 				Func: func(ctx context.Context, params changeset.PostProposalHookParams) error {
 					params.Env.Logger.Info("test-changeset-post-proposal-hook executed")
 					params.Env.Logger.Infof("test-changeset-post-proposal-hook; # reports: %d", len(params.Reports))
+					params.Env.Logger.Infof("test-changeset-post-proposal-hook; config: %v", params.Config)
 					if params.Env.ForkContext != nil {
 						params.Env.Logger.Infof("test-changeset-post-proposal-hook; forkctx family: %v",
 							params.Env.ForkContext.ChainFamily())
@@ -370,6 +378,7 @@ func loadChangesets(envName string) (*changeset.ChangesetsRegistry, error) {
 		Func: func(ctx context.Context, params changeset.PostProposalHookParams) error {
 			params.Env.Logger.Info("test-global-post-proposal-hook executed")
 			params.Env.Logger.Infof("test-global-post-proposal-hook; # reports: %d", len(params.Reports))
+			params.Env.Logger.Infof("test-global-post-proposal-hook; config: %v", params.Config)
 			if params.Env.ForkContext != nil {
 				params.Env.Logger.Infof("test-global-post-proposal-hook; forkctx family: %v", params.Env.ForkContext.ChainFamily())
 			}

--- a/engine/cld/commands/pipeline/run.go
+++ b/engine/cld/commands/pipeline/run.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	fdeployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/changeset"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/commands/flags"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/pipeline/input"
@@ -172,7 +173,7 @@ func runRun(cmd *cobra.Command, cfg *Config, f runFlags) error {
 		return saveErr
 	}
 
-	err = saveChangesetProposalMetadata(actualChangesetName, out)
+	err = saveChangesetProposalMetadata(registry, actualChangesetName, out)
 	if err != nil {
 		return fmt.Errorf("failed to save changeset proposal metadata: %w", err)
 	}
@@ -202,7 +203,9 @@ func runRun(cmd *cobra.Command, cfg *Config, f runFlags) error {
 	return nil
 }
 
-func saveChangesetProposalMetadata(changesetName string, out fdeployment.ChangesetOutput) error {
+func saveChangesetProposalMetadata(
+	registry *changeset.ChangesetsRegistry, changesetName string, out fdeployment.ChangesetOutput,
+) error {
 	if len(out.MCMSTimelockProposals) == 0 {
 		return nil
 	}
@@ -210,6 +213,11 @@ func saveChangesetProposalMetadata(changesetName string, out fdeployment.Changes
 	changesetInputJSON := os.Getenv("DURABLE_PIPELINE_INPUT")
 	if len(changesetInputJSON) == 0 {
 		return errors.New("durable pipeline input is empty or not set")
+	}
+
+	changesetConfig, err := registry.GetConfiguration(changesetName, changesetInputJSON)
+	if err != nil {
+		return fmt.Errorf("failed to get changeset configuration: %w", err)
 	}
 
 	id := uuid.NewString()
@@ -221,13 +229,15 @@ func saveChangesetProposalMetadata(changesetName string, out fdeployment.Changes
 		}
 
 		proposal.Metadata["changesets"] = []struct {
-			ID    string          `json:"id"`
-			Name  string          `json:"name"`
-			Input json.RawMessage `json:"input"`
+			ID     string          `json:"id"`
+			Name   string          `json:"name"`
+			Input  json.RawMessage `json:"input"`
+			Config any             `json:"config"`
 		}{{
-			ID:    id,
-			Name:  changesetName,
-			Input: json.RawMessage(changesetInputJSON),
+			ID:     id,
+			Name:   changesetName,
+			Input:  json.RawMessage(changesetInputJSON),
+			Config: changesetConfig,
 		}}
 
 		for j := range proposal.Operations {

--- a/engine/cld/commands/pipeline/run.go
+++ b/engine/cld/commands/pipeline/run.go
@@ -215,7 +215,7 @@ func saveChangesetProposalMetadata(
 		return errors.New("durable pipeline input is empty or not set")
 	}
 
-	changesetConfig, err := registry.GetConfiguration(changesetName, changesetInputJSON)
+	changesetConfig, err := registry.GetResolvedInput(changesetName, changesetInputJSON)
 	if err != nil {
 		return fmt.Errorf("failed to get changeset configuration: %w", err)
 	}

--- a/engine/cld/commands/pipeline/run_test.go
+++ b/engine/cld/commands/pipeline/run_test.go
@@ -593,7 +593,7 @@ changesets:
   - 0001_test_changeset:
       payload:
         chain: optimism_sepolia
-        value: 100`
+        value: 123456789012345678901234`
 	yamlFileName := "test-input.yaml"
 	require.NoError(t, os.WriteFile(filepath.Join(inputsDir, yamlFileName), []byte(yamlContent), 0o600))
 
@@ -607,7 +607,7 @@ changesets:
 		rp := &registryProviderStub{
 			BaseRegistryProvider: changeset.NewBaseRegistryProvider(),
 			AddAction: func(reg *changeset.ChangesetsRegistry) {
-				reg.Add(changesetName, changeset.Configure(changesetStub).With(1))
+				reg.Add(changesetName, changeset.Configure(changesetStub).WithEnvInput())
 			},
 		}
 		if initErr := rp.Init(); initErr != nil {
@@ -658,8 +658,12 @@ changesets:
 				"input": map[string]any{
 					"payload": map[string]any{
 						"chain": "optimism_sepolia",
-						"value": json.Number("100"),
+						"value": json.Number("123456789012345678901234"),
 					},
+				},
+				"config": map[string]any{
+					"chain": "optimism_sepolia",
+					"value": json.Number("123456789012345678901234"),
 				},
 			},
 		},


### PR DESCRIPTION
This pull request adapts the main hook setup logic in the CLD engine so that the `Config` field from the `PreHookParams` and `PostHookParams` types (which are passed to hook functions) is properly populated.

Additionally, it adds a homonym field to the `PostProposalHookParams` type and deprecates the existing `Input` field, thus ensuring that all hook types provide a consistent interface.

To populate the field with the same value that is passed to changesets, a new `resolvedInput(input string)` method was added to the `internalChangeset` interface. This method simply returns the output of the changeset's configuration providers.

---
CLD-1819