### PR TITLE
refactor(cld): remove archived changeset registry entries

### DIFF
--- a/.changeset/fuzzy-mangos-wear.md
+++ b/.changeset/fuzzy-mangos-wear.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+refactor(cld): remove archived changeset registry entries

--- a/engine/cld/changeset/registry.go
+++ b/engine/cld/changeset/registry.go
@@ -57,10 +57,6 @@ type registryEntry struct {
 	// changeset is the changeset that is registered.
 	changeset ChangeSet
 
-	// gitSHA is the git SHA of the buried changeset. This only applies to changesets that are
-	// buried.
-	gitSHA *string
-
 	// options contains the configuration options for this changeset
 	options ChangesetConfig
 
@@ -88,16 +84,6 @@ func newRegistryEntry(c ChangeSet, opts ChangesetConfig) registryEntry {
 	}
 
 	return entry
-}
-
-// newArchivedRegistryEntry creates a new registry entry for an archived changeset.
-func newArchivedRegistryEntry(gitSHA string) registryEntry {
-	return registryEntry{gitSHA: &gitSHA}
-}
-
-// IsArchived returns true if the changeset is archived.
-func (e registryEntry) IsArchived() bool {
-	return e.gitSHA != nil
 }
 
 // ChangesetsRegistry is a registry of changesets that can be applied to a domain environment.
@@ -324,10 +310,6 @@ func (r *ChangesetsRegistry) getApplyEntryLocked(key string) (registryEntry, err
 		return registryEntry{}, fmt.Errorf("changeset '%s' not found", key)
 	}
 
-	if entry.IsArchived() {
-		return registryEntry{}, fmt.Errorf("changeset '%s' is archived at SHA '%s'", key, *entry.gitSHA)
-	}
-
 	return entry, nil
 }
 
@@ -347,9 +329,6 @@ func (r *ChangesetsRegistry) GetResolvedInput(key string, input string) (any, er
 	entry, ok := r.entries[key]
 	if !ok {
 		return nil, fmt.Errorf("changeset '%s' not found", key)
-	}
-	if entry.IsArchived() {
-		return nil, fmt.Errorf("changeset '%s' is archived at SHA '%s'", key, *entry.gitSHA)
 	}
 
 	return entry.changeset.resolvedInput(input)
@@ -468,15 +447,6 @@ func extractIndexFromKey(key string) (int, error) {
 	}
 
 	return index, nil
-}
-
-// Archive buries a changeset in the registry.
-func (r *ChangesetsRegistry) Archive(key string, gitSHA string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	r.entries[key] = newArchivedRegistryEntry(gitSHA)
-	r.keyHistory = append(r.keyHistory, key)
 }
 
 // LatestKey returns the most recent changeset key.

--- a/engine/cld/changeset/registry_test.go
+++ b/engine/cld/changeset/registry_test.go
@@ -121,9 +121,6 @@ func Test_Changesets_Apply(t *testing.T) {
 	t.Parallel()
 
 	var (
-		archivedKey = "0001_archived_mig"
-		archivedSHA = "abcdef"
-
 		applyKey       = "0002_apply_mig"
 		applyChangeset = noopChangeset{}
 	)
@@ -144,11 +141,6 @@ func Test_Changesets_Apply(t *testing.T) {
 			giveKey: "0003_unregistered",
 			wantErr: "changeset '0003_unregistered' not found",
 		},
-		{
-			name:    "with an archived changeset",
-			giveKey: archivedKey,
-			wantErr: "changeset '0001_archived_mig' is archived at SHA 'abcdef'",
-		},
 	}
 
 	for _, tt := range tests {
@@ -158,7 +150,6 @@ func Test_Changesets_Apply(t *testing.T) {
 			r := NewChangesetsRegistry()
 
 			// Setup the registry.
-			r.Archive(archivedKey, archivedSHA)
 			r.Add(applyKey, applyChangeset)
 
 			got, err := r.Apply(tt.giveKey, fdeployment.Environment{})
@@ -264,18 +255,6 @@ func Test_Changesets_Add(t *testing.T) {
 	require.NotPanics(t, func() {
 		r.Add("0002_same_index", noopChangeset{})
 	}, "Add should not panic when validation is disabled")
-}
-
-func Test_Changesets_Archive(t *testing.T) {
-	t.Parallel()
-
-	r := NewChangesetsRegistry()
-
-	r.Archive("0001_cap_reg", "abcdef")
-	require.Equal(t, []string{"0001_cap_reg"}, r.keyHistory)
-
-	r.Archive("0002_cap_reg", "abcdef")
-	require.Equal(t, []string{"0001_cap_reg", "0002_cap_reg"}, r.keyHistory)
 }
 
 func Test_Changesets_ListKeys(t *testing.T) {


### PR DESCRIPTION
## Summary

This was something i missed when removing the Archive() in [my earlier PR](https://github.com/smartcontractkit/chainlink-deployments/pull/12320)
This change removes support for **archived** changeset entries in `ChangesetsRegistry`: the `gitSHA` tombstone field, `IsArchived()`, `Archive()`, and the error paths in `Apply` / `GetResolvedInput` that blocked archived keys. Tests that covered archiving were removed accordingly.

