### PR TITLE
chore: migrate contract_bindings.go to proposalutils from core repo [CLD-1910]

### DIFF
--- a/.changeset/modern-experts-flash.md
+++ b/.changeset/modern-experts-flash.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+add contract binding types to proposalutils

--- a/engine/cld/mcms/proposalutils/aptos_utils.go
+++ b/engine/cld/mcms/proposalutils/aptos_utils.go
@@ -1,0 +1,13 @@
+package proposalutils
+
+import (
+	mcmsaptossdk "github.com/smartcontractkit/mcms/sdk/aptos"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+)
+
+func GetAptosRoleFromAction(action mcmstypes.TimelockAction) (mcmsaptossdk.TimelockRole, error) {
+	if action == "" {
+		return mcmsaptossdk.TimelockRoleProposer, nil
+	}
+	return mcmsaptossdk.AptosRoleFromAction(action)
+}

--- a/engine/cld/mcms/proposalutils/aptos_utils.go
+++ b/engine/cld/mcms/proposalutils/aptos_utils.go
@@ -9,5 +9,6 @@ func GetAptosRoleFromAction(action mcmstypes.TimelockAction) (mcmsaptossdk.Timel
 	if action == "" {
 		return mcmsaptossdk.TimelockRoleProposer, nil
 	}
+
 	return mcmsaptossdk.AptosRoleFromAction(action)
 }

--- a/engine/cld/mcms/proposalutils/contract_bindings.go
+++ b/engine/cld/mcms/proposalutils/contract_bindings.go
@@ -32,5 +32,6 @@ func (state MCMSWithTimelockContracts) Validate() error {
 	if state.CallProxy == nil {
 		return errors.New("call proxy not found")
 	}
+
 	return nil
 }

--- a/engine/cld/mcms/proposalutils/contract_bindings.go
+++ b/engine/cld/mcms/proposalutils/contract_bindings.go
@@ -6,6 +6,16 @@ import (
 	ownerhelpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
 )
 
