### PR TITLE
chore: use remote chains selectors

### DIFF
--- a/.changeset/easy-waves-hunt.md
+++ b/.changeset/easy-waves-hunt.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+chore: use remote chains selectors

--- a/chain/evm/provider/ctf_anvil_provider.go
+++ b/chain/evm/provider/ctf_anvil_provider.go
@@ -217,7 +217,7 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/crypto"
-	chainsel "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors/remote"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/freeport"
@@ -384,10 +384,11 @@ func (p *CTFAnvilChainProvider) Initialize(ctx context.Context) (chain.BlockChai
 		return nil, fmt.Errorf("failed to validate config: %w", err)
 	}
 
-	chainID, err := chainsel.GetChainIDFromSelector(p.selector)
+	chainDetails, err := chainsel.GetChainDetailsBySelector(ctx, p.selector)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get chain id from selector: %w", err)
+		return nil, fmt.Errorf("failed to get chain details for selector: %w", err)
 	}
+	chainID := chainDetails.ChainID
 
 	httpURL, err := p.startContainer(ctx, chainID)
 	if err != nil {
@@ -400,7 +401,7 @@ func (p *CTFAnvilChainProvider) Initialize(ctx context.Context) (chain.BlockChai
 		return nil, fmt.Errorf("failed to create new logger: %w", err)
 	}
 
-	client, err := rpcclient.NewMultiClient(lggr, rpcclient.RPCConfig{
+	client, err := rpcclient.NewMultiClient(ctx, lggr, rpcclient.RPCConfig{
 		ChainSelector: p.selector,
 		RPCs: []rpcclient.RPC{
 			{

--- a/chain/evm/provider/ctf_geth_provider.go
+++ b/chain/evm/provider/ctf_geth_provider.go
@@ -222,7 +222,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	chainsel "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors/remote"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/freeport"
@@ -380,10 +380,11 @@ func (p *CTFGethChainProvider) Initialize(ctx context.Context) (chain.BlockChain
 		return nil, err
 	}
 
-	chainID, err := chainsel.GetChainIDFromSelector(p.selector)
+	chainDetails, err := chainsel.GetChainDetailsBySelector(ctx, p.selector)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get chain details for selector %d: %w", p.selector, err)
 	}
+	chainID := chainDetails.ChainID
 
 	httpURL, err := p.startContainer(ctx, chainID)
 	if err != nil {
@@ -396,7 +397,7 @@ func (p *CTFGethChainProvider) Initialize(ctx context.Context) (chain.BlockChain
 		return nil, err
 	}
 
-	client, err := rpcclient.NewMultiClient(lggr, rpcclient.RPCConfig{
+	client, err := rpcclient.NewMultiClient(ctx, lggr, rpcclient.RPCConfig{
 		ChainSelector: p.selector,
 		RPCs: []rpcclient.RPC{
 			{

--- a/chain/evm/provider/rpc_provider.go
+++ b/chain/evm/provider/rpc_provider.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	chainsel "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors/remote"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger"
 
@@ -97,10 +97,11 @@ func (p *RPCChainProvider) Initialize(ctx context.Context) (chain.BlockChain, er
 	}
 
 	// Get the Chain ID
-	chainIDStr, err := chainsel.GetChainIDFromSelector(p.selector)
+	chainDetails, err := chainsel.GetChainDetailsBySelector(ctx, p.selector)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get chain ID from selector %d: %w", p.selector, err)
+		return nil, fmt.Errorf("failed to get chain details for selector %d: %w", p.selector, err)
 	}
+	chainIDStr := chainDetails.ChainID
 
 	chainID, ok := new(big.Int).SetString(chainIDStr, 10)
 	if !ok {
@@ -125,7 +126,7 @@ func (p *RPCChainProvider) Initialize(ctx context.Context) (chain.BlockChain, er
 	}
 
 	// Setup the client.
-	client, err := rpcclient.NewMultiClient(p.config.Logger, rpcclient.RPCConfig{
+	client, err := rpcclient.NewMultiClient(ctx, p.config.Logger, rpcclient.RPCConfig{
 		ChainSelector: p.selector,
 		RPCs:          p.config.RPCs,
 	}, p.config.ClientOpts...)

--- a/chain/evm/provider/rpc_provider_test.go
+++ b/chain/evm/provider/rpc_provider_test.go
@@ -158,7 +158,7 @@ func Test_RPCChainProvider_Initialize(t *testing.T) {
 				RPCs:                  []rpcclient.RPC{rpc},
 				ConfirmFunctor:        gethConfirmFunc,
 			},
-			wantErr: "failed to get chain ID from selector",
+			wantErr: "failed to get chain details for selector 1",
 		},
 		{
 			name:         "fails to generate deployer transactor",

--- a/chain/evm/provider/rpcclient/multiclient.go
+++ b/chain/evm/provider/rpcclient/multiclient.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger"
 
-	chainsel "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors/remote"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 )
@@ -94,16 +94,18 @@ func (mc *MultiClient) rpcHealthCheck(ctx context.Context, client *ethclient.Cli
 }
 
 // NewMultiClient creates a new MultiClient with failover capabilities.
-func NewMultiClient(lggr logger.Logger, rpcsCfg RPCConfig, opts ...func(client *MultiClient)) (*MultiClient, error) {
+func NewMultiClient(
+	ctx context.Context, lggr logger.Logger, rpcsCfg RPCConfig, opts ...func(client *MultiClient),
+) (*MultiClient, error) {
 	if len(rpcsCfg.RPCs) == 0 {
 		return nil, errors.New("no RPCs provided, need at least one")
 	}
 	// Set the chain name
-	chain, exists := chainsel.ChainBySelector(rpcsCfg.ChainSelector)
-	if !exists {
-		return nil, fmt.Errorf("chain with selector %d not found", rpcsCfg.ChainSelector)
+	chain, err := chainsel.GetChainDetailsBySelector(ctx, rpcsCfg.ChainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chain details for %d: %w", rpcsCfg.ChainSelector, err)
 	}
-	mc := MultiClient{lggr: lggr, chainName: chain.Name}
+	mc := MultiClient{lggr: lggr, chainName: chain.ChainName}
 
 	mc.RetryConfig = defaultRetryConfig()
 
@@ -115,12 +117,12 @@ func NewMultiClient(lggr logger.Logger, rpcsCfg RPCConfig, opts ...func(client *
 	for i, rpc := range rpcsCfg.RPCs {
 		client, err := mc.dialWithRetry(rpc, lggr)
 		if err != nil {
-			lggr.Warnf("failed to dial client %d for RPC '%s' - %s (%d), trying with the next one: %v", i, rpc.Name, chain.Name, chain.Selector, err)
+			lggr.Warnf("failed to dial client %d for RPC '%s' - %s (%d), trying with the next one: %v", i, rpc.Name, chain.ChainName, chain.ChainSelector, err)
 
 			continue
 		}
-		if err := mc.rpcHealthCheck(context.Background(), client); err != nil {
-			lggr.Warnf("health check failed for client %d for RPC '%s' - %s (%d), trying with the next one: %v", i, rpc.Name, chain.Name, chain.Selector, err)
+		if err := mc.rpcHealthCheck(ctx, client); err != nil {
+			lggr.Warnf("health check failed for client %d for RPC '%s' - %s (%d), trying with the next one: %v", i, rpc.Name, chain.ChainName, chain.ChainSelector, err)
 			client.Close()
 
 			continue
@@ -457,7 +459,6 @@ func (mc *MultiClient) dialWithRetry(rpc RPC, lggr logger.Logger) (*ethclient.Cl
 		return nil
 	}, retry.Attempts(mc.RetryConfig.DialAttempts), retry.Delay(mc.RetryConfig.DialDelay),
 		retry.OnRetry(func(n uint, err error) { retryCount++ }))
-
 	if err != nil {
 		return nil, errors.Join(err, fmt.Errorf("failed to dial endpoint '%s' for RPC %s for chain %s after retries", endpoint, rpc.Name, mc.chainName))
 	}

--- a/chain/evm/provider/rpcclient/multiclient_test.go
+++ b/chain/evm/provider/rpcclient/multiclient_test.go
@@ -56,7 +56,7 @@ func TestMultiClient(t *testing.T) {
 	)
 
 	// Expect defaults to be set if not provided.
-	mc, err := NewMultiClient(lggr, RPCConfig{ChainSelector: chainSelector, RPCs: []RPC{
+	mc, err := NewMultiClient(t.Context(), lggr, RPCConfig{ChainSelector: chainSelector, RPCs: []RPC{
 		{Name: "test-rpc", WSURL: wsURL, HTTPURL: httpURL, PreferredURLScheme: URLSchemePreferenceHTTP},
 	}})
 
@@ -70,11 +70,11 @@ func TestMultiClient(t *testing.T) {
 	assert.Equal(t, RPCDefaultDialRetryDelay, mc.RetryConfig.DialDelay)
 
 	// Expect error if no RPCs provided.
-	_, err = NewMultiClient(lggr, RPCConfig{ChainSelector: chainSelector, RPCs: []RPC{}})
+	_, err = NewMultiClient(t.Context(), lggr, RPCConfig{ChainSelector: chainSelector, RPCs: []RPC{}})
 	require.Error(t, err)
 
 	// Expect second client to be set as backup.
-	mc, err = NewMultiClient(lggr, RPCConfig{ChainSelector: chainSelector, RPCs: []RPC{
+	mc, err = NewMultiClient(t.Context(), lggr, RPCConfig{ChainSelector: chainSelector, RPCs: []RPC{
 		{Name: "test-rpc", WSURL: wsURL, HTTPURL: httpURL, PreferredURLScheme: URLSchemePreferenceHTTP}, //preferred
 		{Name: "test-rpc", WSURL: wsURL, HTTPURL: httpURL, PreferredURLScheme: URLSchemePreferenceHTTP}, //backup
 	}})
@@ -98,7 +98,7 @@ func TestMultiClient_healthCheckSkipsBadRPC(t *testing.T) {
 		chainSelector uint64 = 16015286601757825753
 	)
 
-	mc, err := NewMultiClient(lggr, RPCConfig{ChainSelector: chainSelector, RPCs: []RPC{
+	mc, err := NewMultiClient(t.Context(), lggr, RPCConfig{ChainSelector: chainSelector, RPCs: []RPC{
 		// first RPC -> health-check fails
 		{Name: "bad-rpc", WSURL: "", HTTPURL: badSrv.URL, PreferredURLScheme: URLSchemePreferenceHTTP},
 		// second RPC -> health-check passes

--- a/chain/evm/provider/zksync_rpc_provider.go
+++ b/chain/evm/provider/zksync_rpc_provider.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"math/big"
 
-	chainsel "github.com/smartcontractkit/chain-selectors"
+	chainsel "github.com/smartcontractkit/chain-selectors/remote"
 	zkAccounts "github.com/zksync-sdk/zksync2-go/accounts"
 	zkClients "github.com/zksync-sdk/zksync2-go/clients"
 
@@ -108,10 +108,11 @@ func (p *ZkSyncRPCChainProvider) Initialize(ctx context.Context) (chain.BlockCha
 	}
 
 	// Get the Chain ID
-	chainIDStr, err := chainsel.GetChainIDFromSelector(p.selector)
+	chainDetails, err := chainsel.GetChainDetailsBySelector(ctx, p.selector)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get chain ID from selector %d: %w", p.selector, err)
+		return nil, fmt.Errorf("failed to get chain details for selector %d: %w", p.selector, err)
 	}
+	chainIDStr := chainDetails.ChainID
 
 	chainID, ok := new(big.Int).SetString(chainIDStr, 10)
 	if !ok {
@@ -125,7 +126,7 @@ func (p *ZkSyncRPCChainProvider) Initialize(ctx context.Context) (chain.BlockCha
 	}
 
 	// Setup the client.
-	client, err := rpcclient.NewMultiClient(p.config.Logger, rpcclient.RPCConfig{
+	client, err := rpcclient.NewMultiClient(ctx, p.config.Logger, rpcclient.RPCConfig{
 		ChainSelector: p.selector,
 		RPCs:          p.config.RPCs,
 	}, p.config.ClientOpts...)

--- a/chain/evm/provider/zksync_rpc_provider_test.go
+++ b/chain/evm/provider/zksync_rpc_provider_test.go
@@ -172,7 +172,7 @@ func Test_ZkSyncRPCChainProvider_Initialize(t *testing.T) {
 				RPCs:                  []rpcclient.RPC{rpc},
 				ConfirmFunctor:        gethConfirmFunc,
 			},
-			wantErr: "failed to get chain ID from selector",
+			wantErr: "failed to get chain details for selector 1",
 		},
 		{
 			name:         "fails to generate deployer transactor",

--- a/engine/cld/chains/chains.go
+++ b/engine/cld/chains/chains.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
+	chainselremote "github.com/smartcontractkit/chain-selectors/remote"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger"
 
@@ -61,14 +62,15 @@ func LoadChains(
 
 	for _, selector := range chainselToLoad {
 		// Get the chain family for this selector
-		chainFamily, err := chainsel.GetSelectorFamily(selector)
+		chainDetails, err := chainselremote.GetChainDetailsBySelector(ctx, selector)
 		if err != nil {
-			lggr.Warnw("Unable to get chain family for selector",
+			lggr.Warnw("Unable to get chain details for selector",
 				"selector", selector, "error", err,
 			)
 
-			return fchain.BlockChains{}, fmt.Errorf("unable to get chain family for selector %d", selector)
+			return fchain.BlockChains{}, fmt.Errorf("unable to get chain family for selector %d: %w", selector, err)
 		}
+		chainFamily := chainDetails.Family
 
 		// Check if we have a loader for this chain family
 		loader, exists := chainLoaders[chainFamily]


### PR DESCRIPTION
This pull request updates the `/chain/evm/provider` and `/engine/cld/chains` packages to use remote chain selectors from the `github.com/smartcontractkit/chain-selectors/remote` package. It will enable CLDF clients to load new EVM chains without the need to update the "chain-selectors" library version.