### PR TITLE
feat: port timelockconfig to cldf

### DIFF
--- a/.changeset/curvy-readers-hammer.md
+++ b/.changeset/curvy-readers-hammer.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+port TimelockConfig to MCMS proposalutils

--- a/engine/cld/mcms/proposalutils/timelock_config.go
+++ b/engine/cld/mcms/proposalutils/timelock_config.go
@@ -1,0 +1,197 @@
+package proposalutils
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/gagliardetto/solana-go"
+	ownerhelpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
+	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+
+	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	mcmscontracts "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/contracts/mcms"
+)
+
+// EVMMCMSWithTimelock adapts EVM MCMS-with-timelock state for TimelockConfig helpers.
+type EVMMCMSWithTimelock interface {
+	TimelockContracts() MCMSWithTimelockContracts
+}
+
+// SolanaMCMSWithTimelock adapts Solana MCMS-with-timelock state for TimelockConfig helpers.
+type SolanaMCMSWithTimelock interface {
+	TimelockPrograms() MCMSWithTimelockPrograms
+}
+
+// MCMSWithTimelockPrograms holds the Solana program and PDA seed values needed to resolve MCMS role addresses.
+type MCMSWithTimelockPrograms struct {
+	McmProgram       solana.PublicKey
+	ProposerMcmSeed  mcmssolanasdk.PDASeed
+	CancellerMcmSeed mcmssolanasdk.PDASeed
+	BypasserMcmSeed  mcmssolanasdk.PDASeed
+}
+
+// TimelockConfig configures MCMS timelock proposal behavior.
+type TimelockConfig struct {
+	MinDelay                  time.Duration            `json:"minDelay"` // delay for timelock worker to execute the transfers.
+	MCMSAction                mcmstypes.TimelockAction `json:"mcmsAction"`
+	OverrideRoot              bool                     `json:"overrideRoot"`                        // if true, override the previous root with the new one.
+	TimelockQualifierPerChain map[uint64]string        `json:"timelockQualifierPerChain,omitempty"` // optional qualifier to fetch timelock address from datastore
+	ValidDuration             *mcmstypes.Duration      `json:"validDuration" yaml:"validDuration"`
+}
+
+func (tc *TimelockConfig) MCMBasedOnActionSolana(s SolanaMCMSWithTimelock) (string, error) {
+	// if MCMSAction is not set, default to timelock.Schedule, this is to ensure no breaking changes for existing code
+	if tc.MCMSAction == "" {
+		tc.MCMSAction = mcmstypes.TimelockActionSchedule
+	}
+
+	programs := s.TimelockPrograms()
+	switch tc.MCMSAction {
+	case mcmstypes.TimelockActionSchedule:
+		return mcmssolanasdk.ContractAddress(programs.McmProgram, programs.ProposerMcmSeed), nil
+	case mcmstypes.TimelockActionCancel:
+		return mcmssolanasdk.ContractAddress(programs.McmProgram, programs.CancellerMcmSeed), nil
+	case mcmstypes.TimelockActionBypass:
+		return mcmssolanasdk.ContractAddress(programs.McmProgram, programs.BypasserMcmSeed), nil
+	default:
+		return "", errors.New("invalid MCMS action")
+	}
+}
+
+func (tc *TimelockConfig) MCMBasedOnAction(s EVMMCMSWithTimelock) (*ownerhelpers.ManyChainMultiSig, error) {
+	// if MCMSAction is not set, default to timelock.Schedule, this is to ensure no breaking changes for existing code
+	if tc.MCMSAction == "" {
+		tc.MCMSAction = mcmstypes.TimelockActionSchedule
+	}
+
+	contracts := s.TimelockContracts()
+	switch tc.MCMSAction {
+	case mcmstypes.TimelockActionSchedule:
+		if contracts.ProposerMcm == nil {
+			return nil, errors.New("missing proposerMcm")
+		}
+
+		return contracts.ProposerMcm, nil
+	case mcmstypes.TimelockActionCancel:
+		if contracts.CancellerMcm == nil {
+			return nil, errors.New("missing cancellerMcm")
+		}
+
+		return contracts.CancellerMcm, nil
+	case mcmstypes.TimelockActionBypass:
+		if contracts.BypasserMcm == nil {
+			return nil, errors.New("missing bypasserMcm")
+		}
+
+		return contracts.BypasserMcm, nil
+	default:
+		return nil, errors.New("invalid MCMS action")
+	}
+}
+
+func (tc *TimelockConfig) validateCommon() error {
+	// if MCMSAction is not set, default to timelock.Schedule
+	if tc.MCMSAction == "" {
+		tc.MCMSAction = mcmstypes.TimelockActionSchedule
+	}
+	if tc.MCMSAction != mcmstypes.TimelockActionSchedule &&
+		tc.MCMSAction != mcmstypes.TimelockActionCancel &&
+		tc.MCMSAction != mcmstypes.TimelockActionBypass {
+		return fmt.Errorf("invalid MCMS type %s", tc.MCMSAction)
+	}
+
+	return nil
+}
+
+func (tc *TimelockConfig) Validate(chain cldf_evm.Chain, s EVMMCMSWithTimelock) error {
+	err := tc.validateCommon()
+	if err != nil {
+		return err
+	}
+
+	contracts := s.TimelockContracts()
+	if contracts.Timelock == nil {
+		return fmt.Errorf("missing timelock on %s", chain)
+	}
+	if tc.MCMSAction == mcmstypes.TimelockActionSchedule && contracts.ProposerMcm == nil {
+		return fmt.Errorf("missing proposerMcm on %s", chain)
+	}
+	if tc.MCMSAction == mcmstypes.TimelockActionCancel && contracts.CancellerMcm == nil {
+		return fmt.Errorf("missing cancellerMcm on %s", chain)
+	}
+	if tc.MCMSAction == mcmstypes.TimelockActionBypass && contracts.BypasserMcm == nil {
+		return fmt.Errorf("missing bypasserMcm on %s", chain)
+	}
+	if contracts.Timelock == nil {
+		return fmt.Errorf("missing timelock on %s", chain)
+	}
+	if contracts.CallProxy == nil {
+		return fmt.Errorf("missing callProxy on %s", chain)
+	}
+
+	return nil
+}
+
+func (tc *TimelockConfig) ValidateSolana(e cldf.Environment, chainSelector uint64) error {
+	err := tc.validateCommon()
+	if err != nil {
+		return err
+	}
+
+	validateContract := func(contractType cldf.ContractType) error {
+		timelockID, searchErr := cldf.SearchAddressBook(e.ExistingAddresses, chainSelector, contractType) //nolint:staticcheck // preserve AddressBook compatibility from the core helper.
+		if searchErr != nil {
+			return fmt.Errorf("%s not present on the chain %w", contractType, searchErr)
+		}
+		// Make sure addresses are correctly parsed. Format is: "programID.PDASeed"
+		_, _, parseErr := mcmssolanasdk.ParseContractAddress(timelockID)
+		if parseErr != nil {
+			return fmt.Errorf("failed to parse timelock address: %w", parseErr)
+		}
+
+		return nil
+	}
+
+	err = validateContract(mcmscontracts.RBACTimelock)
+	if err != nil {
+		return err
+	}
+
+	switch tc.MCMSAction {
+	case mcmstypes.TimelockActionSchedule:
+		err = validateContract(mcmscontracts.ProposerManyChainMultisig)
+		if err != nil {
+			return err
+		}
+	case mcmstypes.TimelockActionCancel:
+		err = validateContract(mcmscontracts.CancellerManyChainMultisig)
+		if err != nil {
+			return err
+		}
+	case mcmstypes.TimelockActionBypass:
+		err = validateContract(mcmscontracts.BypasserManyChainMultisig)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("invalid MCMS action %s", tc.MCMSAction)
+	}
+
+	return nil
+}
+
+func (tc *TimelockConfig) ValidateAptos(chain cldf_aptos.Chain, mcmsAddress aptos.AccountAddress) error {
+	if err := tc.validateCommon(); err != nil {
+		return err
+	}
+	if mcmsAddress == (aptos.AccountAddress{}) {
+		return fmt.Errorf("aptos MCMS contract not present on chain %s", chain)
+	}
+
+	return nil
+}