+var (
+	ErrMissingTimelockBinding = errors.New("missing Timelock RBACTimelock binding")
+	ErrMissingCancellerMCM    = errors.New("missing CancellerMcm ManyChainMultiSig binding")
+	ErrMissingProposerMCM     = errors.New("missing ProposerMcm ManyChainMultiSig binding")
+	ErrMissingBypasserMCM     = errors.New("missing BypasserMcm ManyChainMultiSig binding")
+	ErrMissingCallProxy       = errors.New("missing CallProxy binding")
+)
+
+// MCMSWithTimelockContracts holds the Go bindings
+// for a MCMSWithTimelock standard contract deployment.
 type MCMSWithTimelockContracts struct {
 	CancellerMcm *ownerhelpers.ManyChainMultiSig
 	BypasserMcm  *ownerhelpers.ManyChainMultiSig
@@ -14,23 +24,23 @@ type MCMSWithTimelockContracts struct {
 	CallProxy    *ownerhelpers.CallProxy
 }
 
-// Validate checks that all fields are non-nil, ensuring it's ready
+// Validate checks all contract bindings are non-nil, ensuring the struct is ready
 // for use generating views or interactions.
 func (state MCMSWithTimelockContracts) Validate() error {
 	if state.Timelock == nil {
-		return errors.New("timelock not found")
+		return ErrMissingTimelockBinding
 	}
 	if state.CancellerMcm == nil {
-		return errors.New("canceller not found")
+		return ErrMissingCancellerMCM
 	}
 	if state.ProposerMcm == nil {
-		return errors.New("proposer not found")
+		return ErrMissingProposerMCM
 	}
 	if state.BypasserMcm == nil {
-		return errors.New("bypasser not found")
+		return ErrMissingBypasserMCM
 	}
 	if state.CallProxy == nil {
-		return errors.New("call proxy not found")
+		return ErrMissingCallProxy
 	}
 
 	return nil

--- a/engine/cld/mcms/proposalutils/contract_bindings.go
+++ b/engine/cld/mcms/proposalutils/contract_bindings.go
@@ -1,0 +1,36 @@
+package proposalutils
+
+import (
+	"errors"
+
+	ownerhelpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
+)
+
+type MCMSWithTimelockContracts struct {
+	CancellerMcm *ownerhelpers.ManyChainMultiSig
+	BypasserMcm  *ownerhelpers.ManyChainMultiSig
+	ProposerMcm  *ownerhelpers.ManyChainMultiSig
+	Timelock     *ownerhelpers.RBACTimelock
+	CallProxy    *ownerhelpers.CallProxy
+}
+
+// Validate checks that all fields are non-nil, ensuring it's ready
+// for use generating views or interactions.
+func (state MCMSWithTimelockContracts) Validate() error {
+	if state.Timelock == nil {
+		return errors.New("timelock not found")
+	}
+	if state.CancellerMcm == nil {
+		return errors.New("canceller not found")
+	}
+	if state.ProposerMcm == nil {
+		return errors.New("proposer not found")
+	}
+	if state.BypasserMcm == nil {
+		return errors.New("bypasser not found")
+	}
+	if state.CallProxy == nil {
+		return errors.New("call proxy not found")
+	}
+	return nil
+}

--- a/engine/cld/mcms/proposalutils/contract_bindings_test.go
+++ b/engine/cld/mcms/proposalutils/contract_bindings_test.go
@@ -1,0 +1,90 @@
+package proposalutils
+
+import (
+	"testing"
+
+	ownerhelpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCMSWithTimelockContractsValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(MCMSWithTimelockContracts) MCMSWithTimelockContracts
+		wantErr error
+	}{
+		{
+			name: "success",
+			mutate: func(state MCMSWithTimelockContracts) MCMSWithTimelockContracts {
+				return state
+			},
+		},
+		{
+			name: "missing timelock binding",
+			mutate: func(state MCMSWithTimelockContracts) MCMSWithTimelockContracts {
+				state.Timelock = nil
+				return state
+			},
+			wantErr: ErrMissingTimelockBinding,
+		},
+		{
+			name: "missing canceller binding",
+			mutate: func(state MCMSWithTimelockContracts) MCMSWithTimelockContracts {
+				state.CancellerMcm = nil
+				return state
+			},
+			wantErr: ErrMissingCancellerMCM,
+		},
+		{
+			name: "missing proposer binding",
+			mutate: func(state MCMSWithTimelockContracts) MCMSWithTimelockContracts {
+				state.ProposerMcm = nil
+				return state
+			},
+			wantErr: ErrMissingProposerMCM,
+		},
+		{
+			name: "missing bypasser binding",
+			mutate: func(state MCMSWithTimelockContracts) MCMSWithTimelockContracts {
+				state.BypasserMcm = nil
+				return state
+			},
+			wantErr: ErrMissingBypasserMCM,
+		},
+		{
+			name: "missing call proxy binding",
+			mutate: func(state MCMSWithTimelockContracts) MCMSWithTimelockContracts {
+				state.CallProxy = nil
+				return state
+			},
+			wantErr: ErrMissingCallProxy,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := tt.mutate(validContractsState())
+			err := state.Validate()
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func validContractsState() MCMSWithTimelockContracts {
+	return MCMSWithTimelockContracts{
+		CancellerMcm: new(ownerhelpers.ManyChainMultiSig),
+		BypasserMcm:  new(ownerhelpers.ManyChainMultiSig),
+		ProposerMcm:  new(ownerhelpers.ManyChainMultiSig),
+		Timelock:     new(ownerhelpers.RBACTimelock),
+		CallProxy:    new(ownerhelpers.CallProxy),
+	}
+}


### PR DESCRIPTION
Moving code from  https://github.com/smartcontractkit/chainlink/blob/af845d2e76ccb63baf8ceb0544c0f1ba8d7c6029/deployment/common/proposalutils/mcms_helpers.go#L28-L55  into CLDF

## AI Summary
This pull request introduces a new utility to the `proposalutils` package, providing a struct to group related contract bindings and a validation method to ensure all required contracts are present.

Contract binding utilities:

* Added the `MCMSWithTimelockContracts` struct to encapsulate references to multiple contract bindings (`ManyChainMultiSig`, `RBACTimelock`, `CallProxy`) for easier management and access.
* Implemented a `Validate` method on `MCMSWithTimelockContracts` that checks all fields are non-nil, returning descriptive errors if any required contract binding is missing.