### PR TITLE
fix: correct package name for contracts/mcms from proposalutils to mcms

### DIFF
--- a/.changeset/goofy-sloths-rhyme.md
+++ b/.changeset/goofy-sloths-rhyme.md
@@ -1,0 +1,6 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+fix incorrect package name for contracts/mcms
+

--- a/engine/cld/contracts/mcms/contract_types.go
+++ b/engine/cld/contracts/mcms/contract_types.go
@@ -1,4 +1,4 @@
-package proposalutils
+package mcms
 
 import cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 

--- a/engine/cld/contracts/mcms/mcms_role.go
+++ b/engine/cld/contracts/mcms/mcms_role.go
@@ -1,4 +1,4 @@
-package proposalutils
+package mcms
 
 // MCMSRole represents a named role within the MCMS system (e.g. proposer, bypasser, canceller).
 type MCMSRole string

--- a/engine/cld/contracts/mcms/mcms_role_test.go
+++ b/engine/cld/contracts/mcms/mcms_role_test.go
@@ -1,4 +1,4 @@
-package proposalutils
+package mcms
 
 import (
 	"testing"


### PR DESCRIPTION
## What changed

The files in `engine/cld/contracts/mcms/` were incorrectly using `package proposalutils` instead of `package mcms`. This fixes all three files (`contract_types.go`, `mcms_role.go`, `mcms_role_test.go`) to use the correct package name.


## Why

The package declaration didn't match the directory name, which is inconsistent and would cause confusion for users importing the package.