### PR TITLE
CLD-2058: Add in memory and file catalog deletes

### DIFF
--- a/.changeset/small-eagles-own.md
+++ b/.changeset/small-eagles-own.md
@@ -2,4 +2,4 @@
 "chainlink-deployments-framework": minor
 ---
 
-(feat) Support in memory catalog deletes and save keys for latter deleting them from catalog
+(feat) Support in memory catalog deletes and save keys for later deleting them from the catalog

--- a/.changeset/small-eagles-own.md
+++ b/.changeset/small-eagles-own.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+(feat) Support in memory catalog deletes and save keys for latter deleting them from catalog

--- a/datastore/address_ref.go
+++ b/datastore/address_ref.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	ErrAddressRefNotFound = errors.New("no such address ref can be found for the provided key")
-	ErrAddressRefExists   = errors.New("an address ref with the supplied key already exists")
+	ErrAddressRefNotFound        = errors.New("no such address ref can be found for the provided key")
+	ErrAddressRefExists          = errors.New("an address ref with the supplied key already exists")
+	ErrAddressRefVersionRequired = errors.New("the address ref record version is required")
 )
 
 // TODO: ContractType is defined in many places in the codebase. Once it is moved

--- a/datastore/address_ref_key.go
+++ b/datastore/address_ref_key.go
@@ -2,6 +2,8 @@ package datastore
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 )
@@ -65,6 +67,20 @@ func (a addressRefKey) String() string {
 		a.version.String(),
 		a.qualifier,
 	)
+}
+
+// NewAddressRefKeyFromString creates a new AddressRefKey instance from a string representation.
+func NewAddressRefKeyFromString(key string) (AddressRefKey, error) {
+	parts := strings.Split(key, "_")
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("invalid address ref key: %s", key)
+	}
+	chainSelector, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse chain selector: %w", err)
+	}
+
+	return NewAddressRefKey(chainSelector, ContractType(parts[1]), semver.MustParse(parts[2]), parts[3]), nil
 }
 
 // NewAddressRefKey creates a new AddressRefKey instance.

--- a/datastore/address_ref_key_test.go
+++ b/datastore/address_ref_key_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddressRefKey_Equals(t *testing.T) {
@@ -75,4 +76,55 @@ func TestAddressRefKey_String(t *testing.T) {
 	key := NewAddressRefKey(42, ContractType("MyType"), semver.MustParse("1.2.3"), "qual")
 	expected := "42_MyType_1.2.3_qual"
 	assert.Equal(t, expected, key.String())
+}
+
+func TestNewAddressRefKeyFromString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    string
+		want    AddressRefKey
+		wantErr string
+	}{
+		{
+			name: "success: valid string",
+			give: "42_MyContract_1.2.3_primary",
+			want: NewAddressRefKey(42, ContractType("MyContract"), semver.MustParse("1.2.3"), "primary"),
+		},
+		{
+			name:    "failure: too few parts",
+			give:    "42_MyContract_1.2.3",
+			wantErr: "invalid address ref key",
+		},
+		{
+			name:    "failure: too many parts",
+			give:    "42_MyContract_1.2.3_primary_extra",
+			wantErr: "invalid address ref key",
+		},
+		{
+			name:    "failure: invalid chain selector",
+			give:    "notanumber_MyContract_1.2.3_primary",
+			wantErr: "failed to parse chain selector",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NewAddressRefKeyFromString(tt.give)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want.ChainSelector(), got.ChainSelector())
+			assert.Equal(t, tt.want.Type(), got.Type())
+			assert.True(t, tt.want.Version().Equal(got.Version()))
+			assert.Equal(t, tt.want.Qualifier(), got.Qualifier())
+		})
+	}
 }

--- a/datastore/api_v1.go
+++ b/datastore/api_v1.go
@@ -66,7 +66,8 @@ type MutableStore[K Comparable[K], R UniqueRecord[K, R]] interface {
 	// such record exists to be deleted
 	Delete(key K) error
 
-	// RemoteDelete deletes a record from the store and appends the key to DeletedKeys for soft-delete tracking.
+	// RemoteDelete stages the key for remote deletion / soft-delete tracking by appending it to
+	// DeletedRemoteKeys. In-memory implementations do not immediately delete the record from the store.
 	RemoteDelete(key K) error
 }
 

--- a/datastore/api_v1.go
+++ b/datastore/api_v1.go
@@ -65,6 +65,9 @@ type MutableStore[K Comparable[K], R UniqueRecord[K, R]] interface {
 	// Delete deletes record whose primary key elements match the supplied key, returning an error if no
 	// such record exists to be deleted
 	Delete(key K) error
+
+	// RemoteDelete deletes a record from the store and appends the key to DeletedKeys for soft-delete tracking.
+	RemoteDelete(key K) error
 }
 
 // UnaryStore is an interface that represents a read-only store that is limited to a single record.

--- a/datastore/catalog_syncer.go
+++ b/datastore/catalog_syncer.go
@@ -29,12 +29,6 @@ func MergeDataStoreToCatalog(ctx context.Context, sourceDS DataStore, catalog Ca
 			}
 		}
 
-		for _, ref := range addressRefs {
-			if upsertErr := txCatalog.Addresses().Delete(ctx, ref.Key()); upsertErr != nil {
-				return fmt.Errorf("failed to remote delete address reference from catalog: %w", upsertErr)
-			}
-		}
-
 		// Merge all chain metadata to the catalog
 		chainMetadata, err := sourceDS.ChainMetadata().Fetch()
 		if err != nil {

--- a/datastore/catalog_syncer.go
+++ b/datastore/catalog_syncer.go
@@ -29,6 +29,12 @@ func MergeDataStoreToCatalog(ctx context.Context, sourceDS DataStore, catalog Ca
 			}
 		}
 
+		for _, ref := range addressRefs {
+			if upsertErr := txCatalog.Addresses().Delete(ctx, ref.Key()); upsertErr != nil {
+				return fmt.Errorf("failed to remote delete address reference from catalog: %w", upsertErr)
+			}
+		}
+
 		// Merge all chain metadata to the catalog
 		chainMetadata, err := sourceDS.ChainMetadata().Fetch()
 		if err != nil {

--- a/datastore/chain_metadata_key.go
+++ b/datastore/chain_metadata_key.go
@@ -37,6 +37,19 @@ func (c chainMetadataKey) String() string {
 	return strconv.FormatUint(c.chainSelector, 10)
 }
 
+// NewChainMetadataKeyFromString creates a new ChainMetadataKey instance from a string representation.
+func NewChainMetadataKeyFromString(key string) (ChainMetadataKey, error) {
+	if len(key) == 0 {
+		return nil, fmt.Errorf("invalid chain metadata key: %s", key)
+	}
+	chainSelector, err := strconv.ParseUint(key, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse chain selector: %w", err)
+	}
+
+	return NewChainMetadataKey(chainSelector), nil
+}
+
 // NewChainMetadataKey creates a new ChainMetadataKey instance.
 func NewChainMetadataKey(chainSelector uint64) ChainMetadataKey {
 	return chainMetadataKey{

--- a/datastore/chain_metadata_key_test.go
+++ b/datastore/chain_metadata_key_test.go
@@ -55,3 +55,46 @@ func TestChainMetadataKey_String(t *testing.T) {
 	expected := "99"
 	require.Equal(t, expected, key.String())
 }
+
+func TestNewChainMetadataKeyFromString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    string
+		want    ChainMetadataKey
+		wantErr string
+	}{
+		{
+			name: "success: valid string",
+			give: "5009297550715157269",
+			want: NewChainMetadataKey(5009297550715157269),
+		},
+		{
+			name:    "failure: empty string",
+			give:    "",
+			wantErr: "invalid chain metadata key",
+		},
+		{
+			name:    "failure: invalid chain selector",
+			give:    "notanumber",
+			wantErr: "failed to parse chain selector",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NewChainMetadataKeyFromString(tt.give)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want.ChainSelector(), got.ChainSelector())
+		})
+	}
+}

--- a/datastore/contract_metadata_key.go
+++ b/datastore/contract_metadata_key.go
@@ -1,6 +1,10 @@
 package datastore
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 // ContractMetadataKey is an interface that represents a key for ContractMetadata records.
 // It is used to uniquely identify a record in the ContractMetadataStore.
@@ -39,6 +43,20 @@ func (c contractMetadataKey) Equals(other ContractMetadataKey) bool {
 // String returns a string representation of the ContractMetadataKey.
 func (c contractMetadataKey) String() string {
 	return fmt.Sprintf("%d_%s", c.chainSelector, c.address)
+}
+
+// NewContractMetadataKeyFromString creates a new ContractMetadataKey instance from a string representation.
+func NewContractMetadataKeyFromString(key string) (ContractMetadataKey, error) {
+	parts := strings.Split(key, "_")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid contract metadata key: %s", key)
+	}
+	chainSelector, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse chain selector: %w", err)
+	}
+
+	return NewContractMetadataKey(chainSelector, parts[1]), nil
 }
 
 // NewContractMetadataKey creates a new ContractMetadataKey instance.

--- a/datastore/contract_metadata_key_test.go
+++ b/datastore/contract_metadata_key_test.go
@@ -69,3 +69,52 @@ func TestContractMetadataKey_String(t *testing.T) {
 	expected := "99_0xabc"
 	require.Equal(t, expected, key.String())
 }
+
+func TestNewContractMetadataKeyFromString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		give    string
+		want    ContractMetadataKey
+		wantErr string
+	}{
+		{
+			name: "success: valid string",
+			give: "42_0x1234567890abcdef",
+			want: NewContractMetadataKey(42, "0x1234567890abcdef"),
+		},
+		{
+			name:    "failure: too few parts",
+			give:    "42",
+			wantErr: "invalid contract metadata key",
+		},
+		{
+			name:    "failure: too many parts",
+			give:    "42_0xabc_extra",
+			wantErr: "invalid contract metadata key",
+		},
+		{
+			name:    "failure: invalid chain selector",
+			give:    "notanumber_0x1234567890abcdef",
+			wantErr: "failed to parse chain selector",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NewContractMetadataKeyFromString(tt.give)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want.ChainSelector(), got.ChainSelector())
+			require.Equal(t, tt.want.Address(), got.Address())
+		})
+	}
+}

--- a/datastore/memory_address_ref_store.go
+++ b/datastore/memory_address_ref_store.go
@@ -20,9 +20,9 @@ type MutableAddressRefStore interface {
 // MemoryAddressRefStore is an in-memory implementation of the AddressRefStore and
 // MutableAddressRefStore interfaces.
 type MemoryAddressRefStore struct {
-	Records     []AddressRef        `json:"records"`
-	DeletedKeys []AddressRefKey     `json:"deletedKeys,omitempty"`
-	mu          sync.RWMutex
+	Records           []AddressRef `json:"records"`
+	DeletedRemoteKeys []string     `json:"deletedRemoteKeys,omitempty"`
+	mu                sync.RWMutex
 }
 
 // MemoryAddressRefStore implements AddressRefStore interface.
@@ -146,9 +146,24 @@ func (s *MemoryAddressRefStore) Delete(key AddressRefKey) error {
 		return ErrAddressRefNotFound
 	}
 	s.Records = append(s.Records[:idx], s.Records[idx+1:]...)
-	if !slices.Contains(s.DeletedKeys, key) {
-			s.DeletedKeys = append(s.DeletedKeys, key)
+
+	return nil
+}
+
+// RemoteDelete stages the record matching the supplied key for deletion by appending the key
+// to DeletedRemoteKeys. RemoteDelete does not delete the record from the store, it only stages it for deletion
+// and should be used only when we need to delete a record that does not exist in the current in-memory datastore
+// but exists in the remote datastore (e.g. file or catalog).
+func (s *MemoryAddressRefStore) RemoteDelete(key AddressRefKey) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	deletedKey := key.String()
+
+	if slices.Contains(s.DeletedRemoteKeys, deletedKey) {
+		return nil
 	}
+	s.DeletedRemoteKeys = append(s.DeletedRemoteKeys, deletedKey)
 
 	return nil
 }

--- a/datastore/memory_address_ref_store.go
+++ b/datastore/memory_address_ref_store.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"slices"
 	"sync"
 )
 
