### PR TITLE
fix(blockscout-explorer): add raw response on error

### DIFF
--- a/.changeset/thirty-actors-add.md
+++ b/.changeset/thirty-actors-add.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix: blockscout should show raw error on contract verification

--- a/engine/cld/verification/evm/blockscout_verifier.go
+++ b/engine/cld/verification/evm/blockscout_verifier.go
@@ -9,20 +9,13 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/verification"
 	"github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger"
 )
-
-type blockscoutVerifyRequest struct {
-	AddressHash      string `json:"addressHash"`
-	CompilerVersion  string `json:"compilerVersion"`
-	ContractSource   string `json:"contractSourceCode"`
-	Name             string `json:"name"`
-	OptimizationUsed bool   `json:"optimization"`
-}
 
 func newBlockscoutVerifier(cfg VerifierConfig) (verification.Verifiable, error) {
 	apiURL := strings.TrimSpace(cfg.Network.BlockExplorer.URL)
@@ -37,6 +30,7 @@ func newBlockscoutVerifier(cfg VerifierConfig) (verification.Verifiable, error) 
 		metadata:     cfg.Metadata,
 		contractType: cfg.ContractType,
 		version:      cfg.Version,
+		pollInterval: cfg.PollInterval,
 		lggr:         cfg.Logger,
 		httpClient:   cfg.HTTPClient,
 	}, nil
@@ -49,6 +43,7 @@ type blockscoutVerifier struct {
 	metadata     SolidityContractMetadata
 	contractType string
 	version      string
+	pollInterval time.Duration
 	lggr         logger.Logger
 	httpClient   *http.Client
 }
@@ -129,39 +124,50 @@ func (v *blockscoutVerifier) Verify(ctx context.Context) error {
 		v.lggr.Infof("%s is already verified", v.String())
 		return nil
 	}
+
+	constructorArgs, err := v.getConstructorArgs(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get constructor args: %w", err)
+	}
+
 	sourceCode, err := v.metadata.SourceCode()
 	if err != nil {
 		return fmt.Errorf("failed to get source code: %w", err)
 	}
-	name := v.metadata.Name
-	if name == "" {
-		name = v.contractType
+	contractName := v.metadata.Name
+	if contractName == "" {
+		contractName = v.contractType
 	}
-	verifyReq := blockscoutVerifyRequest{
-		AddressHash:      v.address,
-		CompilerVersion:  v.metadata.Version,
-		ContractSource:   sourceCode,
-		Name:             name,
-		OptimizationUsed: true,
-	}
+
+	// Use Etherscan-compatible verifysourcecode with standard JSON input. The legacy
+	// action=verify JSON body treats contractSourceCode as a single .sol file, so
+	// Standard-JSON from SourceCode() was compiled as Solidity and failed with a parse error.
 	u, err := v.apiBase()
 	if err != nil {
 		return fmt.Errorf("invalid API URL: %w", err)
 	}
 	q := u.Query()
 	q.Set("module", "contract")
-	q.Set("action", "verify")
+	q.Set("action", "verifysourcecode")
 	u.RawQuery = q.Encode()
+	verifyURL := u.String()
 
-	jsonData, err := json.Marshal(verifyReq)
+	form := url.Values{}
+	form.Set("contractaddress", v.address)
+	form.Set("sourceCode", sourceCode)
+	form.Set("codeformat", "solidity-standard-json-input")
+	form.Set("contractname", contractName)
+	form.Set("compilerversion", v.metadata.Version)
+	form.Set("constructorArguments", constructorArgs)
+
+	v.lggr.Infof("Blockscout verifysourcecode submit: address=%s contractname=%q compilerversion=%q codeformat=solidity-standard-json-input constructorArgs_hex_len=%d metadata_name=%q",
+		v.address, contractName, v.metadata.Version, len(constructorArgs), v.metadata.Name)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, verifyURL, strings.NewReader(form.Encode()))
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(jsonData))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	client := v.httpClient
 	if client == nil {
 		client = http.DefaultClient
@@ -171,11 +177,179 @@ func (v *blockscoutVerifier) Verify(ctx context.Context) error {
 		return err
 	}
 	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read verify response: %w", err)
+	}
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("http error - status=%d body=%s", resp.StatusCode, string(body))
 	}
