### PR TITLE
chore: bump CTF framework to fix Sui/Aptos cwd tar race

### DIFF
--- a/.changeset/fix-sui-aptos-cwd-tar-race.md
+++ b/.changeset/fix-sui-aptos-cwd-tar-race.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+Bump chainlink-testing-framework/framework to pick up the Sui/Aptos CTF provider cwd-tar-race fix (upstream smartcontractkit/chainlink-testing-framework#2519). Resolves intermittent `archive/tar: write too long` flakes in `Test_CTFChainProvider_Initialize` for the Sui and Aptos providers.

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.18.0
 	github.com/smartcontractkit/chainlink-protos/op-catalog v0.0.4
-	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.13
+	github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.16
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5
 	github.com/smartcontractkit/chainlink-ton v0.0.0-20260219201907-054376f21418
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335

--- a/go.sum
+++ b/go.sum
@@ -771,8 +771,8 @@ github.com/smartcontractkit/chainlink-protos/op-catalog v0.0.4 h1:AEnxv4HM3WD1Rb
 github.com/smartcontractkit/chainlink-protos/op-catalog v0.0.4/go.mod h1:PjZD54vr6rIKEKQj6HNA4hllvYI/QpT+Zefj3tqkFAs=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260205175622-33e65031f9a9 h1:KyPROV+v7P8VdiU7JhVuGLcDlEBsURSpQmSCgNBTY+s=
 github.com/smartcontractkit/chainlink-sui v0.0.0-20260205175622-33e65031f9a9/go.mod h1:KpEWZJMLwbdMHeHQz9rbkES0vRrx4nk6OQXyhlHb9/8=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.13 h1:quHuZ/2I7XZ8pdRw5UAwKW/idsPchHN7KnQ69YWzxS4=
-github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.13/go.mod h1:BALK9cj8sk12e15UF6uDhifHgIApa+6N11TcQfInEro=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.16 h1:pzrAgF6QFMQLS/kukXenLN87PCa48SEMlE7QvJxTOHs=
+github.com/smartcontractkit/chainlink-testing-framework/framework v0.15.16/go.mod h1:BALK9cj8sk12e15UF6uDhifHgIApa+6N11TcQfInEro=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5 h1:RwZXxdIAOyjp6cwc9Quxgr38k8r7ACz+Lxh9o/A6oH0=
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-ton v0.0.0-20260219201907-054376f21418 h1:7f92q/Tz/Ns+gjChmWg5mEonrYutZV33k/1x+Xxsb4I=


### PR DESCRIPTION
## Summary

Bumps `github.com/smartcontractkit/chainlink-testing-framework/framework` to `v0.15.16` to pick up the upstream Sui/Aptos CTF provider cwd-tar-race fix.

Upstream PR: smartcontractkit/chainlink-testing-framework#2519 (merged as `v0.15.16`).

## Root Cause

`chain/sui/provider/ctf_provider.go` and `chain/aptos/provider/ctf_provider.go` both build `blockchain.Input` with no `ContractsDir`. Upstream CTF's `newSui`/`newAptos` called `filepath.Abs(in.ContractsDir)` unconditionally — Go stdlib resolves `filepath.Abs("")` to the process cwd. That cwd was attached as a `testcontainers.ContainerFile`, tarring the host test working directory. Files being written concurrently (logs, db dumps) trip `archive/tar.ErrWriteTooLong` between `os.Stat` (header size) and `io.Copy` (body).

The `retry.Attempts(10)` wrapper in `startContainer` masks most occurrences. `Test_CTFChainProvider_Initialize` (which actually starts a container) hits this path in this repo's own CI.

## Fix

Module bump only — no source changes. Pins framework to `v0.15.16` (stable tag), which gates the `Files:` entry on `ContractsDir != ""`.

Changeset included: `.changeset/fix-sui-aptos-cwd-tar-race.md` (patch).

## Safety

- Callers passing a non-empty `ContractsDir`: identical behaviour.
- Callers passing empty (both Sui and Aptos providers in this repo): `req.Files` now nil. testcontainers-go's hook iterates `range files` — zero iterations on nil, no-op (verified upstream in `lifecycle.go:151`).
- Delta in `framework/components/blockchain/` from previous pin (`v0.15.13`) to `v0.15.16`: 1 unrelated commit (`#2517 update sui version`) + the 2 fix commits. Minimal transitive risk.

## Test plan

- [x] `go build ./...` clean
- [x] `go mod tidy` clean
- [x] CI green — 22 checks pass, 2 skipped, 0 failing
