### PR TITLE
[CLD-1980]: ci: setup release pipeline for operations-gen

### DIFF
--- a/.github/workflows/push-tag-release-operations-gen.yml
+++ b/.github/workflows/push-tag-release-operations-gen.yml
@@ -1,0 +1,27 @@
+name: push-tag-release-operations-gen
+
+on:
+  push:
+    tags:
+      - tools/operations-gen/v*
+
+jobs:
+  cicd-publish-release-operations-gen:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
+    steps:
+      - name: cicd-publish-release-operations-gen
+        uses: smartcontractkit/.github/actions/cicd-build-publish-artifacts-go@b4737861584f88fa9569d6978f70fedf8b1ae67c # cicd-build-publish-artifacts-go@0.4.0
+        with:
+          # general inputs
+          app-name: operations-gen
+          publish: "false" # do not publish docker image to ECR
+          update-git-tag: "false"
+          # goreleaser inputs
+          goreleaser-args: "--config tools/operations-gen/.goreleaser.yml"
+          goreleaser-version: '~> v2'
+          goreleaser-dist: goreleaser-pro
+          goreleaser-key: ${{ secrets.GORELEASER_KEY }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,4 +16,7 @@ After every PR with a changeset is merged, a changesets CI job will create or up
 
 1. Approve or request approval to merge the "Version Packages" PR.
 2. Merge the "Version Packages" PR.
-3. This will trigger the release workflow, automatically releasing a new version and pushing a tag for the version. Check the [release view](https://github.com/smartcontractkit/chainlink-deployments-framework/releases) to confirm the latest release.
+3. This will trigger the release workflow, automatically releasing new versions and pushing tags.
+4. Root framework releases use `vX.Y.Z` tags.
+5. When the `operations-gen` package version is changed, CI also creates `tools/operations-gen/vX.Y.Z` and triggers the operations-gen binary release workflow.
+6. Check the [release view](https://github.com/smartcontractkit/chainlink-deployments-framework/releases) to confirm the latest root and operations-gen releases.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -64,6 +64,12 @@ This will prompt you to:
 2. Choose the type of change (patch, minor, major)
 3. Write a summary of the changes
 
+Package selection guidance:
+
+- Select `chainlink-deployments-framework` for framework/library changes.
+- Select `operations-gen` for changes under `tools/operations-gen` that affect the CLI behavior, generated output, or user-facing contract generation API.
+- Select both packages when a change impacts both release streams.
+
 ### 2. Changeset File Structure
 
 Changesets are stored as markdown files in the `.changeset` directory (managed automatically):
@@ -71,6 +77,7 @@ Changesets are stored as markdown files in the `.changeset` directory (managed a
 ```markdown
 ---
 "chainlink-deployments-framework": major
+"operations-gen": minor
 ---
 
 feat: support feature A
@@ -237,3 +244,5 @@ balance, err := provider.GetBalance(ctx, 1, "0x123...")  // 1 = Ethereum mainnet
 | Rename public struct field | MAJOR        | `OldName` → `NewName`                  |
 | Update documentation       | PATCH        | README, code comments                  |
 | Internal refactoring       | PATCH        | Private function changes               |
+
+For operations generator releases, CI will create/push module tags in the format `tools/operations-gen/vX.Y.Z` when the `operations-gen` package version changes.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A deployment framework for chainlink-deployments ",
   "private": true,
   "scripts": {
-    "ci:changeset:publish": "pnpm changeset publish",
+    "ci:changeset:publish": "node ./scripts/release/tag-releases.mjs",
     "ci:changeset:version": "pnpm changeset version && pnpm version --patch"
   },
   "author": "@smartcontractkit",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "."
+  - "tools/operations-gen"

--- a/scripts/release/tag-releases.mjs
+++ b/scripts/release/tag-releases.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const dryRun = process.argv.includes("--dry-run");
+const rootPackageJSONPath = resolve(repoRoot, "package.json");
+const operationsGenPackageJSONPath = resolve(repoRoot, "tools/operations-gen/package.json");
+const rootPackageJSON = JSON.parse(readFileSync(rootPackageJSONPath, "utf8"));
+const operationsGenPackageJSON = JSON.parse(readFileSync(operationsGenPackageJSONPath, "utf8"));
+const rootVersion = rootPackageJSON.version;
+const operationsGenVersion = operationsGenPackageJSON.version;
+
+const SEMVER_RE = /^\d+\.\d+\.\d+(-[\w.]+)?(\+[\w.]+)?$/;
+
+function validateSemver(version, source) {
+  if (!version) {
+    throw new Error(`Missing version in ${source}`);
+  }
+  if (!SEMVER_RE.test(version)) {
+    throw new Error(`Invalid semver "${version}" in ${source}`);
+  }
+}
+
+validateSemver(rootVersion, rootPackageJSONPath);
+validateSemver(operationsGenVersion, operationsGenPackageJSONPath);
+
+const tagsToCreate = [`v${rootVersion}`, `tools/operations-gen/v${operationsGenVersion}`];
+
+function git(...args) {
+  return execFileSync("git", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+try {
+  git("fetch", "--tags", "--quiet");
+} catch (err) {
+  console.warn(`Warning: unable to refresh tags: ${err.message}`);
+}
+
+for (const tag of tagsToCreate) {
+  // Remote is authoritative: check origin first so a locally-created-but-unpushed
+  // tag does not cause us to silently skip the push.
+  let existsOnRemote = false;
+  try {
+    const remoteTag = git("ls-remote", "--tags", "origin", `refs/tags/${tag}`);
+    existsOnRemote = !!remoteTag;
+  } catch (err) {
+    if (dryRun) {
+      console.warn(`[dry-run] Unable to verify remote tag ${tag}: ${err.message}`);
+      console.log(`[dry-run] Would create and push ${tag}`);
+      continue;
+    }
+    throw new Error(`Failed checking remote tag ${tag}: ${err.message}`);
+  }
+
+  if (existsOnRemote) {
+    console.log(`Tag ${tag} already exists on origin; skipping.`);
+    continue;
+  }
+
+  if (dryRun) {
+    console.log(`[dry-run] Would create and push ${tag}`);
+    continue;
+  }
+
+  // Force-create the local tag at HEAD so a stale local tag with the same
+  // name cannot accidentally be pushed to origin.
+  git("tag", "-f", tag);
+  git("push", "origin", `refs/tags/${tag}`);
+  console.log(`Created and pushed ${tag}`);
+}

--- a/tools/operations-gen/.goreleaser.yml
+++ b/tools/operations-gen/.goreleaser.yml
@@ -1,0 +1,42 @@
+version: 2
+project_name: operations-gen
+
+monorepo:
+  tag_prefix: tools/operations-gen/
+
+builds:
+  - id: operations-gen
+    main: .
+    dir: tools/operations-gen
+    binary: operations-gen
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X main.version={{ .Version }} -X main.commit={{ .Commit }} -X main.date={{ .Date }}
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+release:
+  github:
+    owner: smartcontractkit
+    name: chainlink-deployments-framework
+  prerelease: auto
+  footer: |
+    Check out the official changelog [here](https://github.com/smartcontractkit/chainlink-deployments-framework/blob/main/tools/operations-gen/CHANGELOG.md)
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  disable: true

--- a/tools/operations-gen/README.md
+++ b/tools/operations-gen/README.md
@@ -10,6 +10,28 @@ go run ./tools/operations-gen -config /path/to/operations_gen_config.yaml
 
 The `-config` path can be absolute or relative to the current working directory.
 
+Print the CLI release metadata:
+
+```bash
+go run ./tools/operations-gen -version
+```
+
+## Install a released version
+
+This module is released with Go module subdirectory tags in the form `tools/operations-gen/vX.Y.Z`.
+
+Install a specific released version:
+
+```bash
+go install github.com/smartcontractkit/chainlink-deployments-framework/tools/operations-gen@vX.Y.Z
+```
+
+Download prebuilt release binaries and checksums from the GitHub Releases page:
+
+```text
+https://github.com/smartcontractkit/chainlink-deployments-framework/releases
+```
+
 ## Project structure
 
 ```text
@@ -62,24 +84,24 @@ contracts:
 
 ### Top-level fields
 
-| Field              | Required | Description                                                                                   |
-| ------------------ | -------- | --------------------------------------------------------------------------------------------- |
-| `version`          | Yes      | Config schema version                                                                         |
-| `chain_family`     | No       | Target chain family. Only `"evm"` is supported. Defaults to `"evm"`.                          |
-| `input.abi_base_path` | Yes   | Directory containing versioned ABI files. Relative to the config file.                            |
-| `input.bytecode_base_path` | Yes | Directory containing versioned bytecode files. Relative to the config file.                  |
-| `output.base_path` | Yes      | Root directory where generated files are written. Relative to the config file.                    |
+| Field                      | Required | Description                                                                    |
+| -------------------------- | -------- | ------------------------------------------------------------------------------ |
+| `version`                  | Yes      | Config schema version                                                          |
+| `chain_family`             | No       | Target chain family. Only `"evm"` is supported. Defaults to `"evm"`.           |
+| `input.abi_base_path`      | Yes      | Directory containing versioned ABI files. Relative to the config file.         |
+| `input.bytecode_base_path` | Yes      | Directory containing versioned bytecode files. Relative to the config file.    |
+| `output.base_path`         | Yes      | Root directory where generated files are written. Relative to the config file. |
 
 ### Contract fields
 
-| Field           | Required | Description                                                                                                      |
-| --------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
-| `contract_name` | Yes      | Contract name as it appears in the ABI (e.g. `FeeQuoter`)                                                        |
-| `version`       | Yes      | Semver version of the contract (e.g. `"1.6.0"`)                                                                  |
-| `package_name`  | No       | Override the generated Go package name. Defaults to `snake_case(contract_name)`.                                 |
-| `abi_file`      | No       | Override the ABI filename. Defaults to `{package_name}.json`.                                                    |
-| `version_path`  | No       | Override the directory path derived from the version. Defaults to `v{major}_{minor}_{patch}`.                    |
-| `omit_deploy`   | No       | Skip generation of the `Deploy` operation and bytecode constant. Defaults to `false`.                          |
+| Field           | Required | Description                                                                                   |
+| --------------- | -------- | --------------------------------------------------------------------------------------------- |
+| `contract_name` | Yes      | Contract name as it appears in the ABI (e.g. `FeeQuoter`)                                     |
+| `version`       | Yes      | Semver version of the contract (e.g. `"1.6.0"`)                                               |
+| `package_name`  | No       | Override the generated Go package name. Defaults to `snake_case(contract_name)`.              |
+| `abi_file`      | No       | Override the ABI filename. Defaults to `{package_name}.json`.                                 |
+| `version_path`  | No       | Override the directory path derived from the version. Defaults to `v{major}_{minor}_{patch}`. |
+| `omit_deploy`   | No       | Skip generation of the `Deploy` operation and bytecode constant. Defaults to `false`.         |
 
 ### Function access control
 

--- a/tools/operations-gen/main.go
+++ b/tools/operations-gen/main.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -19,25 +20,49 @@ import (
 //go:embed templates
 var templatesFS embed.FS
 
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 // chainFamilies is the single registration point for all supported chain families.
 var chainFamilies = map[string]core.ChainFamilyHandler{
 	"evm": evm.Handler{},
 }
 
 func main() {
-	configPath := flag.String("config", "operations_gen_config.yaml", "Path to config file")
-	flag.Parse()
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run is the testable entrypoint. It uses a dedicated FlagSet so it can be
+// called multiple times (e.g. in tests) without conflicting with the global
+// flag.CommandLine that the testing harness parses before any test runs.
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("operations-gen", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	configPath := fs.String("config", "operations_gen_config.yaml", "Path to config file")
+	showVersion := fs.Bool("version", false, "Print version information and exit")
+
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	if *showVersion {
+		fmt.Fprintf(stdout, "operations-gen version=%s commit=%s date=%s\n", version, commit, date)
+		return 0
+	}
 
 	configData, err := os.ReadFile(*configPath)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading config: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error reading config: %v\n", err)
+		return 1
 	}
 
 	var config core.Config
 	if err = yaml.Unmarshal(configData, &config); err != nil {
-		fmt.Fprintf(os.Stderr, "Error parsing config: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error parsing config: %v\n", err)
+		return 1
 	}
 
 	chainFamily := config.ChainFamily
@@ -47,30 +72,33 @@ func main() {
 
 	handler, ok := chainFamilies[chainFamily]
 	if !ok {
-		fmt.Fprintf(os.Stderr, "Unsupported chain_family %q (supported: %s)\n",
+		fmt.Fprintf(stderr, "Unsupported chain_family %q (supported: %s)\n",
 			chainFamily, supportedFamilies())
-		os.Exit(1)
+
+		return 1
 	}
 
 	tmpl, err := loadTemplate(chainFamily)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error loading template for chain family %q: %v\n", chainFamily, err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error loading template for chain family %q: %v\n", chainFamily, err)
+		return 1
 	}
 
 	configDir := filepath.Dir(*configPath)
 	absConfigDir, err := filepath.Abs(configDir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error resolving config directory: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error resolving config directory: %v\n", err)
+		return 1
 	}
 
 	config.ConfigDir = absConfigDir
 
 	if err := handler.Generate(config, tmpl); err != nil {
-		fmt.Fprintf(os.Stderr, "Error generating operations: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error generating operations: %v\n", err)
+		return 1
 	}
+
+	return 0
 }
 
 // loadTemplate loads the code generation template for the given chain family.

--- a/tools/operations-gen/main_test.go
+++ b/tools/operations-gen/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -11,5 +13,29 @@ func TestLoadTemplate_UnknownFamily(t *testing.T) {
 	_, err := loadTemplate("solana")
 	if err == nil {
 		t.Error("expected error for unsupported chain family, got nil")
+	}
+}
+
+// TestVersionFlag verifies that the -version flag prints version metadata to
+// stdout and returns exit code 0 without requiring a config file.
+func TestVersionFlag(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	exitCode := run([]string{"-version"}, &stdout, &stderr)
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d; stderr: %s", exitCode, stderr.String())
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"version=" + version,
+		"commit=" + commit,
+		"date=" + date,
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("-version output missing %q; got: %s", want, output)
+		}
 	}
 }

--- a/tools/operations-gen/package.json
+++ b/tools/operations-gen/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "operations-gen",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Changesets metadata package for tools/operations-gen Go module"
+}


### PR DESCRIPTION
Setup changeset config and go releaser config

Similar to [chainlink-protos here](https://github.com/smartcontractkit/chainlink-protos/blob/main/package.json#L5), i have to override the `ci:changeset:publish` command with custom script. This is because changeset by default does not understand the tagging semantic for go.

Per the [go mod docs](https://go.dev/ref/mod#vcs-version), 

> If a module is defined in a subdirectory within the repository, that is, the [module subdirectory](https://go.dev/ref/mod#glos-module-subdirectory) portion of the module path is not empty, then each tag name must be prefixed with the module subdirectory, followed by a slash. For example, the module golang.org/x/tools/gopls is defined in the gopls subdirectory of the repository with root path golang.org/x/tools. The version v0.4.0 of that module must have the tag named gopls/v0.4.0 in that repository.

the tag has to be the format `<path-to-gomod>/v0.4.0`. eg instead of `operations-gen@0.4.0` , we want `tools/operations-gen/v0.4.0`. This means we have to perform tagging ourselves

JIRA:  https://smartcontract-it.atlassian.net/browse/CLD-1980