-	v.lggr.Infof("Verification submitted successfully for contract %s", v.address)
 
-	return nil
+	var submitResp etherscanAPIResponse[string]
+	if err := json.Unmarshal(body, &submitResp); err != nil {
+		snippet := string(body)
+		if len(snippet) > 512 {
+			snippet = snippet[:512] + "..."
+		}
+
+		return fmt.Errorf("decode verifysourcecode response: %w (body=%s)", err, snippet)
+	}
+	if submitResp.Status != statusOK || !strings.EqualFold(submitResp.Message, messageOK) {
+		msg := submitResp.Message
+		if msg == "" {
+			msg = submitResp.Result
+		}
+		if msg == "" {
+			msg = string(bytes.TrimSpace(body))
+		}
+
+		return fmt.Errorf("blockscout verifysourcecode rejected: status=%s message=%s: %s", submitResp.Status, submitResp.Message, msg)
+	}
+
+	guid := submitResp.Result
+	// Async verification: poll with guid (same flow as Etherscan-compatible APIs).
+	pollDur := v.effectivePollInterval()
+	for range maxVerificationPollAttempts {
+		statusResp, rawCheckBody, err := v.blockscoutCheckVerifyStatus(ctx, guid)
+		if err != nil {
+			return fmt.Errorf("check verification status: %w", err)
+		}
+		resultLower := strings.ToLower(statusResp.Result)
+		if statusResp.Status == statusOK && strings.Contains(resultLower, "pass") {
+			v.lggr.Infof("Verification submitted successfully for contract %s", v.address)
+			return nil
+		}
+		if strings.Contains(resultLower, "fail") {
+			msg := strings.TrimSpace(statusResp.Message)
+			// Many Blockscout instances return status=1 and message=OK even when result begins with
+			// "Fail - …"; compiler details are often not in this JSON. Log full body for debugging.
+			v.lggr.Warnf("Blockscout checkverifystatus (failure): full JSON: %s", truncateForLog(string(rawCheckBody), 6000))
+			hint := ""
+			if statusResp.Status == statusOK && strings.EqualFold(msg, messageOK) {
+				hint = " (this explorer uses status=1/message=OK even on verification failure; details are usually not in the API — check explorer UI or contractname/metadata vs on-chain bytecode)"
+			}
+
+			return fmt.Errorf("blockscout verification failed: result=%q message=%q api_status=%s%s; submitted contractname=%q compilerversion=%q constructorArgs_hex_len=%d; raw_checkverifystatus=%s",
+				statusResp.Result, msg, statusResp.Status, hint,
+				contractName, v.metadata.Version, len(constructorArgs), truncateForLog(string(rawCheckBody), 2000))
+		}
+		v.lggr.Infof("Verification status — %s, checking again in %s", statusResp.Result, pollDur)
+		select {
+		case <-time.After(pollDur):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return fmt.Errorf("blockscout verification timed out after %d attempts", maxVerificationPollAttempts)
+}
+
+func (v *blockscoutVerifier) effectivePollInterval() time.Duration {
+	d := v.pollInterval
+	if d <= 0 {
+		d = 5 * time.Second
+	}
+
+	return d
+}
+
+// blockscoutCheckVerifyStatus calls module=contract&action=checkverifystatus (Etherscan-compatible).
+// rawBody is the exact JSON bytes (for logging when the parsed fields are unhelpful).
+func (v *blockscoutVerifier) blockscoutCheckVerifyStatus(ctx context.Context, guid string) (etherscanAPIResponse[string], []byte, error) {
+	u, err := v.apiBase()
+	if err != nil {
+		return etherscanAPIResponse[string]{}, nil, err
+	}
+	q := u.Query()
+	q.Set("module", "contract")
+	q.Set("action", "checkverifystatus")
+	q.Set("guid", guid)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return etherscanAPIResponse[string]{}, nil, err
+	}
+	client := v.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return etherscanAPIResponse[string]{}, nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return etherscanAPIResponse[string]{}, nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return etherscanAPIResponse[string]{}, body, fmt.Errorf("http error - status=%d body=%s", resp.StatusCode, string(body))
+	}
+	var apiResp etherscanAPIResponse[string]
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return etherscanAPIResponse[string]{}, body, fmt.Errorf("decode checkverifystatus: %w", err)
+	}
+
+	return apiResp, body, nil
+}
+
+func truncateForLog(s string, maxLen int) string {
+	if maxLen <= 0 || len(s) <= maxLen {
+		return s
+	}
+
+	return s[:maxLen] + "…(truncated)"
+}
+
+// getConstructorArgs mirrors Etherscan logic: extract constructor suffix from the contract-creation tx.
+func (v *blockscoutVerifier) getConstructorArgs(ctx context.Context) (string, error) {
+	u, err := v.apiBase()
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set("module", "account")
+	q.Set("action", "txlist")
+	q.Set("address", v.address)
+	q.Set("page", "1")
+	q.Set("offset", "1")
+	q.Set("sort", "asc")
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	client := v.httpClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	var apiResp etherscanAPIResponse[[]transactionInfo]
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return "", fmt.Errorf("decode txlist: %w", err)
+	}
+	if apiResp.Status != statusOK {
+		return "", fmt.Errorf("txlist API error: status=%s message=%s", apiResp.Status, apiResp.Message)
+	}
+	if len(apiResp.Result) != 1 {
+		return "", fmt.Errorf("expected 1 contract creation tx, got %d", len(apiResp.Result))
+	}
+	tx := apiResp.Result[0]
+	bytecode := strings.TrimPrefix(v.metadata.Bytecode, "0x")
+	txInput := strings.TrimPrefix(tx.Input, "0x")
+	if !strings.HasPrefix(txInput, bytecode) {
+		return "", nil
+	}
+
+	return txInput[len(bytecode):], nil
 }