@@ -19,8 +20,9 @@ type MutableAddressRefStore interface {
 // MemoryAddressRefStore is an in-memory implementation of the AddressRefStore and
 // MutableAddressRefStore interfaces.
 type MemoryAddressRefStore struct {
-	Records []AddressRef `json:"records"`
-	mu      sync.RWMutex
+	Records     []AddressRef        `json:"records"`
+	DeletedKeys []AddressRefKey     `json:"deletedKeys,omitempty"`
+	mu          sync.RWMutex
 }
 
 // MemoryAddressRefStore implements AddressRefStore interface.
@@ -133,8 +135,8 @@ func (s *MemoryAddressRefStore) Update(record AddressRef) error {
 	return nil
 }
 
-// Delete deletes record whose primary key elements match the supplied AddressRecord, returning an error if no
-// such record exists to be deleted.
+// Delete removes the record matching the supplied key from the store and appends the key
+// to DeletedKeys for soft-delete tracking. Returns ErrAddressRefNotFound if the key does not exist.
 func (s *MemoryAddressRefStore) Delete(key AddressRefKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -144,6 +146,9 @@ func (s *MemoryAddressRefStore) Delete(key AddressRefKey) error {
 		return ErrAddressRefNotFound
 	}
 	s.Records = append(s.Records[:idx], s.Records[idx+1:]...)
+	if !slices.Contains(s.DeletedKeys, key) {
+			s.DeletedKeys = append(s.DeletedKeys, key)
+	}
 
 	return nil
 }

--- a/datastore/memory_address_ref_store.go
+++ b/datastore/memory_address_ref_store.go
@@ -135,8 +135,8 @@ func (s *MemoryAddressRefStore) Update(record AddressRef) error {
 	return nil
 }
 
-// Delete removes the record matching the supplied key from the store and appends the key
-// to DeletedKeys for soft-delete tracking. Returns ErrAddressRefNotFound if the key does not exist.
+// Delete removes the record matching the supplied key from the store.
+// Returns ErrAddressRefNotFound if the key does not exist.
 func (s *MemoryAddressRefStore) Delete(key AddressRefKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/datastore/memory_address_ref_store.go
+++ b/datastore/memory_address_ref_store.go
@@ -21,7 +21,7 @@ type MutableAddressRefStore interface {
 // MutableAddressRefStore interfaces.
 type MemoryAddressRefStore struct {
 	Records           []AddressRef `json:"records"`
-	DeletedRemoteKeys []string     `json:"deletedRemoteKeys,omitempty"`
+	DeletedRemoteKeys []string     `json:"deletedRemoteKeys"`
 	mu                sync.RWMutex
 }
 
@@ -33,7 +33,10 @@ var _ MutableAddressRefStore = &MemoryAddressRefStore{}
 
 // NewMemoryAddressRefStore creates a new MemoryAddressRefStore instance.
 func NewMemoryAddressRefStore() *MemoryAddressRefStore {
-	return &MemoryAddressRefStore{Records: []AddressRef{}}
+	return &MemoryAddressRefStore{
+		Records:           []AddressRef{},
+		DeletedRemoteKeys: []string{},
+	}
 }
 
 // Get returns the AddressRef for the provided key, or an error if no such record exists.
@@ -98,6 +101,13 @@ func (s *MemoryAddressRefStore) Add(record AddressRef) error {
 	if idx != -1 {
 		return ErrAddressRefExists
 	}
+
+	if record.Version == nil {
+		return ErrAddressRefVersionRequired
+	}
+	// If a record with the same key is being added, remove it from the deleted remote keys
+	// this covers cases that we want to delete and recreate a record which has the same key as the old one.
+	s.DeletedRemoteKeys = deleteFromSlice(s.DeletedRemoteKeys, record.Key().String())
 	s.Records = append(s.Records, record)
 
 	return nil
@@ -108,6 +118,13 @@ func (s *MemoryAddressRefStore) Add(record AddressRef) error {
 func (s *MemoryAddressRefStore) Upsert(record AddressRef) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if record.Version == nil {
+		return ErrAddressRefVersionRequired
+	}
+	// If a record with the same key is being upserted, remove it from the deleted remote keys
+	// this covers cases that we want to delete and recreate a record which has the same key as the old one.
+	s.DeletedRemoteKeys = deleteFromSlice(s.DeletedRemoteKeys, record.Key().String())
 
 	idx := s.indexOf(record.Key())
 	if idx != -1 {
@@ -130,6 +147,14 @@ func (s *MemoryAddressRefStore) Update(record AddressRef) error {
 	if idx == -1 {
 		return ErrAddressRefNotFound
 	}
+
+	if record.Version == nil {
+		return ErrAddressRefVersionRequired
+	}
+
+	// If a record with the same key is being updated, remove it from the deleted remote keys
+	// this covers cases that we want to delete and recreate a record which has the same key as the old one.
+	s.DeletedRemoteKeys = deleteFromSlice(s.DeletedRemoteKeys, record.Key().String())
 	s.Records[idx] = record
 
 	return nil
@@ -160,10 +185,9 @@ func (s *MemoryAddressRefStore) RemoteDelete(key AddressRefKey) error {
 
 	deletedKey := key.String()
 
-	if slices.Contains(s.DeletedRemoteKeys, deletedKey) {
-		return nil
+	if !slices.Contains(s.DeletedRemoteKeys, deletedKey) {
+		s.DeletedRemoteKeys = append(s.DeletedRemoteKeys, deletedKey)
 	}
-	s.DeletedRemoteKeys = append(s.DeletedRemoteKeys, deletedKey)
 
 	return nil
 }

--- a/datastore/memory_address_ref_store_test.go
+++ b/datastore/memory_address_ref_store_test.go
@@ -303,18 +303,16 @@ func TestMemoryAddressRefStore_Delete(t *testing.T) {
 		}
 	)
 
-	t.Run("success: deletes given record and appends to DeletedKeys", func(t *testing.T) {
+	t.Run("success: deletes record from Records", func(t *testing.T) {
 		t.Parallel()
 
 		store := MemoryAddressRefStore{Records: []AddressRef{recordOne, recordTwo, recordThree}}
 		assert.Len(t, store.Records, 3)
-		assert.Len(t, store.DeletedKeys, 0)
+		assert.Empty(t, store.DeletedRemoteKeys)
 		err := store.Delete(recordTwo.Key())
 		require.NoError(t, err)
 		assert.Equal(t, []AddressRef{recordOne, recordThree}, store.Records)
-		assert.Len(t, store.DeletedKeys, 1)
-		assert.True(t, store.DeletedKeys[0].Equals(recordTwo.Key()))
-		assert.Len(t, store.Records, 2)
+		assert.Empty(t, store.DeletedRemoteKeys)
 	})
 
 	t.Run("error: absent key returns ErrAddressRefNotFound", func(t *testing.T) {
@@ -322,25 +320,79 @@ func TestMemoryAddressRefStore_Delete(t *testing.T) {
 
 		store := MemoryAddressRefStore{Records: []AddressRef{recordOne, recordThree}}
 		assert.Len(t, store.Records, 2)
-		assert.Len(t, store.DeletedKeys, 0)
+		assert.Empty(t, store.DeletedRemoteKeys)
 		err := store.Delete(recordTwo.Key())
 		require.ErrorIs(t, err, ErrAddressRefNotFound)
 		assert.Equal(t, []AddressRef{recordOne, recordThree}, store.Records)
-		assert.Len(t, store.DeletedKeys, 0)
+		assert.Empty(t, store.DeletedRemoteKeys)
 	})
 
-	t.Run("error: second Delete returns ErrAddressRefNotFound, DeletedKeys unchanged", func(t *testing.T) {
+	t.Run("error: second Delete returns ErrAddressRefNotFound", func(t *testing.T) {
 		t.Parallel()
 
 		store := MemoryAddressRefStore{Records: []AddressRef{recordOne, recordTwo, recordThree}}
 		assert.Len(t, store.Records, 3)
-		assert.Len(t, store.DeletedKeys, 0)
 		require.NoError(t, store.Delete(recordTwo.Key()))
-		assert.Len(t, store.DeletedKeys, 1)
-		assert.True(t, store.DeletedKeys[0].Equals(recordTwo.Key()))
-		require.ErrorIs(t, store.Delete(recordTwo.Key()), ErrAddressRefNotFound)
-		assert.Len(t, store.DeletedKeys, 1)
 		assert.Len(t, store.Records, 2)
+		require.ErrorIs(t, store.Delete(recordTwo.Key()), ErrAddressRefNotFound)
+		assert.Len(t, store.Records, 2)
+		assert.Empty(t, store.DeletedRemoteKeys)
+	})
+}
+
+func TestMemoryAddressRefStore_RemoteDelete(t *testing.T) {
+	t.Parallel()
+
+	var (
+		recordOne = AddressRef{
+			Address:       "0x2324224",
+			ChainSelector: 1,
+			Type:          "type1",
+			Version:       semver.MustParse("0.5.0"),
+			Qualifier:     "qual1",
+			Labels:        NewLabelSet("label1", "label2", "label3"),
+		}
+
+		recordTwo = AddressRef{
+			Address:       "0x2324224",
+			ChainSelector: 2,
+			Type:          "typeX",
+			Version:       semver.MustParse("0.5.0"),
+			Qualifier:     "qual1",
+			Labels:        NewLabelSet("label13", "label23", "label33"),
+		}
+
+		recordThree = AddressRef{
+			Address:       "0x2324224",
+			ChainSelector: 3,
+			Type:          "typeZ",
+			Version:       semver.MustParse("0.5.0"),
+			Qualifier:     "qual1",
+			Labels:        NewLabelSet("label13", "label23", "label33"),
+		}
+	)
+
+	t.Run("success: stages key in DeletedRemoteKeys without removing from Records", func(t *testing.T) {
+		t.Parallel()
+
+		store := MemoryAddressRefStore{Records: []AddressRef{recordOne, recordTwo, recordThree}}
+		assert.Len(t, store.Records, 3)
+		assert.Empty(t, store.DeletedRemoteKeys)
+		err := store.RemoteDelete(recordTwo.Key())
+		require.NoError(t, err)
+		assert.Len(t, store.Records, 3)
+		assert.Len(t, store.DeletedRemoteKeys, 1)
+		assert.Equal(t, store.DeletedRemoteKeys[0], recordTwo.Key().String())
+	})
+
+	t.Run("success: second RemoteDelete does not duplicate entry", func(t *testing.T) {
+		t.Parallel()
+
+		store := MemoryAddressRefStore{Records: []AddressRef{recordOne, recordTwo, recordThree}}
+		require.NoError(t, store.RemoteDelete(recordTwo.Key()))
+		require.NoError(t, store.RemoteDelete(recordTwo.Key()))
+		assert.Len(t, store.Records, 3)
+		assert.Len(t, store.DeletedRemoteKeys, 1)
 	})
 }
 

--- a/datastore/memory_address_ref_store_test.go
+++ b/datastore/memory_address_ref_store_test.go
@@ -88,11 +88,12 @@ func TestMemoryAddressRefStore_Add(t *testing.T) {
 	)
 
 	tests := []struct {
-		name          string
-		givenState    []AddressRef
-		giveRecord    AddressRef
-		expectedState []AddressRef
-		expectedError error
+		name              string
+		givenState        []AddressRef
+		deletedRemoteKeys []string
+		giveRecord        AddressRef
+		expectedState     []AddressRef
+		expectedError     error
 	}{
 		{
 			name:       "success: adds new record",
@@ -110,13 +111,37 @@ func TestMemoryAddressRefStore_Add(t *testing.T) {
 			giveRecord:    record,
 			expectedError: ErrAddressRefExists,
 		},
+		{
+			name:       "error: version is nil",
+			givenState: []AddressRef{},
+			giveRecord: AddressRef{
+				Address:       "0x2324224",
+				ChainSelector: 1,
+				Type:          "type1",
+				Qualifier:     "qual1",
+				Labels: NewLabelSet(
+					"label1", "label2", "label3",
+				),
+			},
+			expectedError: ErrAddressRefVersionRequired,
+		},
+		{
+			name:              "success: add record that was staged for deletion",
+			givenState:        []AddressRef{},
+			deletedRemoteKeys: []string{record.Key().String()},
+			giveRecord:        record,
+			expectedState: []AddressRef{
+				record,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			store := MemoryAddressRefStore{Records: tt.givenState}
+			store := MemoryAddressRefStore{Records: tt.givenState, DeletedRemoteKeys: tt.deletedRemoteKeys}
+			assert.Len(t, store.DeletedRemoteKeys, len(tt.deletedRemoteKeys))
 			err := store.Add(tt.giveRecord)
 
 			if tt.expectedError != nil {
@@ -125,6 +150,7 @@ func TestMemoryAddressRefStore_Add(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expectedState, store.Records)
+				assert.Empty(t, store.DeletedRemoteKeys)
 			}
 		})
 	}
@@ -157,10 +183,12 @@ func TestMemoryAddressRefStore_Upsert(t *testing.T) {
 	)
 
 	tests := []struct {
-		name          string
-		givenState    []AddressRef
-		expectedState []AddressRef
-		giveRecord    AddressRef
+		name              string
+		givenState        []AddressRef
+		expectedState     []AddressRef
+		giveRecord        AddressRef
+		deletedRemoteKeys []string
+		expectedError     error
 	}{
 		{
 			name:       "success: adds new record",
@@ -180,18 +208,51 @@ func TestMemoryAddressRefStore_Upsert(t *testing.T) {
 				newRecord,
 			},
 		},
+		{
+			name:              "success: upsert record that was staged for deletion",
+			givenState:        []AddressRef{},
+			deletedRemoteKeys: []string{oldRecord.Key().String()},
+			giveRecord:        oldRecord,
+			expectedState: []AddressRef{
+				oldRecord,
+			},
+		},
+		{
+			name:              "error: version is nil",
+			givenState:        []AddressRef{},
+			deletedRemoteKeys: []string{oldRecord.Key().String()},
+			giveRecord: AddressRef{
+				Address:       "0x2324224",
+				ChainSelector: 1,
+				Type:          "type1",
+				Version:       nil,
+				Qualifier:     "qual1",
+				Labels: NewLabelSet(
+					"label1", "label2", "label3",
+				),
+			},
+			expectedError: ErrAddressRefVersionRequired,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			store := MemoryAddressRefStore{Records: tt.givenState}
+			store := MemoryAddressRefStore{Records: tt.givenState, DeletedRemoteKeys: tt.deletedRemoteKeys}
+			assert.Len(t, store.DeletedRemoteKeys, len(tt.deletedRemoteKeys))
 			// Check the error, which will always be nil for the
 			// in memory implementation, to satisfy the linter
 			err := store.Upsert(tt.giveRecord)
-			require.NoError(t, err)
-			assert.Equal(t, tt.expectedState, store.Records)
+
+			if tt.expectedError != nil {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectedError, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedState, store.Records)
+				assert.Empty(t, store.DeletedRemoteKeys)
+			}
 		})
 	}
 }
@@ -220,14 +281,25 @@ func TestMemoryAddressRefStore_Update(t *testing.T) {
 				"label13", "label23", "label33",
 			),
 		}
+		nilRecord = AddressRef{
+			Address:       "0x2324224",
+			ChainSelector: 1,
+			Type:          "type1",
+			Version:       nil,
+			Qualifier:     "qual1",
+			Labels: NewLabelSet(
+				"label13", "label23", "label33",
+			),
+		}
 	)
 
 	tests := []struct {
-		name          string
-		givenState    []AddressRef
-		expectedState []AddressRef
-		giveRecord    AddressRef
-		expectedError error
+		name              string
+		givenState        []AddressRef
+		expectedState     []AddressRef
+		deletedRemoteKeys []string
+		giveRecord        AddressRef
+		expectedError     error
 	}{
 		{
 			name: "success: updates existing record",
@@ -245,13 +317,42 @@ func TestMemoryAddressRefStore_Update(t *testing.T) {
 			giveRecord:    newRecord,
 			expectedError: ErrAddressRefNotFound,
 		},
+		{
+			name: "error: version is nil",
+			givenState: []AddressRef{
+				nilRecord,
+			},
+			giveRecord: AddressRef{
+				Address:       "0x2324224",
+				ChainSelector: 1,
+				Type:          "type1",
+				Version:       nil,
+				Qualifier:     "qual1",
+				Labels: NewLabelSet(
+					"label1", "label2", "label3",
+				),
+			},
+			expectedError: ErrAddressRefVersionRequired,
+		},
+		{
+			name: "success: update record that was staged for deletion",
+			givenState: []AddressRef{
+				oldRecord,
+			},
+			deletedRemoteKeys: []string{oldRecord.Key().String()},
+			giveRecord:        oldRecord,
+			expectedState: []AddressRef{
+				oldRecord,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			store := MemoryAddressRefStore{Records: tt.givenState}
+			store := MemoryAddressRefStore{Records: tt.givenState, DeletedRemoteKeys: tt.deletedRemoteKeys}
+			assert.Len(t, store.DeletedRemoteKeys, len(tt.deletedRemoteKeys))
 			err := store.Update(tt.giveRecord)
 
 			if tt.expectedError != nil {
@@ -260,6 +361,7 @@ func TestMemoryAddressRefStore_Update(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expectedState, store.Records)
+				assert.Empty(t, store.DeletedRemoteKeys)
 			}
 		})
 	}
@@ -375,20 +477,22 @@ func TestMemoryAddressRefStore_RemoteDelete(t *testing.T) {
 	t.Run("success: stages key in DeletedRemoteKeys without removing from Records", func(t *testing.T) {
 		t.Parallel()
 
-		store := MemoryAddressRefStore{Records: []AddressRef{recordOne, recordTwo, recordThree}}
+		store := NewMemoryAddressRefStore()
+		store.Records = append(store.Records, recordOne, recordTwo, recordThree)
 		assert.Len(t, store.Records, 3)
 		assert.Empty(t, store.DeletedRemoteKeys)
 		err := store.RemoteDelete(recordTwo.Key())
 		require.NoError(t, err)
 		assert.Len(t, store.Records, 3)
 		assert.Len(t, store.DeletedRemoteKeys, 1)
-		assert.Equal(t, store.DeletedRemoteKeys[0], recordTwo.Key().String())
+		assert.Contains(t, store.DeletedRemoteKeys, recordTwo.Key().String())
 	})
 
 	t.Run("success: second RemoteDelete does not duplicate entry", func(t *testing.T) {
 		t.Parallel()
 
-		store := MemoryAddressRefStore{Records: []AddressRef{recordOne, recordTwo, recordThree}}
+		store := NewMemoryAddressRefStore()
+		store.Records = append(store.Records, recordOne, recordTwo, recordThree)
 		require.NoError(t, store.RemoteDelete(recordTwo.Key()))
 		require.NoError(t, store.RemoteDelete(recordTwo.Key()))
 		assert.Len(t, store.Records, 3)

--- a/datastore/memory_address_ref_store_test.go
+++ b/datastore/memory_address_ref_store_test.go
@@ -303,53 +303,45 @@ func TestMemoryAddressRefStore_Delete(t *testing.T) {
 		}
 	)
 
-	tests := []struct {
-		name          string
-		givenState    []AddressRef
-		expectedState []AddressRef
-		giveKey       AddressRefKey
-		expectedError error
-	}{
-		{
-			name: "success: deletes given record",
-			givenState: []AddressRef{
-				recordOne,
-				recordTwo,
-				recordThree,
-			},
-			giveKey: recordTwo.Key(),
-			expectedState: []AddressRef{
-				recordOne,
-				recordThree,
-			},
-		},
-		{
-			name: "error: record not found",
-			givenState: []AddressRef{
-				recordOne,
-				recordThree,
-			},
-			giveKey:       recordTwo.Key(),
-			expectedError: ErrAddressRefNotFound,
-		},
-	}
+	t.Run("success: deletes given record and appends to DeletedKeys", func(t *testing.T) {
+		t.Parallel()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		store := MemoryAddressRefStore{Records: []AddressRef{recordOne, recordTwo, recordThree}}
+		assert.Len(t, store.Records, 3)
+		assert.Len(t, store.DeletedKeys, 0)
+		err := store.Delete(recordTwo.Key())
+		require.NoError(t, err)
+		assert.Equal(t, []AddressRef{recordOne, recordThree}, store.Records)
+		assert.Len(t, store.DeletedKeys, 1)
+		assert.True(t, store.DeletedKeys[0].Equals(recordTwo.Key()))
+		assert.Len(t, store.Records, 2)
+	})
 
-			store := MemoryAddressRefStore{Records: tt.givenState}
-			err := store.Delete(tt.giveKey)
+	t.Run("error: absent key returns ErrAddressRefNotFound", func(t *testing.T) {
+		t.Parallel()
 
-			if tt.expectedError != nil {
-				require.Error(t, err)
-				assert.Equal(t, tt.expectedError, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expectedState, store.Records)
-			}
-		})
-	}
+		store := MemoryAddressRefStore{Records: []AddressRef{recordOne, recordThree}}
+		assert.Len(t, store.Records, 2)
+		assert.Len(t, store.DeletedKeys, 0)
+		err := store.Delete(recordTwo.Key())
+		require.ErrorIs(t, err, ErrAddressRefNotFound)
+		assert.Equal(t, []AddressRef{recordOne, recordThree}, store.Records)
+		assert.Len(t, store.DeletedKeys, 0)
+	})
+
+	t.Run("error: second Delete returns ErrAddressRefNotFound, DeletedKeys unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		store := MemoryAddressRefStore{Records: []AddressRef{recordOne, recordTwo, recordThree}}
+		assert.Len(t, store.Records, 3)
+		assert.Len(t, store.DeletedKeys, 0)
+		require.NoError(t, store.Delete(recordTwo.Key()))
+		assert.Len(t, store.DeletedKeys, 1)
+		assert.True(t, store.DeletedKeys[0].Equals(recordTwo.Key()))
+		require.ErrorIs(t, store.Delete(recordTwo.Key()), ErrAddressRefNotFound)
+		assert.Len(t, store.DeletedKeys, 1)
+		assert.Len(t, store.Records, 2)
+	})
 }
 
 func TestMemoryAddressRefStore_Fetch(t *testing.T) {

--- a/datastore/memory_chain_metadata_store.go
+++ b/datastore/memory_chain_metadata_store.go
@@ -20,9 +20,9 @@ type MutableChainMetadataStore interface {
 // MemoryChainMetadataStore is an in-memory implementation of the ChainMetadataStore and
 // MutableChainMetadataStore interfaces.
 type MemoryChainMetadataStore struct {
-	mu          sync.RWMutex
-	Records     []ChainMetadata    `json:"records"`
-	DeletedKeys []ChainMetadataKey `json:"deletedKeys,omitempty"`
+	mu                sync.RWMutex
+	Records           []ChainMetadata `json:"records"`
+	DeletedRemoteKeys []string        `json:"deletedRemoteKeys,omitempty"`
 }
 
 // MemoryChainMetadataStore implements ChainMetadataStore interface.
@@ -145,8 +145,8 @@ func (s *MemoryChainMetadataStore) Update(record ChainMetadata) error {
 	return nil
 }
 
-// Delete removes the record matching the supplied key from the store and appends the key
-// to DeletedKeys for soft-delete tracking. Returns ErrChainMetadataNotFound if the key does not exist.
+// Delete removes the record matching the supplied key from the store.
+// Returns ErrChainMetadataNotFound if the key does not exist.
 func (s *MemoryChainMetadataStore) Delete(key ChainMetadataKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -156,9 +156,24 @@ func (s *MemoryChainMetadataStore) Delete(key ChainMetadataKey) error {
 		return ErrChainMetadataNotFound
 	}
 	s.Records = append(s.Records[:idx], s.Records[idx+1:]...)
-	if !slices.Contains(s.DeletedKeys, key) {
-		s.DeletedKeys = append(s.DeletedKeys, key)
+
+	return nil
+}
+
+// RemoteDelete stages the record matching the supplied key for deletion by appending the key
+// to DeletedRemoteKeys. RemoteDelete does not delete the record from the store, it only stages it for deletion
+// and should be used only when we need to delete a record that does not exist in the current in-memory datastore
+// but exists in the remote datastore (e.g. file or catalog).
+func (s *MemoryChainMetadataStore) RemoteDelete(key ChainMetadataKey) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	deletedKey := key.String()
+
+	if slices.Contains(s.DeletedRemoteKeys, deletedKey) {
+		return nil
 	}
+	s.DeletedRemoteKeys = append(s.DeletedRemoteKeys, deletedKey)
 
 	return nil
 }

--- a/datastore/memory_chain_metadata_store.go
+++ b/datastore/memory_chain_metadata_store.go
@@ -22,7 +22,7 @@ type MutableChainMetadataStore interface {
 type MemoryChainMetadataStore struct {
 	mu                sync.RWMutex
 	Records           []ChainMetadata `json:"records"`
-	DeletedRemoteKeys []string        `json:"deletedRemoteKeys,omitempty"`
+	DeletedRemoteKeys []string        `json:"deletedRemoteKeys"`
 }
 
 // MemoryChainMetadataStore implements ChainMetadataStore interface.
@@ -33,7 +33,10 @@ var _ MutableChainMetadataStore = &MemoryChainMetadataStore{}
 
 // NewMemoryChainMetadataStore creates a new MemoryChainMetadataStore instance.
 func NewMemoryChainMetadataStore() *MemoryChainMetadataStore {
-	return &MemoryChainMetadataStore{Records: []ChainMetadata{}}
+	return &MemoryChainMetadataStore{
+		Records:           []ChainMetadata{},
+		DeletedRemoteKeys: []string{},
+	}
 }
 
 // Get returns the ChainMetadata for the provided key, or an error if no such record exists.
@@ -108,6 +111,9 @@ func (s *MemoryChainMetadataStore) Add(record ChainMetadata) error {
 	if idx != -1 {
 		return ErrChainMetadataExists
 	}
+	// If a record with the same key is being added, remove it from the deleted remote keys
+	// this covers cases that we want to delete and recreate a record which has the same key as the old one.
+	s.DeletedRemoteKeys = deleteFromSlice(s.DeletedRemoteKeys, record.Key().String())
 	s.Records = append(s.Records, record)
 
 	return nil
@@ -118,6 +124,10 @@ func (s *MemoryChainMetadataStore) Add(record ChainMetadata) error {
 func (s *MemoryChainMetadataStore) Upsert(record ChainMetadata) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// If a record with the same key is being upserted, remove it from the deleted remote keys
+	// this covers cases that we want to delete and recreate a record which has the same key as the old one.
+	s.DeletedRemoteKeys = deleteFromSlice(s.DeletedRemoteKeys, record.Key().String())
 
 	idx := s.indexOf(record.Key())
 	if idx == -1 {
@@ -140,6 +150,9 @@ func (s *MemoryChainMetadataStore) Update(record ChainMetadata) error {
 	if idx == -1 {
 		return ErrChainMetadataNotFound
 	}
+	// If a record with the same key is being upserted, remove it from the deleted remote keys
+	// this covers cases that we want to delete and recreate a record which has the same key as the old one.
+	s.DeletedRemoteKeys = deleteFromSlice(s.DeletedRemoteKeys, record.Key().String())
 	s.Records[idx] = record
 
 	return nil
@@ -170,10 +183,9 @@ func (s *MemoryChainMetadataStore) RemoteDelete(key ChainMetadataKey) error {
 
 	deletedKey := key.String()
 
-	if slices.Contains(s.DeletedRemoteKeys, deletedKey) {
-		return nil
+	if !slices.Contains(s.DeletedRemoteKeys, deletedKey) {
+		s.DeletedRemoteKeys = append(s.DeletedRemoteKeys, deletedKey)
 	}
-	s.DeletedRemoteKeys = append(s.DeletedRemoteKeys, deletedKey)
 
 	return nil
 }

--- a/datastore/memory_chain_metadata_store.go
+++ b/datastore/memory_chain_metadata_store.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"slices"
 	"sync"
 )
 
@@ -19,8 +20,9 @@ type MutableChainMetadataStore interface {
 // MemoryChainMetadataStore is an in-memory implementation of the ChainMetadataStore and
 // MutableChainMetadataStore interfaces.
 type MemoryChainMetadataStore struct {
-	mu      sync.RWMutex
-	Records []ChainMetadata `json:"records"`
+	mu          sync.RWMutex
+	Records     []ChainMetadata    `json:"records"`
+	DeletedKeys []ChainMetadataKey `json:"deletedKeys,omitempty"`
 }
 
 // MemoryChainMetadataStore implements ChainMetadataStore interface.
@@ -143,8 +145,8 @@ func (s *MemoryChainMetadataStore) Update(record ChainMetadata) error {
 	return nil
 }
 
-// Delete deletes an existing record whose primary key elements match the supplied ChainMetadata, returning an error if no
-// such record exists.
+// Delete removes the record matching the supplied key from the store and appends the key
+// to DeletedKeys for soft-delete tracking. Returns ErrChainMetadataNotFound if the key does not exist.
 func (s *MemoryChainMetadataStore) Delete(key ChainMetadataKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -154,6 +156,9 @@ func (s *MemoryChainMetadataStore) Delete(key ChainMetadataKey) error {
 		return ErrChainMetadataNotFound
 	}
 	s.Records = append(s.Records[:idx], s.Records[idx+1:]...)
+	if !slices.Contains(s.DeletedKeys, key) {
+		s.DeletedKeys = append(s.DeletedKeys, key)
+	}
 
 	return nil
 }

--- a/datastore/memory_chain_metadata_store_test.go
+++ b/datastore/memory_chain_metadata_store_test.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
@@ -70,11 +71,12 @@ func TestMemoryChainMetadataStore_Add(t *testing.T) {
 	)
 
 	tests := []struct {
-		name          string
-		givenState    []ChainMetadata
-		giveRecord    ChainMetadata
-		expectedState []ChainMetadata
-		expectedError error
+		name              string
+		givenState        []ChainMetadata
+		giveRecord        ChainMetadata
+		expectedState     []ChainMetadata
+		deletedRemoteKeys []string
+		expectedError     error
 	}{
 		{
 			name:       "success: adds new record",
@@ -92,13 +94,23 @@ func TestMemoryChainMetadataStore_Add(t *testing.T) {
 			giveRecord:    record,
 			expectedError: ErrChainMetadataExists,
 		},
+		{
+			name:              "success: add record that was staged for deletion",
+			givenState:        []ChainMetadata{},
+			deletedRemoteKeys: []string{record.Key().String()},
+			giveRecord:        record,
+			expectedState: []ChainMetadata{
+				record,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			store := MemoryChainMetadataStore{Records: tt.givenState}
+			store := MemoryChainMetadataStore{Records: tt.givenState, DeletedRemoteKeys: tt.deletedRemoteKeys}
+			assert.Len(t, store.DeletedRemoteKeys, len(tt.deletedRemoteKeys))
 			err := store.Add(tt.giveRecord)
 
 			if tt.expectedError != nil {
@@ -107,6 +119,7 @@ func TestMemoryChainMetadataStore_Add(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedState, store.Records)
+				assert.Empty(t, store.DeletedRemoteKeys)
 			}
 		})
 	}
@@ -128,10 +141,11 @@ func TestMemoryChainMetadataStore_Upsert(t *testing.T) {
 	)
 
 	tests := []struct {
-		name          string
-		givenState    []ChainMetadata
-		expectedState []ChainMetadata
-		giveRecord    ChainMetadata
+		name              string
+		givenState        []ChainMetadata
+		expectedState     []ChainMetadata
+		giveRecord        ChainMetadata
+		deletedRemoteKeys []string
 	}{
 		{
 			name:       "success: adds new record",
@@ -151,18 +165,29 @@ func TestMemoryChainMetadataStore_Upsert(t *testing.T) {
 				newRecord,
 			},
 		},
+		{
+			name:              "success: upsert record that was staged for deletion",
+			givenState:        []ChainMetadata{},
+			deletedRemoteKeys: []string{oldRecord.Key().String()},
+			giveRecord:        oldRecord,
+			expectedState: []ChainMetadata{
+				oldRecord,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			store := MemoryChainMetadataStore{Records: tt.givenState}
+			store := MemoryChainMetadataStore{Records: tt.givenState, DeletedRemoteKeys: tt.deletedRemoteKeys}
+			assert.Len(t, store.DeletedRemoteKeys, len(tt.deletedRemoteKeys))
 			// Check the error for the in-memory store, which will always be nil for the
 			// in memory implementation, to satisfy the linter
 			err := store.Upsert(tt.giveRecord)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedState, store.Records)
+			assert.Empty(t, store.DeletedRemoteKeys)
 		})
 	}
 }
@@ -183,11 +208,12 @@ func TestMemoryChainMetadataStore_Update(t *testing.T) {
 	)
 
 	tests := []struct {
-		name          string
-		givenState    []ChainMetadata
-		expectedState []ChainMetadata
-		giveRecord    ChainMetadata
-		expectedError error
+		name              string
+		givenState        []ChainMetadata
+		expectedState     []ChainMetadata
+		giveRecord        ChainMetadata
+		expectedError     error
+		deletedRemoteKeys []string
 	}{
 		{
 			name: "success: updates existing record",
@@ -205,13 +231,25 @@ func TestMemoryChainMetadataStore_Update(t *testing.T) {
 			giveRecord:    newRecord,
 			expectedError: ErrChainMetadataNotFound,
 		},
+		{
+			name: "success: update record that was staged for deletion",
+			givenState: []ChainMetadata{
+				oldRecord,
+			},
+			deletedRemoteKeys: []string{oldRecord.Key().String()},
+			giveRecord:        oldRecord,
+			expectedState: []ChainMetadata{
+				oldRecord,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			store := MemoryChainMetadataStore{Records: tt.givenState}
+			store := MemoryChainMetadataStore{Records: tt.givenState, DeletedRemoteKeys: tt.deletedRemoteKeys}
+			assert.Len(t, store.DeletedRemoteKeys, len(tt.deletedRemoteKeys))
 			err := store.Update(tt.giveRecord)
 
 			if tt.expectedError != nil {
@@ -220,6 +258,7 @@ func TestMemoryChainMetadataStore_Update(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedState, store.Records)
+				assert.Empty(t, store.DeletedRemoteKeys)
 			}
 		})
 	}
@@ -300,20 +339,22 @@ func TestMemoryChainMetadataStore_RemoteDelete(t *testing.T) {
 	t.Run("success: stages key in DeletedRemoteKeys without removing from Records", func(t *testing.T) {
 		t.Parallel()
 
-		store := MemoryChainMetadataStore{Records: []ChainMetadata{recordOne, recordTwo, recordThree}}
+		store := NewMemoryChainMetadataStore()
+		store.Records = append(store.Records, recordOne, recordTwo, recordThree)
 		require.Len(t, store.Records, 3)
 		require.Empty(t, store.DeletedRemoteKeys)
 		err := store.RemoteDelete(recordTwo.Key())
 		require.NoError(t, err)
 		require.Len(t, store.Records, 3)
 		require.Len(t, store.DeletedRemoteKeys, 1)
-		require.Equal(t, store.DeletedRemoteKeys[0], recordTwo.Key().String())
+		require.Contains(t, store.DeletedRemoteKeys, recordTwo.Key().String())
 	})
 
 	t.Run("success: second RemoteDelete does not duplicate entry", func(t *testing.T) {
 		t.Parallel()
 
-		store := MemoryChainMetadataStore{Records: []ChainMetadata{recordOne, recordTwo, recordThree}}
+		store := NewMemoryChainMetadataStore()
+		store.Records = append(store.Records, recordOne, recordTwo, recordThree)
 		require.NoError(t, store.RemoteDelete(recordTwo.Key()))
 		require.NoError(t, store.RemoteDelete(recordTwo.Key()))
 		require.Len(t, store.Records, 3)

--- a/datastore/memory_chain_metadata_store_test.go
+++ b/datastore/memory_chain_metadata_store_test.go
@@ -245,53 +245,37 @@ func TestMemoryMemoryChainMetadataStore_Delete(t *testing.T) {
 		}
 	)
 
-	tests := []struct {
-		name          string
-		givenState    []ChainMetadata
-		expectedState []ChainMetadata
-		giveKey       ChainMetadataKey
-		expectedError error
-	}{
-		{
-			name: "success: deletes given record",
-			givenState: []ChainMetadata{
-				recordOne,
-				recordTwo,
-				recordThree,
-			},
-			giveKey: recordTwo.Key(),
-			expectedState: []ChainMetadata{
-				recordOne,
-				recordThree,
-			},
-		},
-		{
-			name: "error: record not found",
-			givenState: []ChainMetadata{
-				recordOne,
-				recordThree,
-			},
-			giveKey:       recordTwo.Key(),
-			expectedError: ErrChainMetadataNotFound,
-		},
-	}
+	t.Run("success: deletes given record and appends to DeletedKeys", func(t *testing.T) {
+		t.Parallel()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		store := MemoryChainMetadataStore{Records: []ChainMetadata{recordOne, recordTwo, recordThree}}
+		err := store.Delete(recordTwo.Key())
+		require.NoError(t, err)
+		require.Equal(t, []ChainMetadata{recordOne, recordThree}, store.Records)
+		require.Len(t, store.DeletedKeys, 1)
+		require.True(t, store.DeletedKeys[0].Equals(recordTwo.Key()))
+	})
 
-			store := MemoryChainMetadataStore{Records: tt.givenState}
-			err := store.Delete(tt.giveKey)
+	t.Run("error: absent key returns ErrChainMetadataNotFound", func(t *testing.T) {
+		t.Parallel()
 
-			if tt.expectedError != nil {
-				require.Error(t, err)
-				require.Equal(t, tt.expectedError, err)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.expectedState, store.Records)
-			}
-		})
-	}
+		store := MemoryChainMetadataStore{Records: []ChainMetadata{recordOne, recordThree}}
+		err := store.Delete(recordTwo.Key())
+		require.ErrorIs(t, err, ErrChainMetadataNotFound)
+		require.Equal(t, []ChainMetadata{recordOne, recordThree}, store.Records)
+		require.Len(t, store.DeletedKeys, 0)
+	})
+
+	t.Run("error: second Delete returns ErrChainMetadataNotFound, DeletedKeys unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		store := MemoryChainMetadataStore{Records: []ChainMetadata{recordOne, recordTwo, recordThree}}
+		require.NoError(t, store.Delete(recordTwo.Key()))
+		require.Len(t, store.DeletedKeys, 1)
+		require.True(t, store.DeletedKeys[0].Equals(recordTwo.Key()))
+		require.ErrorIs(t, store.Delete(recordTwo.Key()), ErrChainMetadataNotFound)
+		require.Len(t, store.DeletedKeys, 1)
+	})
 }
 
 func TestMemoryChainMetadataStore_Fetch(t *testing.T) {

--- a/datastore/memory_chain_metadata_store_test.go
+++ b/datastore/memory_chain_metadata_store_test.go
@@ -245,15 +245,14 @@ func TestMemoryMemoryChainMetadataStore_Delete(t *testing.T) {
 		}
 	)
 
-	t.Run("success: deletes given record and appends to DeletedKeys", func(t *testing.T) {
+	t.Run("success: deletes record from Records", func(t *testing.T) {
 		t.Parallel()
 
 		store := MemoryChainMetadataStore{Records: []ChainMetadata{recordOne, recordTwo, recordThree}}
 		err := store.Delete(recordTwo.Key())
 		require.NoError(t, err)
 		require.Equal(t, []ChainMetadata{recordOne, recordThree}, store.Records)
-		require.Len(t, store.DeletedKeys, 1)
-		require.True(t, store.DeletedKeys[0].Equals(recordTwo.Key()))
+		require.Empty(t, store.DeletedRemoteKeys)
 	})
 
 	t.Run("error: absent key returns ErrChainMetadataNotFound", func(t *testing.T) {
@@ -263,18 +262,62 @@ func TestMemoryMemoryChainMetadataStore_Delete(t *testing.T) {
 		err := store.Delete(recordTwo.Key())
 		require.ErrorIs(t, err, ErrChainMetadataNotFound)
 		require.Equal(t, []ChainMetadata{recordOne, recordThree}, store.Records)
-		require.Len(t, store.DeletedKeys, 0)
+		require.Empty(t, store.DeletedRemoteKeys)
 	})
 
-	t.Run("error: second Delete returns ErrChainMetadataNotFound, DeletedKeys unchanged", func(t *testing.T) {
+	t.Run("error: second Delete returns ErrChainMetadataNotFound", func(t *testing.T) {
 		t.Parallel()
 
 		store := MemoryChainMetadataStore{Records: []ChainMetadata{recordOne, recordTwo, recordThree}}
 		require.NoError(t, store.Delete(recordTwo.Key()))
-		require.Len(t, store.DeletedKeys, 1)
-		require.True(t, store.DeletedKeys[0].Equals(recordTwo.Key()))
+		require.Len(t, store.Records, 2)
 		require.ErrorIs(t, store.Delete(recordTwo.Key()), ErrChainMetadataNotFound)
-		require.Len(t, store.DeletedKeys, 1)
+		require.Len(t, store.Records, 2)
+		require.Empty(t, store.DeletedRemoteKeys)
+	})
+}
+
+func TestMemoryChainMetadataStore_RemoteDelete(t *testing.T) {
+	t.Parallel()
+
+	var (
+		recordOne = ChainMetadata{
+			ChainSelector: 1,
+			Metadata:      testMetadata{Field: "metadata1", ChainSelector: 0},
+		}
+
+		recordTwo = ChainMetadata{
+			ChainSelector: 2,
+			Metadata:      testMetadata{Field: "metadata2", ChainSelector: 0},
+		}
+
+		recordThree = ChainMetadata{
+			ChainSelector: 3,
+			Metadata:      testMetadata{Field: "metadata3", ChainSelector: 0},
+		}
+	)
+
+	t.Run("success: stages key in DeletedRemoteKeys without removing from Records", func(t *testing.T) {
+		t.Parallel()
+
+		store := MemoryChainMetadataStore{Records: []ChainMetadata{recordOne, recordTwo, recordThree}}
+		require.Len(t, store.Records, 3)
+		require.Empty(t, store.DeletedRemoteKeys)
+		err := store.RemoteDelete(recordTwo.Key())
+		require.NoError(t, err)
+		require.Len(t, store.Records, 3)
+		require.Len(t, store.DeletedRemoteKeys, 1)
+		require.Equal(t, store.DeletedRemoteKeys[0], recordTwo.Key().String())
+	})
+
+	t.Run("success: second RemoteDelete does not duplicate entry", func(t *testing.T) {
+		t.Parallel()
+
+		store := MemoryChainMetadataStore{Records: []ChainMetadata{recordOne, recordTwo, recordThree}}
+		require.NoError(t, store.RemoteDelete(recordTwo.Key()))
+		require.NoError(t, store.RemoteDelete(recordTwo.Key()))
+		require.Len(t, store.Records, 3)
+		require.Len(t, store.DeletedRemoteKeys, 1)
 	})
 }
 

--- a/datastore/memory_contract_metadata_store.go
+++ b/datastore/memory_contract_metadata_store.go
@@ -20,9 +20,9 @@ type MutableContractMetadataStore interface {
 // MemoryContractMetadataStore is an in-memory implementation of the ContractMetadataStore and
 // MutableContractMetadataStore interfaces.
 type MemoryContractMetadataStore struct {
-	mu          sync.RWMutex
-	Records     []ContractMetadata        `json:"records"`
-	DeletedKeys []ContractMetadataKey     `json:"deletedKeys,omitempty"`
+	mu                sync.RWMutex
+	Records           []ContractMetadata `json:"records"`
+	DeletedRemoteKeys []string           `json:"deletedRemoteKeys,omitempty"`
 }
 
 // MemoryContractMetadataStore implements ContractMetadataStore interface.
@@ -145,8 +145,8 @@ func (s *MemoryContractMetadataStore) Update(record ContractMetadata) error {
 	return nil
 }
 
-// Delete removes the record matching the supplied key from the store and appends the key
-// to DeletedKeys for soft-delete tracking. Returns ErrContractMetadataNotFound if the key does not exist.
+// Delete removes the record matching the supplied key from the store.
+// Returns ErrContractMetadataNotFound if the key does not exist.
 func (s *MemoryContractMetadataStore) Delete(key ContractMetadataKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -156,9 +156,24 @@ func (s *MemoryContractMetadataStore) Delete(key ContractMetadataKey) error {
 		return ErrContractMetadataNotFound
 	}
 	s.Records = append(s.Records[:idx], s.Records[idx+1:]...)
-	if !slices.Contains(s.DeletedKeys, key) {
-		s.DeletedKeys = append(s.DeletedKeys, key)
+
+	return nil
+}
+
+// RemoteDelete stages the record matching the supplied key for deletion by appending the key
+// to DeletedRemoteKeys. RemoteDelete does not delete the record from the store, it only stages it for deletion
+// and should be used only when we need to delete a record that does not exist in the current in-memory datastore
+// but exists in the remote datastore (e.g. file or catalog).
+func (s *MemoryContractMetadataStore) RemoteDelete(key ContractMetadataKey) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	deletedKey := key.String()
+
+	if slices.Contains(s.DeletedRemoteKeys, deletedKey) {
+		return nil
 	}
+	s.DeletedRemoteKeys = append(s.DeletedRemoteKeys, deletedKey)
 
 	return nil
 }

--- a/datastore/memory_contract_metadata_store.go
+++ b/datastore/memory_contract_metadata_store.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"slices"
 	"sync"
 )
 
@@ -19,8 +20,9 @@ type MutableContractMetadataStore interface {
 // MemoryContractMetadataStore is an in-memory implementation of the ContractMetadataStore and
 // MutableContractMetadataStore interfaces.
 type MemoryContractMetadataStore struct {
-	mu      sync.RWMutex
-	Records []ContractMetadata `json:"records"`
+	mu          sync.RWMutex
+	Records     []ContractMetadata        `json:"records"`
+	DeletedKeys []ContractMetadataKey     `json:"deletedKeys,omitempty"`
 }
 
 // MemoryContractMetadataStore implements ContractMetadataStore interface.
@@ -143,8 +145,8 @@ func (s *MemoryContractMetadataStore) Update(record ContractMetadata) error {
 	return nil
 }
 
-// Delete deletes an existing record whose primary key elements match the supplied ContractMetadata, returning an error if no
-// such record exists.
+// Delete removes the record matching the supplied key from the store and appends the key
+// to DeletedKeys for soft-delete tracking. Returns ErrContractMetadataNotFound if the key does not exist.
 func (s *MemoryContractMetadataStore) Delete(key ContractMetadataKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -154,6 +156,9 @@ func (s *MemoryContractMetadataStore) Delete(key ContractMetadataKey) error {
 		return ErrContractMetadataNotFound
 	}
 	s.Records = append(s.Records[:idx], s.Records[idx+1:]...)
+	if !slices.Contains(s.DeletedKeys, key) {
+		s.DeletedKeys = append(s.DeletedKeys, key)
+	}
 
 	return nil
 }

--- a/datastore/memory_contract_metadata_store.go
+++ b/datastore/memory_contract_metadata_store.go
@@ -22,7 +22,7 @@ type MutableContractMetadataStore interface {
 type MemoryContractMetadataStore struct {
 	mu                sync.RWMutex
 	Records           []ContractMetadata `json:"records"`
-	DeletedRemoteKeys []string           `json:"deletedRemoteKeys,omitempty"`
+	DeletedRemoteKeys []string           `json:"deletedRemoteKeys"`
 }
 
 // MemoryContractMetadataStore implements ContractMetadataStore interface.
@@ -33,7 +33,10 @@ var _ MutableContractMetadataStore = &MemoryContractMetadataStore{}
 
 // NewMemoryContractMetadataStore creates a new MemoryContractMetadataStore instance.
 func NewMemoryContractMetadataStore() *MemoryContractMetadataStore {
-	return &MemoryContractMetadataStore{Records: []ContractMetadata{}}
+	return &MemoryContractMetadataStore{
+		Records:           []ContractMetadata{},
+		DeletedRemoteKeys: []string{},
+	}
 }
 
 // Get returns the ContractMetadata for the provided key, or an error if no such record exists.
@@ -108,6 +111,9 @@ func (s *MemoryContractMetadataStore) Add(record ContractMetadata) error {
 	if idx != -1 {
 		return ErrContractMetadataExists
 	}
+	// If a record with the same key is being added, remove it from the deleted remote keys
+	// this covers cases that we want to delete and recreate a record which has the same key as the old one.
+	s.DeletedRemoteKeys = deleteFromSlice(s.DeletedRemoteKeys, record.Key().String())
 	s.Records = append(s.Records, record)
 
 	return nil
@@ -118,6 +124,10 @@ func (s *MemoryContractMetadataStore) Add(record ContractMetadata) error {
 func (s *MemoryContractMetadataStore) Upsert(record ContractMetadata) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// If a record with the same key is being upserted, remove it from the deleted remote keys
+	// this covers cases that we want to delete and recreate a record which has the same key as the old one.
+	s.DeletedRemoteKeys = deleteFromSlice(s.DeletedRemoteKeys, record.Key().String())
 
 	idx := s.indexOf(record.Key())
 	if idx == -1 {
@@ -140,6 +150,9 @@ func (s *MemoryContractMetadataStore) Update(record ContractMetadata) error {
 	if idx == -1 {
 		return ErrContractMetadataNotFound
 	}
+	// If a record with the same key is being upserted, remove it from the deleted remote keys
+	// this covers cases that we want to delete and recreate a record which has the same key as the old one.
+	s.DeletedRemoteKeys = deleteFromSlice(s.DeletedRemoteKeys, record.Key().String())
 	s.Records[idx] = record
 
 	return nil
@@ -170,10 +183,9 @@ func (s *MemoryContractMetadataStore) RemoteDelete(key ContractMetadataKey) erro
 
 	deletedKey := key.String()
 
-	if slices.Contains(s.DeletedRemoteKeys, deletedKey) {
-		return nil
+	if !slices.Contains(s.DeletedRemoteKeys, deletedKey) {
+		s.DeletedRemoteKeys = append(s.DeletedRemoteKeys, deletedKey)
 	}
-	s.DeletedRemoteKeys = append(s.DeletedRemoteKeys, deletedKey)
 
 	return nil
 }

--- a/datastore/memory_contract_metadata_store_test.go
+++ b/datastore/memory_contract_metadata_store_test.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
@@ -73,11 +74,12 @@ func TestMemoryContractMetadataStore_Add(t *testing.T) {
 	)
 
 	tests := []struct {
-		name          string
-		givenState    []ContractMetadata
-		giveRecord    ContractMetadata
-		expectedState []ContractMetadata
-		expectedError error
+		name              string
+		givenState        []ContractMetadata
+		giveRecord        ContractMetadata
+		expectedState     []ContractMetadata
+		deletedRemoteKeys []string
+		expectedError     error
 	}{
 		{
 			name:       "success: adds new record",
@@ -95,13 +97,23 @@ func TestMemoryContractMetadataStore_Add(t *testing.T) {
 			giveRecord:    record,
 			expectedError: ErrContractMetadataExists,
 		},
+		{
+			name:              "success: add record that was staged for deletion",
+			givenState:        []ContractMetadata{},
+			deletedRemoteKeys: []string{record.Key().String()},
+			giveRecord:        record,
+			expectedState: []ContractMetadata{
+				record,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			store := MemoryContractMetadataStore{Records: tt.givenState}
+			store := MemoryContractMetadataStore{Records: tt.givenState, DeletedRemoteKeys: tt.deletedRemoteKeys}
+			assert.Len(t, store.DeletedRemoteKeys, len(tt.deletedRemoteKeys))
 			err := store.Add(tt.giveRecord)
 
 			if tt.expectedError != nil {
@@ -110,6 +122,7 @@ func TestMemoryContractMetadataStore_Add(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedState, store.Records)
+				assert.Empty(t, store.DeletedRemoteKeys)
 			}
 		})
 	}
@@ -133,10 +146,11 @@ func TestMemoryContractMetadataStore_Upsert(t *testing.T) {
 	)
 
 	tests := []struct {
-		name          string
-		givenState    []ContractMetadata
-		expectedState []ContractMetadata
-		giveRecord    ContractMetadata
+		name              string
+		givenState        []ContractMetadata
+		expectedState     []ContractMetadata
+		giveRecord        ContractMetadata
+		deletedRemoteKeys []string
 	}{
 		{
 			name:       "success: adds new record",
@@ -156,18 +170,29 @@ func TestMemoryContractMetadataStore_Upsert(t *testing.T) {
 				newRecord,
 			},
 		},
+		{
+			name:              "success: upsert record that was staged for deletion",
+			givenState:        []ContractMetadata{},
+			deletedRemoteKeys: []string{oldRecord.Key().String()},
+			giveRecord:        oldRecord,
+			expectedState: []ContractMetadata{
+				oldRecord,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			store := MemoryContractMetadataStore{Records: tt.givenState}
+			store := MemoryContractMetadataStore{Records: tt.givenState, DeletedRemoteKeys: tt.deletedRemoteKeys}
+			assert.Len(t, store.DeletedRemoteKeys, len(tt.deletedRemoteKeys))
 			// Check the error for the in-memory store, which will always be nil for the
 			// in memory implementation, to satisfy the linter
 			err := store.Upsert(tt.giveRecord)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedState, store.Records)
+			assert.Empty(t, store.DeletedRemoteKeys)
 		})
 	}
 }
@@ -190,11 +215,12 @@ func TestMemoryContractMetadataStore_Update(t *testing.T) {
 	)
 
 	tests := []struct {
-		name          string
-		givenState    []ContractMetadata
-		expectedState []ContractMetadata
-		giveRecord    ContractMetadata
-		expectedError error
+		name              string
+		givenState        []ContractMetadata
+		expectedState     []ContractMetadata
+		giveRecord        ContractMetadata
+		expectedError     error
+		deletedRemoteKeys []string
 	}{
 		{
 			name: "success: updates existing record",
@@ -212,13 +238,25 @@ func TestMemoryContractMetadataStore_Update(t *testing.T) {
 			giveRecord:    newRecord,
 			expectedError: ErrContractMetadataNotFound,
 		},
+		{
+			name: "success: update record that was staged for deletion",
+			givenState: []ContractMetadata{
+				oldRecord,
+			},
+			deletedRemoteKeys: []string{oldRecord.Key().String()},
+			giveRecord:        oldRecord,
+			expectedState: []ContractMetadata{
+				oldRecord,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			store := MemoryContractMetadataStore{Records: tt.givenState}
+			store := MemoryContractMetadataStore{Records: tt.givenState, DeletedRemoteKeys: tt.deletedRemoteKeys}
+			assert.Len(t, store.DeletedRemoteKeys, len(tt.deletedRemoteKeys))
 			err := store.Update(tt.giveRecord)
 
 			if tt.expectedError != nil {
@@ -227,6 +265,7 @@ func TestMemoryContractMetadataStore_Update(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedState, store.Records)
+				assert.Empty(t, store.DeletedRemoteKeys)
 			}
 		})
 	}
@@ -313,20 +352,22 @@ func TestMemoryContractMetadataStore_RemoteDelete(t *testing.T) {
 	t.Run("success: stages key in DeletedRemoteKeys without removing from Records", func(t *testing.T) {
 		t.Parallel()
 
-		store := MemoryContractMetadataStore{Records: []ContractMetadata{recordOne, recordTwo, recordThree}}
+		store := NewMemoryContractMetadataStore()
+		store.Records = append(store.Records, recordOne, recordTwo, recordThree)
 		require.Len(t, store.Records, 3)
 		require.Empty(t, store.DeletedRemoteKeys)
 		err := store.RemoteDelete(recordTwo.Key())
 		require.NoError(t, err)
 		require.Len(t, store.Records, 3)
 		require.Len(t, store.DeletedRemoteKeys, 1)
-		require.Equal(t, store.DeletedRemoteKeys[0], recordTwo.Key().String())
+		require.Contains(t, store.DeletedRemoteKeys, recordTwo.Key().String())
 	})
 
 	t.Run("success: second RemoteDelete does not duplicate entry", func(t *testing.T) {
 		t.Parallel()
 
-		store := MemoryContractMetadataStore{Records: []ContractMetadata{recordOne, recordTwo, recordThree}}
+		store := NewMemoryContractMetadataStore()
+		store.Records = append(store.Records, recordOne, recordTwo, recordThree)
 		require.NoError(t, store.RemoteDelete(recordTwo.Key()))
 		require.NoError(t, store.RemoteDelete(recordTwo.Key()))
 		require.Len(t, store.Records, 3)

--- a/datastore/memory_contract_metadata_store_test.go
+++ b/datastore/memory_contract_metadata_store_test.go
@@ -255,15 +255,14 @@ func TestMemoryMemoryContractMetadataStore_Delete(t *testing.T) {
 		}
 	)
 
-	t.Run("success: deletes given record and appends to DeletedKeys", func(t *testing.T) {
+	t.Run("success: deletes record from Records", func(t *testing.T) {
 		t.Parallel()
 
 		store := MemoryContractMetadataStore{Records: []ContractMetadata{recordOne, recordTwo, recordThree}}
 		err := store.Delete(recordTwo.Key())
 		require.NoError(t, err)
 		require.Equal(t, []ContractMetadata{recordOne, recordThree}, store.Records)
-		require.Len(t, store.DeletedKeys, 1)
-		require.True(t, store.DeletedKeys[0].Equals(recordTwo.Key()))
+		require.Empty(t, store.DeletedRemoteKeys)
 	})
 
 	t.Run("error: absent key returns ErrContractMetadataNotFound", func(t *testing.T) {
@@ -273,18 +272,65 @@ func TestMemoryMemoryContractMetadataStore_Delete(t *testing.T) {
 		err := store.Delete(recordTwo.Key())
 		require.ErrorIs(t, err, ErrContractMetadataNotFound)
 		require.Equal(t, []ContractMetadata{recordOne, recordThree}, store.Records)
-		require.Len(t, store.DeletedKeys, 0)
+		require.Empty(t, store.DeletedRemoteKeys)
 	})
 
-	t.Run("error: second Delete returns ErrContractMetadataNotFound, DeletedKeys unchanged", func(t *testing.T) {
+	t.Run("error: second Delete returns ErrContractMetadataNotFound", func(t *testing.T) {
 		t.Parallel()
 
 		store := MemoryContractMetadataStore{Records: []ContractMetadata{recordOne, recordTwo, recordThree}}
 		require.NoError(t, store.Delete(recordTwo.Key()))
-		require.Len(t, store.DeletedKeys, 1)
-		require.True(t, store.DeletedKeys[0].Equals(recordTwo.Key()))
+		require.Len(t, store.Records, 2)
 		require.ErrorIs(t, store.Delete(recordTwo.Key()), ErrContractMetadataNotFound)
-		require.Len(t, store.DeletedKeys, 1)
+		require.Len(t, store.Records, 2)
+		require.Empty(t, store.DeletedRemoteKeys)
+	})
+}
+
+func TestMemoryContractMetadataStore_RemoteDelete(t *testing.T) {
+	t.Parallel()
+
+	var (
+		recordOne = ContractMetadata{
+			ChainSelector: 1,
+			Address:       "0x2324224",
+			Metadata:      testMetadata{Field: "metadata1", ChainSelector: 0},
+		}
+
+		recordTwo = ContractMetadata{
+			ChainSelector: 2,
+			Address:       "0x2324224",
+			Metadata:      testMetadata{Field: "metadata2", ChainSelector: 0},
+		}
+
+		recordThree = ContractMetadata{
+			ChainSelector: 3,
+			Address:       "0x2324224",
+			Metadata:      testMetadata{Field: "metadata3", ChainSelector: 0},
+		}
+	)
+
+	t.Run("success: stages key in DeletedRemoteKeys without removing from Records", func(t *testing.T) {
+		t.Parallel()
+
+		store := MemoryContractMetadataStore{Records: []ContractMetadata{recordOne, recordTwo, recordThree}}
+		require.Len(t, store.Records, 3)
+		require.Empty(t, store.DeletedRemoteKeys)
+		err := store.RemoteDelete(recordTwo.Key())
+		require.NoError(t, err)
+		require.Len(t, store.Records, 3)
+		require.Len(t, store.DeletedRemoteKeys, 1)
+		require.Equal(t, store.DeletedRemoteKeys[0], recordTwo.Key().String())
+	})
+
+	t.Run("success: second RemoteDelete does not duplicate entry", func(t *testing.T) {
+		t.Parallel()
+
+		store := MemoryContractMetadataStore{Records: []ContractMetadata{recordOne, recordTwo, recordThree}}
+		require.NoError(t, store.RemoteDelete(recordTwo.Key()))
+		require.NoError(t, store.RemoteDelete(recordTwo.Key()))
+		require.Len(t, store.Records, 3)
+		require.Len(t, store.DeletedRemoteKeys, 1)
 	})
 }
 

--- a/datastore/memory_contract_metadata_store_test.go
+++ b/datastore/memory_contract_metadata_store_test.go
@@ -255,53 +255,37 @@ func TestMemoryMemoryContractMetadataStore_Delete(t *testing.T) {
 		}
 	)
 
-	tests := []struct {
-		name          string
-		givenState    []ContractMetadata
-		expectedState []ContractMetadata
-		giveKey       ContractMetadataKey
-		expectedError error
-	}{
-		{
-			name: "success: deletes given record",
-			givenState: []ContractMetadata{
-				recordOne,
-				recordTwo,
-				recordThree,
-			},
-			giveKey: recordTwo.Key(),
-			expectedState: []ContractMetadata{
-				recordOne,
-				recordThree,
-			},
-		},
-		{
-			name: "error: record not found",
-			givenState: []ContractMetadata{
-				recordOne,
-				recordThree,
-			},
-			giveKey:       recordTwo.Key(),
-			expectedError: ErrContractMetadataNotFound,
-		},
-	}
+	t.Run("success: deletes given record and appends to DeletedKeys", func(t *testing.T) {
+		t.Parallel()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		store := MemoryContractMetadataStore{Records: []ContractMetadata{recordOne, recordTwo, recordThree}}
+		err := store.Delete(recordTwo.Key())
+		require.NoError(t, err)
+		require.Equal(t, []ContractMetadata{recordOne, recordThree}, store.Records)
+		require.Len(t, store.DeletedKeys, 1)
+		require.True(t, store.DeletedKeys[0].Equals(recordTwo.Key()))
+	})
 
-			store := MemoryContractMetadataStore{Records: tt.givenState}
-			err := store.Delete(tt.giveKey)
+	t.Run("error: absent key returns ErrContractMetadataNotFound", func(t *testing.T) {
+		t.Parallel()
 
-			if tt.expectedError != nil {
-				require.Error(t, err)
-				require.Equal(t, tt.expectedError, err)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.expectedState, store.Records)
-			}
-		})
-	}
+		store := MemoryContractMetadataStore{Records: []ContractMetadata{recordOne, recordThree}}
+		err := store.Delete(recordTwo.Key())
+		require.ErrorIs(t, err, ErrContractMetadataNotFound)
+		require.Equal(t, []ContractMetadata{recordOne, recordThree}, store.Records)
+		require.Len(t, store.DeletedKeys, 0)
+	})
+
+	t.Run("error: second Delete returns ErrContractMetadataNotFound, DeletedKeys unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		store := MemoryContractMetadataStore{Records: []ContractMetadata{recordOne, recordTwo, recordThree}}
+		require.NoError(t, store.Delete(recordTwo.Key()))
+		require.Len(t, store.DeletedKeys, 1)
+		require.True(t, store.DeletedKeys[0].Equals(recordTwo.Key()))
+		require.ErrorIs(t, store.Delete(recordTwo.Key()), ErrContractMetadataNotFound)
+		require.Len(t, store.DeletedKeys, 1)
+	})
 }
 
 func TestMemoryContractMetadataStore_Fetch(t *testing.T) {

--- a/datastore/memory_datastore.go
+++ b/datastore/memory_datastore.go
@@ -1,6 +1,9 @@
 package datastore
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // MemoryDataStore is a concrete implementation of the MutableDataStore interface.
 var _ MutableDataStore = &MemoryDataStore{}
@@ -70,8 +73,12 @@ func (s *MemoryDataStore) Merge(other DataStore) error {
 
 	// Propagate address ref deletions
 	if src, ok := other.Addresses().(*MemoryAddressRefStore); ok {
-		for _, dk := range src.DeletedKeys {
-			if err = s.AddressRefStore.Delete(dk); err != nil && !errors.Is(err, ErrAddressRefNotFound) {
+		for _, dk := range src.DeletedRemoteKeys {
+			key, keyErr := NewAddressRefKeyFromString(dk)
+			if keyErr != nil {
+				return fmt.Errorf("failed to parse address ref key: %w", keyErr)
+			}
+			if err = s.AddressRefStore.Delete(key); err != nil {
 				return err
 			}
 		}
@@ -91,8 +98,12 @@ func (s *MemoryDataStore) Merge(other DataStore) error {
 
 	// Propagate chain metadata deletions
 	if src, ok := other.ChainMetadata().(*MemoryChainMetadataStore); ok {
-		for _, dk := range src.DeletedKeys {
-			if err = s.ChainMetadataStore.Delete(dk); err != nil && !errors.Is(err, ErrChainMetadataNotFound) {
+		for _, dk := range src.DeletedRemoteKeys {
+			key, keyErr := NewChainMetadataKeyFromString(dk)
+			if keyErr != nil {
+				return fmt.Errorf("failed to parse chain metadata key: %w", keyErr)
+			}
+			if err = s.ChainMetadataStore.Delete(key); err != nil {
 				return err
 			}
 		}
@@ -113,8 +124,12 @@ func (s *MemoryDataStore) Merge(other DataStore) error {
 
 	// Propagate contract metadata deletions
 	if src, ok := other.ContractMetadata().(*MemoryContractMetadataStore); ok {
-		for _, dk := range src.DeletedKeys {
-			if err = s.ContractMetadataStore.Delete(dk); err != nil && !errors.Is(err, ErrContractMetadataNotFound) {
+		for _, dk := range src.DeletedRemoteKeys {
+			key, keyErr := NewContractMetadataKeyFromString(dk)
+			if keyErr != nil {
+				return fmt.Errorf("failed to parse contract metadata key: %w", keyErr)
+			}
+			if err = s.ContractMetadataStore.Delete(key); err != nil {
 				return err
 			}
 		}

--- a/datastore/memory_datastore.go
+++ b/datastore/memory_datastore.go
@@ -55,14 +55,25 @@ func (s *MemoryDataStore) EnvMetadata() MutableEnvMetadataStore {
 
 // Merge merges the given mutable data store into the current MemoryDataStore.
 func (s *MemoryDataStore) Merge(other DataStore) error {
+	// Fetch address ref records from the other data store
 	addressRefs, err := other.Addresses().Fetch()
 	if err != nil {
 		return err
 	}
 
+	// Upsert address ref records into the current data store
 	for _, addressRef := range addressRefs {
 		if err = s.AddressRefStore.Upsert(addressRef); err != nil {
 			return err
+		}
+	}
+
+	// Propagate address ref deletions
+	if src, ok := other.Addresses().(*MemoryAddressRefStore); ok {
+		for _, dk := range src.DeletedKeys {
+			if err = s.AddressRefStore.Delete(dk); err != nil && !errors.Is(err, ErrAddressRefNotFound) {
+				return err
+			}
 		}
 	}
 
@@ -71,23 +82,45 @@ func (s *MemoryDataStore) Merge(other DataStore) error {
 		return err
 	}
 
+	// Upsert chain metadata records into the current data store
 	for _, record := range chainMetadataRecords {
 		if err = s.ChainMetadataStore.Upsert(record); err != nil {
 			return err
 		}
 	}
 
+	// Propagate chain metadata deletions
+	if src, ok := other.ChainMetadata().(*MemoryChainMetadataStore); ok {
+		for _, dk := range src.DeletedKeys {
+			if err = s.ChainMetadataStore.Delete(dk); err != nil && !errors.Is(err, ErrChainMetadataNotFound) {
+				return err
+			}
+		}
+	}
+
+	// Fetch contract metadata records from the other data store
 	contractMetadataRecords, err := other.ContractMetadata().Fetch()
 	if err != nil {
 		return err
 	}
 
+	// Upsert contract metadata records into the current data store
 	for _, record := range contractMetadataRecords {
 		if err = s.ContractMetadataStore.Upsert(record); err != nil {
 			return err
 		}
 	}
 
+	// Propagate contract metadata deletions
+	if src, ok := other.ContractMetadata().(*MemoryContractMetadataStore); ok {
+		for _, dk := range src.DeletedKeys {
+			if err = s.ContractMetadataStore.Delete(dk); err != nil && !errors.Is(err, ErrContractMetadataNotFound) {
+				return err
+			}
+		}
+	}
+
+	// Fetch env metadata record from the other data store
 	envMetadata, err := other.EnvMetadata().Get()
 	if err != nil {
 		if errors.Is(err, ErrEnvMetadataNotSet) {

--- a/datastore/memory_datastore_test.go
+++ b/datastore/memory_datastore_test.go
@@ -10,51 +10,59 @@ import (
 func TestMemoryDataStore_Merge(t *testing.T) {
 	t.Parallel()
 
+	var (
+		addressRefRecord = AddressRef{
+			Address:   "0x123",
+			Type:      "type1",
+			Version:   semver.MustParse("1.0.0"),
+			Qualifier: "qualifier1",
+		}
+		chainMetadataRecord = ChainMetadata{
+			ChainSelector: 1,
+			Metadata: testMetadata{
+				Field:         "test field",
+				ChainSelector: 1,
+			},
+		}
+		contractMetadataRecord = ContractMetadata{
+			Address:       "0x123",
+			ChainSelector: 2,
+			Metadata: testMetadata{
+				Field:         "another test field",
+				ChainSelector: 2,
+			},
+		}
+		envMetadataRecord = EnvMetadata{
+			Metadata: testMetadata{
+				Field:         "env test field",
+				ChainSelector: 1,
+			},
+		}
+	)
+
 	tests := []struct {
 		name                          string
 		setup                         func() (*MemoryDataStore, *MemoryDataStore)
 		expectedAddrRefsCount         int
 		excpectedChainMetadataCount   int
 		expectedContractMetadataCount int
+		expectedError                 error
 	}{
 		{
 			name: "Merge single address",
 			setup: func() (*MemoryDataStore, *MemoryDataStore) {
 				dataStore1 := NewMemoryDataStore()
 				dataStore2 := NewMemoryDataStore()
-				err := dataStore2.Addresses().Add(AddressRef{
-					Address:   "0x123",
-					Type:      "type1",
-					Version:   semver.MustParse("1.0.0"),
-					Qualifier: "qualifier1",
-				})
+				err := dataStore2.Addresses().Add(addressRefRecord)
 				require.NoError(t, err, "Adding data to dataStore2 should not fail")
 
-				err = dataStore2.ChainMetadata().Add(ChainMetadata{
-					ChainSelector: 1,
-					Metadata: testMetadata{
-						Field:         "test field",
-						ChainSelector: 1,
-					},
-				})
+				err = dataStore2.ChainMetadata().Add(chainMetadataRecord)
 				require.NoError(t, err, "Adding chain metadata to dataStore2 should not fail")
 
-				err = dataStore2.ContractMetadata().Add(ContractMetadata{
-					Address:       "0x123",
-					ChainSelector: 2,
-					Metadata: testMetadata{
-						Field:         "another test field",
-						ChainSelector: 2,
-					},
-				})
+				err = dataStore2.ContractMetadata().Add(contractMetadataRecord)
 				require.NoError(t, err, "Adding another chain metadata to dataStore2 should not fail")
 
-				err = dataStore2.EnvMetadata().Set(EnvMetadata{
-					Metadata: testMetadata{
-						Field:         "env test field",
-						ChainSelector: 1,
-					},
-				})
+				err = dataStore2.EnvMetadata().Set(envMetadataRecord)
 				require.NoError(t, err, "Adding env metadata to dataStore2 should not fail")
 
 				return dataStore1, dataStore2
@@ -64,59 +72,111 @@ func TestMemoryDataStore_Merge(t *testing.T) {
 			expectedContractMetadataCount: 1,
 		},
 		{
-			name: "Merge propagates deletions: delete wins over existing records",
+			name: "Merge deletions errors: delete address ref record that does not exist produces an error",
 			setup: func() (*MemoryDataStore, *MemoryDataStore) {
 				dataStore1 := NewMemoryDataStore()
 				dataStore2 := NewMemoryDataStore()
 
-				// dataStore1 has records A and B for each store
-				require.NoError(t, dataStore1.Addresses().Add(AddressRef{
-					Address: "0x111", Type: "typeA", Version: semver.MustParse("1.0.0"), Qualifier: "q",
-				}))
-				require.NoError(t, dataStore1.Addresses().Add(AddressRef{
-					Address: "0x222", Type: "typeB", Version: semver.MustParse("1.0.0"), Qualifier: "q",
-				}))
-				require.NoError(t, dataStore1.ChainMetadata().Add(ChainMetadata{
-					ChainSelector: 10, Metadata: testMetadata{Field: "a"},
-				}))
-				require.NoError(t, dataStore1.ChainMetadata().Add(ChainMetadata{
-					ChainSelector: 20, Metadata: testMetadata{Field: "b"},
-				}))
-				require.NoError(t, dataStore1.ContractMetadata().Add(ContractMetadata{
-					ChainSelector: 10, Address: "0x111", Metadata: testMetadata{Field: "a"},
-				}))
-				require.NoError(t, dataStore1.ContractMetadata().Add(ContractMetadata{
-					ChainSelector: 20, Address: "0x222", Metadata: testMetadata{Field: "b"},
-				}))
-				require.NoError(t, dataStore1.EnvMetadata().Set(EnvMetadata{
-					Metadata: testMetadata{Field: "env"},
-				}))
+				err := dataStore1.Addresses().Add(addressRefRecord)
+				require.NoError(t, err, "Adding data to dataStore2 should not fail")
 
-				// dataStore2 deletes key A from each store (key A is not in dataStore2's Records)
-				require.NoError(t, dataStore2.Addresses().Delete(NewAddressRefKey(0, "typeA", semver.MustParse("1.0.0"), "q")))
-				require.NoError(t, dataStore2.ChainMetadata().Delete(NewChainMetadataKey(10)))
-				require.NoError(t, dataStore2.ContractMetadata().Delete(NewContractMetadataKey(10, "0x111")))
+				err = dataStore1.ChainMetadata().Add(chainMetadataRecord)
+				require.NoError(t, err, "Adding chain metadata to dataStore2 should not fail")
+
+				err = dataStore1.ContractMetadata().Add(contractMetadataRecord)
+				require.NoError(t, err, "Adding another chain metadata to dataStore2 should not fail")
+
+				err = dataStore1.EnvMetadata().Set(envMetadataRecord)
+				require.NoError(t, err, "Adding env metadata to dataStore2 should not fail")
+
+				// dataStore2 stages a record for deletion that does not exist in dataStore1
+				require.NoError(t, dataStore2.Addresses().RemoteDelete(NewAddressRefKey(0, "typeA", semver.MustParse("1.0.0"), "q")))
 
 				return dataStore1, dataStore2
 			},
 			expectedAddrRefsCount:         1,
 			excpectedChainMetadataCount:   1,
 			expectedContractMetadataCount: 1,
+			expectedError:                 ErrAddressRefNotFound,
 		},
 		{
-			name: "Merge propagates deletions: delete of non-existent key is a no-op",
+			name: "Merge deletions errors: delete chain metadata record that does not exist produces an error",
 			setup: func() (*MemoryDataStore, *MemoryDataStore) {
 				dataStore1 := NewMemoryDataStore()
 				dataStore2 := NewMemoryDataStore()
 
-				// dataStore1 is empty; dataStore2 deletes a key that was never in dataStore1
-				require.NoError(t, dataStore2.Addresses().Delete(NewAddressRefKey(0, "typeA", semver.MustParse("1.0.0"), "q")))
-				require.NoError(t, dataStore2.ChainMetadata().Delete(NewChainMetadataKey(10)))
-				require.NoError(t, dataStore2.ContractMetadata().Delete(NewContractMetadataKey(10, "0x111")))
+				err := dataStore1.Addresses().Add(addressRefRecord)
+				require.NoError(t, err, "Adding data to dataStore2 should not fail")
 
-				require.NoError(t, dataStore1.EnvMetadata().Set(EnvMetadata{
-					Metadata: testMetadata{Field: "env"},
-				}))
+				err = dataStore1.ChainMetadata().Add(chainMetadataRecord)
+				require.NoError(t, err, "Adding chain metadata to dataStore2 should not fail")
+
+				err = dataStore1.ContractMetadata().Add(contractMetadataRecord)
+				require.NoError(t, err, "Adding another chain metadata to dataStore2 should not fail")
+
+				err = dataStore1.EnvMetadata().Set(envMetadataRecord)
+				require.NoError(t, err, "Adding env metadata to dataStore2 should not fail")
+
+				// dataStore2 stages a record for deletion that does not exist in dataStore1
+				require.NoError(t, dataStore2.ChainMetadata().RemoteDelete(NewChainMetadataKey(10)))
+
+				return dataStore1, dataStore2
+			},
+			expectedAddrRefsCount:         1,
+			excpectedChainMetadataCount:   1,
+			expectedContractMetadataCount: 1,
+			expectedError:                 ErrChainMetadataNotFound,
+		},
+		{
+			name: "Merge deletions errors: delete contract metadata record that does not exist produces an error",
+			setup: func() (*MemoryDataStore, *MemoryDataStore) {
+				dataStore1 := NewMemoryDataStore()
+				dataStore2 := NewMemoryDataStore()
+
+				err := dataStore1.Addresses().Add(addressRefRecord)
+				require.NoError(t, err, "Adding data to dataStore2 should not fail")
+
+				err = dataStore1.ChainMetadata().Add(chainMetadataRecord)
+				require.NoError(t, err, "Adding chain metadata to dataStore2 should not fail")
+
+				err = dataStore1.ContractMetadata().Add(contractMetadataRecord)
+				require.NoError(t, err, "Adding another chain metadata to dataStore2 should not fail")
+
+				err = dataStore1.EnvMetadata().Set(envMetadataRecord)
+				require.NoError(t, err, "Adding env metadata to dataStore2 should not fail")
+
+				// dataStore2 stages a record for deletion that does not exist in dataStore1
+				require.NoError(t, dataStore2.ContractMetadata().RemoteDelete(NewContractMetadataKey(10, "0x111")))
+
+				return dataStore1, dataStore2
+			},
+			expectedAddrRefsCount:         1,
+			excpectedChainMetadataCount:   1,
+			expectedContractMetadataCount: 1,
+			expectedError:                 ErrContractMetadataNotFound,
+		},
+		{
+			name: "Merge propagete deletions: deletes record from remote data store",
+			setup: func() (*MemoryDataStore, *MemoryDataStore) {
+				dataStore1 := NewMemoryDataStore()
+				dataStore2 := NewMemoryDataStore()
+
+				err := dataStore1.Addresses().Add(addressRefRecord)
+				require.NoError(t, err, "Adding data to dataStore2 should not fail")
+
+				err = dataStore1.ChainMetadata().Add(chainMetadataRecord)
+				require.NoError(t, err, "Adding chain metadata to dataStore2 should not fail")
+
+				err = dataStore1.ContractMetadata().Add(contractMetadataRecord)
+				require.NoError(t, err, "Adding another chain metadata to dataStore2 should not fail")
+
+				err = dataStore1.EnvMetadata().Set(envMetadataRecord)
+				require.NoError(t, err, "Adding env metadata to dataStore2 should not fail")
+
+				// dataStore2 stages a record for deletion that does not exist in dataStore1
+				require.NoError(t, dataStore2.Addresses().RemoteDelete(addressRefRecord.Key()))
+				require.NoError(t, dataStore2.ChainMetadata().RemoteDelete(chainMetadataRecord.Key()))
+				require.NoError(t, dataStore2.ContractMetadata().RemoteDelete(contractMetadataRecord.Key()))
 
 				return dataStore1, dataStore2
 			},
@@ -192,8 +252,13 @@ func TestMemoryDataStore_Merge(t *testing.T) {
 			dataStore1, dataStore2 := tt.setup()
 
 			// Merge dataStore2 into dataStore1
-			err := dataStore1.Merge(dataStore2.Seal())
-			require.NoError(t, err, "Merging dataStore2 into dataStore1 should not fail")
+			if tt.expectedError != nil {
+				err := dataStore1.Merge(dataStore2.Seal())
+				require.ErrorIs(t, err, tt.expectedError, "Merging dataStore2 into dataStore1 should return the expected error")
+			} else {
+				err := dataStore1.Merge(dataStore2.Seal())
+				require.NoError(t, err, "Merging dataStore2 into dataStore1 should not fail")
+			}
 
 			// Verify that dataStore1 contains the merged data
 			addressRefs, err := dataStore1.Addresses().Fetch()

--- a/datastore/memory_datastore_test.go
+++ b/datastore/memory_datastore_test.go
@@ -78,16 +78,16 @@ func TestMemoryDataStore_Merge(t *testing.T) {
 				dataStore2 := NewMemoryDataStore()
 
 				err := dataStore1.Addresses().Add(addressRefRecord)
-				require.NoError(t, err, "Adding data to dataStore2 should not fail")
+				require.NoError(t, err, "Adding data to dataStore1 should not fail")
 
 				err = dataStore1.ChainMetadata().Add(chainMetadataRecord)
-				require.NoError(t, err, "Adding chain metadata to dataStore2 should not fail")
+				require.NoError(t, err, "Adding chain metadata to dataStore1 should not fail")
 
 				err = dataStore1.ContractMetadata().Add(contractMetadataRecord)
-				require.NoError(t, err, "Adding another chain metadata to dataStore2 should not fail")
+				require.NoError(t, err, "Adding another chain metadata to dataStore1 should not fail")
 
 				err = dataStore1.EnvMetadata().Set(envMetadataRecord)
-				require.NoError(t, err, "Adding env metadata to dataStore2 should not fail")
+				require.NoError(t, err, "Adding env metadata to dataStore1 should not fail")
 
 				// dataStore2 stages a record for deletion that does not exist in dataStore1
 				require.NoError(t, dataStore2.Addresses().RemoteDelete(NewAddressRefKey(0, "typeA", semver.MustParse("1.0.0"), "q")))

--- a/datastore/memory_datastore_test.go
+++ b/datastore/memory_datastore_test.go
@@ -64,6 +64,67 @@ func TestMemoryDataStore_Merge(t *testing.T) {
 			expectedContractMetadataCount: 1,
 		},
 		{
+			name: "Merge propagates deletions: delete wins over existing records",
+			setup: func() (*MemoryDataStore, *MemoryDataStore) {
+				dataStore1 := NewMemoryDataStore()
+				dataStore2 := NewMemoryDataStore()
+
+				// dataStore1 has records A and B for each store
+				require.NoError(t, dataStore1.Addresses().Add(AddressRef{
+					Address: "0x111", Type: "typeA", Version: semver.MustParse("1.0.0"), Qualifier: "q",
+				}))
+				require.NoError(t, dataStore1.Addresses().Add(AddressRef{
+					Address: "0x222", Type: "typeB", Version: semver.MustParse("1.0.0"), Qualifier: "q",
+				}))
+				require.NoError(t, dataStore1.ChainMetadata().Add(ChainMetadata{
+					ChainSelector: 10, Metadata: testMetadata{Field: "a"},
+				}))
+				require.NoError(t, dataStore1.ChainMetadata().Add(ChainMetadata{
+					ChainSelector: 20, Metadata: testMetadata{Field: "b"},
+				}))
+				require.NoError(t, dataStore1.ContractMetadata().Add(ContractMetadata{
+					ChainSelector: 10, Address: "0x111", Metadata: testMetadata{Field: "a"},
+				}))
+				require.NoError(t, dataStore1.ContractMetadata().Add(ContractMetadata{
+					ChainSelector: 20, Address: "0x222", Metadata: testMetadata{Field: "b"},
+				}))
+				require.NoError(t, dataStore1.EnvMetadata().Set(EnvMetadata{
+					Metadata: testMetadata{Field: "env"},
+				}))
+
+				// dataStore2 deletes key A from each store (key A is not in dataStore2's Records)
+				require.NoError(t, dataStore2.Addresses().Delete(NewAddressRefKey(0, "typeA", semver.MustParse("1.0.0"), "q")))
+				require.NoError(t, dataStore2.ChainMetadata().Delete(NewChainMetadataKey(10)))
+				require.NoError(t, dataStore2.ContractMetadata().Delete(NewContractMetadataKey(10, "0x111")))
+
+				return dataStore1, dataStore2
+			},
+			expectedAddrRefsCount:         1,
+			excpectedChainMetadataCount:   1,
+			expectedContractMetadataCount: 1,
+		},
+		{
+			name: "Merge propagates deletions: delete of non-existent key is a no-op",
+			setup: func() (*MemoryDataStore, *MemoryDataStore) {
+				dataStore1 := NewMemoryDataStore()
+				dataStore2 := NewMemoryDataStore()
+
+				// dataStore1 is empty; dataStore2 deletes a key that was never in dataStore1
+				require.NoError(t, dataStore2.Addresses().Delete(NewAddressRefKey(0, "typeA", semver.MustParse("1.0.0"), "q")))
+				require.NoError(t, dataStore2.ChainMetadata().Delete(NewChainMetadataKey(10)))
+				require.NoError(t, dataStore2.ContractMetadata().Delete(NewContractMetadataKey(10, "0x111")))
+
+				require.NoError(t, dataStore1.EnvMetadata().Set(EnvMetadata{
+					Metadata: testMetadata{Field: "env"},
+				}))
+
+				return dataStore1, dataStore2
+			},
+			expectedAddrRefsCount:         0,
+			excpectedChainMetadataCount:   0,
+			expectedContractMetadataCount: 0,
+		},
+		{
 			name: "Match existing address with labels",
 			setup: func() (*MemoryDataStore, *MemoryDataStore) {
 				dataStore1 := NewMemoryDataStore()

--- a/datastore/memory_datastore_test.go
+++ b/datastore/memory_datastore_test.go
@@ -156,7 +156,7 @@ func TestMemoryDataStore_Merge(t *testing.T) {
 			expectedError:                 ErrContractMetadataNotFound,
 		},
 		{
-			name: "Merge propagete deletions: deletes record from remote data store",
+			name: "Merge propagate deletions: deletes record from remote data store",
 			setup: func() (*MemoryDataStore, *MemoryDataStore) {
 				dataStore1 := NewMemoryDataStore()
 				dataStore2 := NewMemoryDataStore()

--- a/datastore/utils.go
+++ b/datastore/utils.go
@@ -1,0 +1,13 @@
+package datastore
+
+import "slices"
+
+// deleteFromSlice deletes the first occurrence of item from the slice.
+// If item is not found, the slice is returned unchanged.
+func deleteFromSlice[T comparable](slice []T, item T) []T {
+	if idx := slices.Index(slice, item); idx != -1 {
+		return slices.Delete(slice, idx, idx+1)
+	}
+
+	return slice
+}

--- a/datastore/utils_test.go
+++ b/datastore/utils_test.go
@@ -1,0 +1,51 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_deleteFromSlice(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		slice []string
+		item  string
+		want  []string
+	}{
+		{
+			name:  "remove first of one match at index zero",
+			slice: []string{"a", "b", "c"},
+			item:  "a",
+			want:  []string{"b", "c"},
+		},
+		{
+			name:  "remove first of two matches",
+			slice: []string{"a", "b", "a", "c"},
+			item:  "a",
+			want:  []string{"b", "a", "c"},
+		},
+		{
+			name:  "remove last of one match",
+			slice: []string{"a", "b", "c"},
+			item:  "c",
+			want:  []string{"a", "b"},
+		},
+		{
+			name:  "remove none",
+			slice: []string{"a", "b", "a", "c"},
+			item:  "d",
+			want:  []string{"a", "b", "a", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := deleteFromSlice(tt.slice, tt.item)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/engine/cld/domain/envdir_test.go
+++ b/engine/cld/domain/envdir_test.go
@@ -722,6 +722,11 @@ func Test_EnvDir_MergeChangesetDataStore(t *testing.T) {
 	err = mergeDatastore.Merge(dataStore2.Seal())
 	require.NoError(t, err)
 
+	deletionDatastore := fdatastore.NewMemoryDataStore()
+
+	err = deletionDatastore.Merge(dataStore2.Seal())
+	require.NoError(t, err)
+
 	tests := []struct {
 		name              string
 		beforeFunc        func(*testing.T, EnvDir)
@@ -797,6 +802,45 @@ func Test_EnvDir_MergeChangesetDataStore(t *testing.T) {
 			},
 			giveChangesetName: "durable_pipeline",
 			want:              mergeDatastore.Seal(),
+		},
+		{
+			name: "success with merging datastore that deletes an existing record",
+			beforeFunc: func(t *testing.T, envdir EnvDir) {
+				t.Helper()
+
+				// Populate the env dir with dataStore1
+				arts := envdir.ArtifactsDir()
+				err := arts.SaveChangesetOutput("0001_initial", fdeployment.ChangesetOutput{
+					DataStore: dataStore1,
+				})
+				require.NoError(t, err)
+
+				err = envdir.MergeChangesetDataStore("0001_initial", "")
+				require.NoError(t, err)
+
+				// Populate the env dir with dataStore2
+				err = arts.SaveChangesetOutput("0002_initial", fdeployment.ChangesetOutput{
+					DataStore: dataStore2,
+				})
+				require.NoError(t, err)
+
+				err = envdir.MergeChangesetDataStore("0002_initial", "")
+				require.NoError(t, err)
+
+				// Create a changeset that stages the dataStore1 record for remote deletion
+				deletionStore := fdatastore.NewMemoryDataStore()
+				addresses, err := dataStore1.Addresses().Fetch()
+				require.NoError(t, err)
+				err = deletionStore.Addresses().RemoteDelete(addresses[0].Key())
+				require.NoError(t, err)
+
+				err = arts.SaveChangesetOutput("0002_deletion", fdeployment.ChangesetOutput{
+					DataStore: deletionStore,
+				})
+				require.NoError(t, err)
+			},
+			giveChangesetName: "0002_deletion",
+			want:              deletionDatastore.Seal(),
 		},
 		{
 			name: "success skips with no changeset datastore found",


### PR DESCRIPTION
# CLD-2058: Add in memory and file catalog deletes

- Adds Deletions keys for `AddressRef`, `ChainMetadata` and `ContractMetadata`
- Remove deleted records and save keys for later removing them from catalog
- Add a Method that can convert the deletion key string to a private `keyRef` to avoid exposing the struct  and allow for key deletions.
- During merge, ensure that after the two datastores are merged, we call delete for any key that is marked for deletion. 
- If a key does not exist and we try to delete it return a not found error informing the user about a potential bug in their changeset or wrong input. 


## Example

Directly delete from in-memory datastore in a changeset (only changeset related contract deployments available). This instanyl

```
	dataStore.Addresses().Delete(ds.AddressRefKey{
		ChainSelector: chainSelector,
		Type:          "LinkToken",
		Version:       semver.MustParse("1.0.0"),
		Qualifier:     "LinkTokenContractV1_" + addr.String(),
	})
```

Staging a file for deletion for a file that exists in the inflated datastore (remote datastore either backed by file or catalog).

```
 # Fetch all addresses
	addresses, err := e.DataStore.Addresses().Fetch()
	if err != nil {
		return cldf.ChangesetOutput{},
			fmt.Errorf("failed to fetch addresses: %w", err)
	}

# Find specific address 
	for _, address := range addresses {
		if address.Address == "0x123" {
# Stage the deletion for a later step (during merge)
			dataStore.Addresses().RemoteDelete(address.Key())
		}
	}