--- a/engine/cld/mcms/proposalutils/timelock_config_test.go
+++ b/engine/cld/mcms/proposalutils/timelock_config_test.go
@@ -1,0 +1,215 @@
+package proposalutils
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/aptos-labs/aptos-go-sdk"
+	"github.com/gagliardetto/solana-go"
+	ownerhelpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/require"
+
+	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	mcmscontracts "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/contracts/mcms"
+)
+
+type stubEVMState struct {
+	contracts MCMSWithTimelockContracts
+}
+
+func (s stubEVMState) TimelockContracts() MCMSWithTimelockContracts {
+	return s.contracts
+}
+
+type stubSolanaState struct {
+	programs MCMSWithTimelockPrograms
+}
+
+func (s stubSolanaState) TimelockPrograms() MCMSWithTimelockPrograms {
+	return s.programs
+}
+
+func TestTimelockConfigMCMBasedOnActionDefaultsToSchedule(t *testing.T) {
+	t.Parallel()
+
+	cfg := TimelockConfig{}
+	proposer := &ownerhelpers.ManyChainMultiSig{}
+
+	got, err := cfg.MCMBasedOnAction(stubEVMState{
+		contracts: MCMSWithTimelockContracts{ProposerMcm: proposer},
+	})
+
+	require.NoError(t, err)
+	require.Same(t, proposer, got)
+	require.Equal(t, mcmstypes.TimelockActionSchedule, cfg.MCMSAction)
+}
+
+func TestTimelockConfigMCMBasedOnActionSelectsRole(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		action    mcmstypes.TimelockAction
+		contracts MCMSWithTimelockContracts
+		want      func(MCMSWithTimelockContracts) *ownerhelpers.ManyChainMultiSig
+	}{
+		{
+			name:      "schedule",
+			action:    mcmstypes.TimelockActionSchedule,
+			contracts: MCMSWithTimelockContracts{ProposerMcm: &ownerhelpers.ManyChainMultiSig{}},
+			want:      func(c MCMSWithTimelockContracts) *ownerhelpers.ManyChainMultiSig { return c.ProposerMcm },
+		},
+		{
+			name:      "cancel",
+			action:    mcmstypes.TimelockActionCancel,
+			contracts: MCMSWithTimelockContracts{CancellerMcm: &ownerhelpers.ManyChainMultiSig{}},
+			want:      func(c MCMSWithTimelockContracts) *ownerhelpers.ManyChainMultiSig { return c.CancellerMcm },
+		},
+		{
+			name:      "bypass",
+			action:    mcmstypes.TimelockActionBypass,
+			contracts: MCMSWithTimelockContracts{BypasserMcm: &ownerhelpers.ManyChainMultiSig{}},
+			want:      func(c MCMSWithTimelockContracts) *ownerhelpers.ManyChainMultiSig { return c.BypasserMcm },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := TimelockConfig{MCMSAction: tt.action}
+
+			got, err := cfg.MCMBasedOnAction(stubEVMState{contracts: tt.contracts})
+
+			require.NoError(t, err)
+			require.Same(t, tt.want(tt.contracts), got)
+		})
+	}
+}
+
+func TestTimelockConfigMCMBasedOnActionErrorsOnMissingRole(t *testing.T) {
+	t.Parallel()
+
+	cfg := TimelockConfig{MCMSAction: mcmstypes.TimelockActionCancel}
+
+	_, err := cfg.MCMBasedOnAction(stubEVMState{})
+
+	require.EqualError(t, err, "missing cancellerMcm")
+}
+
+func TestTimelockConfigMCMBasedOnActionSolanaSelectsRole(t *testing.T) {
+	t.Parallel()
+
+	program := solana.NewWallet().PublicKey()
+	programs := MCMSWithTimelockPrograms{
+		McmProgram:       program,
+		ProposerMcmSeed:  mcmssolanasdk.PDASeed([32]byte{1}),
+		CancellerMcmSeed: mcmssolanasdk.PDASeed([32]byte{2}),
+		BypasserMcmSeed:  mcmssolanasdk.PDASeed([32]byte{3}),
+	}
+
+	tests := []struct {
+		name   string
+		action mcmstypes.TimelockAction
+		want   string
+	}{
+		{
+			name:   "schedule",
+			action: mcmstypes.TimelockActionSchedule,
+			want:   mcmssolanasdk.ContractAddress(program, programs.ProposerMcmSeed),
+		},
+		{
+			name:   "cancel",
+			action: mcmstypes.TimelockActionCancel,
+			want:   mcmssolanasdk.ContractAddress(program, programs.CancellerMcmSeed),
+		},
+		{
+			name:   "bypass",
+			action: mcmstypes.TimelockActionBypass,
+			want:   mcmssolanasdk.ContractAddress(program, programs.BypasserMcmSeed),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := TimelockConfig{MCMSAction: tt.action}
+
+			got, err := cfg.MCMBasedOnActionSolana(stubSolanaState{programs: programs})
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTimelockConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	chain := cldf_evm.Chain{Selector: chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector}
+	cfg := TimelockConfig{}
+
+	err := cfg.Validate(chain, stubEVMState{
+		contracts: MCMSWithTimelockContracts{
+			ProposerMcm: &ownerhelpers.ManyChainMultiSig{},
+			Timelock:    &ownerhelpers.RBACTimelock{},
+			CallProxy:   &ownerhelpers.CallProxy{},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, mcmstypes.TimelockActionSchedule, cfg.MCMSAction)
+}
+
+func TestTimelockConfigValidateErrorsOnMissingCallProxy(t *testing.T) {
+	t.Parallel()
+
+	chain := cldf_evm.Chain{Selector: chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector}
+	cfg := TimelockConfig{}
+
+	err := cfg.Validate(chain, stubEVMState{
+		contracts: MCMSWithTimelockContracts{
+			ProposerMcm: &ownerhelpers.ManyChainMultiSig{},
+			Timelock:    &ownerhelpers.RBACTimelock{},
+		},
+	})
+
+	require.ErrorContains(t, err, "missing callProxy")
+}
+
+func TestTimelockConfigValidateSolana(t *testing.T) {
+	t.Parallel()
+
+	ab := cldf.NewMemoryAddressBook()
+	version := *semver.MustParse("1.0.0")
+	chainSelector := chainsel.SOLANA_DEVNET.Selector
+	program := solana.NewWallet().PublicKey()
+
+	require.NoError(t, ab.Save(chainSelector, mcmssolanasdk.ContractAddress(program, mcmssolanasdk.PDASeed([32]byte{1})), cldf.NewTypeAndVersion(mcmscontracts.RBACTimelock, version)))
+	require.NoError(t, ab.Save(chainSelector, mcmssolanasdk.ContractAddress(program, mcmssolanasdk.PDASeed([32]byte{2})), cldf.NewTypeAndVersion(mcmscontracts.ProposerManyChainMultisig, version)))
+
+	cfg := TimelockConfig{}
+	err := cfg.ValidateSolana(cldf.Environment{ExistingAddresses: ab}, chainSelector)
+
+	require.NoError(t, err)
+	require.Equal(t, mcmstypes.TimelockActionSchedule, cfg.MCMSAction)
+}
+
+func TestTimelockConfigValidateAptos(t *testing.T) {
+	t.Parallel()
+
+	cfg := TimelockConfig{}
+	var addr aptos.AccountAddress
+
+	require.NoError(t, addr.ParseStringRelaxed("0x1"))
+	require.NoError(t, cfg.ValidateAptos(cldf_aptos.Chain{Selector: chainsel.APTOS_MAINNET.Selector}, addr))
+
+	err := cfg.ValidateAptos(cldf_aptos.Chain{Selector: chainsel.APTOS_MAINNET.Selector}, aptos.AccountAddress{})
+	require.ErrorContains(t, err, "aptos MCMS contract not present")
+}


### PR DESCRIPTION
## Summary

Moves `TimelockConfig` and its related MCMS timelock validation/action-selection helpers into CLDF `proposalutils`, preserving the existing behavior and test coverage so core can consume this from CLDF instead of owning the implementation.