--- a/engine/cld/verification/evm/blockscout_verifier_test.go
+++ b/engine/cld/verification/evm/blockscout_verifier_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
@@ -142,4 +144,486 @@ func TestBlockscoutVerifier_String(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "MyContract 2.0.0 (0xabc on zora-mainnet)", v.String())
+}
+
+func TestBlockscoutVerifier_Verify_HTTP200WithStatusZero_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		action := r.URL.Query().Get("action")
+		switch {
+		case r.Method == http.MethodGet && action == "getabi":
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "0", "result": ""})
+		case r.Method == http.MethodGet && action == "txlist":
+			// One creation tx; bytecode prefix mismatch → empty constructor args
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "1", "message": "OK",
+				"result": []map[string]string{{"input": "0xbbbb"}},
+			})
+		case r.Method == http.MethodPost && action == "verifysourcecode":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"status": "0", "message": "NOTOK", "result": "Compilation error",
+			})
+		default:
+			http.Error(w, "unexpected request "+r.Method+" action="+action, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	chain, ok := chainsel.ChainBySelector(chainsel.ZORA_MAINNET.Selector)
+	require.True(t, ok)
+
+	v, err := newBlockscoutVerifier(VerifierConfig{
+		Chain:   chain,
+		Network: cfgnet.Network{ChainSelector: chain.Selector, BlockExplorer: cfgnet.BlockExplorer{URL: server.URL}},
+		Address: "0x1234567890123456789012345678901234567890",
+		Metadata: SolidityContractMetadata{
+			Name:     "Test",
+			Version:  "0.8.19",
+			Language: "Solidity",
+			Settings: map[string]any{},
+			Sources:  map[string]any{"Test.sol": map[string]any{"content": "contract Test {}"}},
+			Bytecode: "0xaaaa",
+		},
+		ContractType: "Test",
+		Version:      "1.0.0",
+		Logger:       logger.Nop(),
+		HTTPClient:   server.Client(),
+	})
+	require.NoError(t, err)
+
+	err = v.(*blockscoutVerifier).Verify(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "blockscout verifysourcecode rejected")
+}
+
+func TestBlockscoutVerifier_Verify_StatusOne_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		action := r.URL.Query().Get("action")
+		switch {
+		case r.Method == http.MethodGet && action == "getabi":
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "0", "result": ""})
+		case r.Method == http.MethodGet && action == "txlist":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "1", "message": "OK",
+				"result": []map[string]string{{"input": "0xbbbb"}},
+			})
+		case r.Method == http.MethodPost && action == "verifysourcecode":
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "1", "message": "OK", "result": "abc-guid"})
+		case r.Method == http.MethodGet && action == "checkverifystatus":
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "1", "message": "OK", "result": "Pass - Verified"})
+		default:
+			http.Error(w, "unexpected request "+r.Method+" action="+action, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	chain, ok := chainsel.ChainBySelector(chainsel.ZORA_MAINNET.Selector)
+	require.True(t, ok)
+
+	v, err := newBlockscoutVerifier(VerifierConfig{
+		Chain:   chain,
+		Network: cfgnet.Network{ChainSelector: chain.Selector, BlockExplorer: cfgnet.BlockExplorer{URL: server.URL}},
+		Address: "0x1234567890123456789012345678901234567890",
+		Metadata: SolidityContractMetadata{
+			Name:     "Test",
+			Version:  "0.8.19",
+			Language: "Solidity",
+			Settings: map[string]any{},
+			Sources:  map[string]any{"Test.sol": map[string]any{"content": "contract Test {}"}},
+			Bytecode: "0xaaaa",
+		},
+		ContractType: "Test",
+		Version:      "1.0.0",
+		PollInterval: time.Nanosecond,
+		Logger:       logger.Nop(),
+		HTTPClient:   server.Client(),
+	})
+	require.NoError(t, err)
+
+	err = v.(*blockscoutVerifier).Verify(context.Background())
+	require.NoError(t, err)
+}
+
+func TestTruncateForLog(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "short", truncateForLog("short", 100))
+	require.Empty(t, truncateForLog("", 0))
+	long := strings.Repeat("x", 100)
+	out := truncateForLog(long, 10)
+	require.True(t, strings.HasPrefix(out, strings.Repeat("x", 10)))
+	require.Contains(t, out, "truncated")
+}
+
+func TestBlockscoutVerifier_Verify_AlreadyVerified_ShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	var txlistCalls, postCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		action := r.URL.Query().Get("action")
+		switch {
+		case r.Method == http.MethodGet && action == "getabi":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "1", "result": `[{"type":"function"}]`})
+		case r.Method == http.MethodGet && action == "txlist":
+			txlistCalls++
+			http.Error(w, "should not call txlist", http.StatusTeapot)
+		case r.Method == http.MethodPost && action == "verifysourcecode":
+			postCalls++
+			http.Error(w, "should not submit", http.StatusTeapot)
+		default:
+			http.Error(w, "unexpected", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	chain, ok := chainsel.ChainBySelector(chainsel.ZORA_MAINNET.Selector)
+	require.True(t, ok)
+
+	v, err := newBlockscoutVerifier(VerifierConfig{
+		Chain:   chain,
+		Network: cfgnet.Network{ChainSelector: chain.Selector, BlockExplorer: cfgnet.BlockExplorer{URL: server.URL}},
+		Address: "0x1234567890123456789012345678901234567890",
+		Metadata: SolidityContractMetadata{
+			Name:     "X",
+			Version:  "0.8.19",
+			Language: "Solidity",
+			Settings: map[string]any{},
+			Sources:  map[string]any{"X.sol": map[string]any{"content": "contract X {}"}},
+		},
+		ContractType: "X",
+		Version:      "1.0.0",
+		Logger:       logger.Nop(),
+		HTTPClient:   server.Client(),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, v.(*blockscoutVerifier).Verify(context.Background()))
+	require.Equal(t, 0, txlistCalls)
+	require.Equal(t, 0, postCalls)
+}
+
+func TestBlockscoutVerifier_Verify_FailCheckVerifyStatus_MessageOK(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		action := r.URL.Query().Get("action")
+		switch {
+		case r.Method == http.MethodGet && action == "getabi":
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "0", "result": ""})
+		case r.Method == http.MethodGet && action == "txlist":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "1", "message": "OK",
+				"result": []map[string]string{{"input": "0xbbbb"}},
+			})
+		case r.Method == http.MethodPost && action == "verifysourcecode":
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "1", "message": "OK", "result": "job-guid"})
+		case r.Method == http.MethodGet && action == "checkverifystatus":
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"status": "1", "message": "OK", "result": "Fail - Unable to verify",
+			})
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+action, http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	chain, ok := chainsel.ChainBySelector(chainsel.ZORA_MAINNET.Selector)
+	require.True(t, ok)
+
+	v, err := newBlockscoutVerifier(VerifierConfig{
+		Chain:   chain,
+		Network: cfgnet.Network{ChainSelector: chain.Selector, BlockExplorer: cfgnet.BlockExplorer{URL: server.URL}},
+		Address: "0x1234567890123456789012345678901234567890",
+		Metadata: SolidityContractMetadata{
+			Name:     "contracts/Foo.sol:Foo",
+			Version:  "0.8.19",
+			Language: "Solidity",
+			Settings: map[string]any{},
+			Sources:  map[string]any{"Foo.sol": map[string]any{"content": "contract Foo {}"}},
+			Bytecode: "0xaaaa",
+		},
+		ContractType: "Foo",
+		Version:      "1.0.0",
+		PollInterval: time.Nanosecond,
+		Logger:       logger.Nop(),
+		HTTPClient:   server.Client(),
+	})
+	require.NoError(t, err)
+
+	err = v.(*blockscoutVerifier).Verify(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "blockscout verification failed")
+	require.Contains(t, err.Error(), "explorer uses status=1/message=OK")
+	require.Contains(t, err.Error(), `contractname="contracts/Foo.sol:Foo"`)
+}
+
+func TestBlockscoutVerifier_Verify_PendingThenTimeout(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		action := r.URL.Query().Get("action")
+		switch {
+		case r.Method == http.MethodGet && action == "getabi":
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "0", "result": ""})
+		case r.Method == http.MethodGet && action == "txlist":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "1", "message": "OK",
+				"result": []map[string]string{{"input": "0xbbbb"}},
+			})
+		case r.Method == http.MethodPost && action == "verifysourcecode":
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "1", "message": "OK", "result": "g"})
+		case r.Method == http.MethodGet && action == "checkverifystatus":
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "1", "message": "OK", "result": "Pending in queue"})
+		default:
+			http.Error(w, "unexpected", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	chain, ok := chainsel.ChainBySelector(chainsel.ZORA_MAINNET.Selector)
+	require.True(t, ok)
+
+	v, err := newBlockscoutVerifier(VerifierConfig{
+		Chain:   chain,
+		Network: cfgnet.Network{ChainSelector: chain.Selector, BlockExplorer: cfgnet.BlockExplorer{URL: server.URL}},
+		Address: "0x1234567890123456789012345678901234567890",
+		Metadata: SolidityContractMetadata{
+			Name:     "T",
+			Version:  "0.8.19",
+			Language: "Solidity",
+			Settings: map[string]any{},
+			Sources:  map[string]any{"T.sol": map[string]any{"content": "contract T {}"}},
+			Bytecode: "0xaaaa",
+		},
+		ContractType: "T",
+		Version:      "1.0.0",
+		PollInterval: time.Nanosecond,
+		Logger:       logger.Nop(),
+		HTTPClient:   server.Client(),
+	})
+	require.NoError(t, err)
+
+	err = v.(*blockscoutVerifier).Verify(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out after")
+}
+
+func TestBlockscoutVerifier_getConstructorArgs_MatchingBytecode(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "txlist", r.URL.Query().Get("action"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "1", "message": "OK",
+			"result": []map[string]string{{"input": "0xaabbccddeeff"}},
+		})
+	}))
+	defer server.Close()
+
+	chain, ok := chainsel.ChainBySelector(chainsel.ZORA_MAINNET.Selector)
+	require.True(t, ok)
+
+	v, err := newBlockscoutVerifier(VerifierConfig{
+		Chain:   chain,
+		Network: cfgnet.Network{ChainSelector: chain.Selector, BlockExplorer: cfgnet.BlockExplorer{URL: server.URL}},
+		Address: "0x1234567890123456789012345678901234567890",
+		Metadata: SolidityContractMetadata{
+			Bytecode: "0xaabbcc",
+		},
+		Logger:     logger.Nop(),
+		HTTPClient: server.Client(),
+	})
+	require.NoError(t, err)
+
+	args, err := v.(*blockscoutVerifier).getConstructorArgs(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "ddeeff", args)
+}
+
+func TestBlockscoutVerifier_getConstructorArgs_TxlistNotOK(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// result must decode as []transactionInfo; empty array keeps JSON shape valid.
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "0", "message": "NOTOK", "result": []any{}})
+	}))
+	defer server.Close()
+
+	chain, ok := chainsel.ChainBySelector(chainsel.ZORA_MAINNET.Selector)
+	require.True(t, ok)
+
+	v, err := newBlockscoutVerifier(VerifierConfig{
+		Chain:      chain,
+		Network:    cfgnet.Network{ChainSelector: chain.Selector, BlockExplorer: cfgnet.BlockExplorer{URL: server.URL}},
+		Address:    "0x1234567890123456789012345678901234567890",
+		Metadata:   SolidityContractMetadata{},
+		Logger:     logger.Nop(),
+		HTTPClient: server.Client(),
+	})
+	require.NoError(t, err)
+
+	_, err = v.(*blockscoutVerifier).getConstructorArgs(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "txlist API error")
+}
+
+func TestBlockscoutVerifier_Verify_SubmitDecodeError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		action := r.URL.Query().Get("action")
+		switch {
+		case r.Method == http.MethodGet && action == "getabi":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "0", "result": ""})
+		case r.Method == http.MethodGet && action == "txlist":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "1", "message": "OK",
+				"result": []map[string]string{{"input": "0xbbbb"}},
+			})
+		case r.Method == http.MethodPost && action == "verifysourcecode":
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = w.Write([]byte("not-json{"))
+		default:
+			http.Error(w, "unexpected", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	chain, ok := chainsel.ChainBySelector(chainsel.ZORA_MAINNET.Selector)
+	require.True(t, ok)
+
+	v, err := newBlockscoutVerifier(VerifierConfig{
+		Chain:   chain,
+		Network: cfgnet.Network{ChainSelector: chain.Selector, BlockExplorer: cfgnet.BlockExplorer{URL: server.URL}},
+		Address: "0x1234567890123456789012345678901234567890",
+		Metadata: SolidityContractMetadata{
+			Name: "N", Version: "0.8.19", Language: "Solidity",
+			Settings: map[string]any{}, Sources: map[string]any{"N.sol": map[string]any{"content": "contract N {}"}},
+			Bytecode: "0xaaaa",
+		},
+		ContractType: "N",
+		Logger:       logger.Nop(),
+		HTTPClient:   server.Client(),
+	})
+	require.NoError(t, err)
+
+	err = v.(*blockscoutVerifier).Verify(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decode verifysourcecode response")
+}
+
+func TestBlockscoutVerifier_Verify_SubmitHTTPError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		action := r.URL.Query().Get("action")
+		switch {
+		case r.Method == http.MethodGet && action == "getabi":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "0", "result": ""})
+		case r.Method == http.MethodGet && action == "txlist":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "1", "message": "OK",
+				"result": []map[string]string{{"input": "0xbbbb"}},
+			})
+		case r.Method == http.MethodPost && action == "verifysourcecode":
+			http.Error(w, "server error", http.StatusInternalServerError)
+		default:
+			http.Error(w, "unexpected", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	chain, ok := chainsel.ChainBySelector(chainsel.ZORA_MAINNET.Selector)
+	require.True(t, ok)
+
+	v, err := newBlockscoutVerifier(VerifierConfig{
+		Chain:   chain,
+		Network: cfgnet.Network{ChainSelector: chain.Selector, BlockExplorer: cfgnet.BlockExplorer{URL: server.URL}},
+		Address: "0x1234567890123456789012345678901234567890",
+		Metadata: SolidityContractMetadata{
+			Name:     "N",
+			Version:  "0.8.19",
+			Language: "Solidity",
+			Settings: map[string]any{},
+			Sources:  map[string]any{"N.sol": map[string]any{"content": "contract N {}"}},
+			Bytecode: "0xaaaa",
+		},
+		ContractType: "N",
+		Logger:       logger.Nop(),
+		HTTPClient:   server.Client(),
+	})
+	require.NoError(t, err)
+
+	err = v.(*blockscoutVerifier).Verify(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "http error")
+}
+
+func TestBlockscoutVerifier_Verify_UsesContractTypeWhenMetadataNameEmpty(t *testing.T) {
+	t.Parallel()
+
+	var sawContractName string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		action := r.URL.Query().Get("action")
+		switch {
+		case r.Method == http.MethodGet && action == "getabi":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "0", "result": ""})
+		case r.Method == http.MethodGet && action == "txlist":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "1", "message": "OK",
+				"result": []map[string]string{{"input": "0xbbbb"}},
+			})
+		case r.Method == http.MethodPost && action == "verifysourcecode":
+			assert.NoError(t, r.ParseForm())
+			sawContractName = r.FormValue("contractname")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "0", "message": "bad", "result": "x"})
+		default:
+			http.Error(w, "unexpected", http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+
+	chain, ok := chainsel.ChainBySelector(chainsel.ZORA_MAINNET.Selector)
+	require.True(t, ok)
+
+	v, err := newBlockscoutVerifier(VerifierConfig{
+		Chain:   chain,
+		Network: cfgnet.Network{ChainSelector: chain.Selector, BlockExplorer: cfgnet.BlockExplorer{URL: server.URL}},
+		Address: "0x1234567890123456789012345678901234567890",
+		Metadata: SolidityContractMetadata{
+			Name:     "",
+			Version:  "0.8.19",
+			Language: "Solidity",
+			Settings: map[string]any{},
+			Sources:  map[string]any{"P.sol": map[string]any{"content": "contract P {}"}},
+			Bytecode: "0xaaaa",
+		},
+		ContractType: "PoolType",
+		Version:      "1.0.0",
+		Logger:       logger.Nop(),
+		HTTPClient:   server.Client(),
+	})
+	require.NoError(t, err)
+
+	_ = v.(*blockscoutVerifier).Verify(context.Background())
+	require.Equal(t, "PoolType", sawContractName)
 }


### PR DESCRIPTION
Fix issue where blockscout returns error with 200 ok response which we assumed means verification is successful just because of http code. Now we get the raw error, provide more info and logging.