### PR TITLE
fix: remove chainlink-ton/deployment

### DIFF
--- a/.changeset/moody-dodos-flow.md
+++ b/.changeset/moody-dodos-flow.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+remove chainlink-ton/deployment dependency

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,7 +81,11 @@ linters:
               desc: Use github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger instead
             - pkg: github.com/smartcontractkit/chainlink-common
               desc: We want to avoid importing this package as it has regular breaking changes.
-            - pkg: github.com/smartcontractkit/chainlink-(?!deployments-framework(?:/|$))[^/]+/deployment(/.*)?$
+            - pkg: github.com/smartcontractkit/chainlink-ccip/deployment
+              desc: We want to avoid importing this package as it creates import cycles
+            - pkg: github.com/smartcontractkit/chainlink-sui/deployment
+              desc: We want to avoid importing this package as it creates import cycles
+            - pkg: github.com/smartcontractkit/chainlink-ton/deployment
               desc: We want to avoid importing this package as it creates import cycles
     goconst:
       min-len: 5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,7 +81,7 @@ linters:
               desc: Use github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger instead
             - pkg: github.com/smartcontractkit/chainlink-common
               desc: We want to avoid importing this package as it has regular breaking changes.
-            - pkg: github.com/smartcontractkit/chainlink-[^/]+/deployment(/.*)?$
+            - pkg: github.com/smartcontractkit/chainlink-(?!deployments-framework(?:/|$))[^/]+/deployment(/.*)?$
               desc: We want to avoid importing this package as it creates import cycles
     goconst:
       min-len: 5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,7 +81,7 @@ linters:
               desc: Use github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger instead
             - pkg: github.com/smartcontractkit/chainlink-common
               desc: We want to avoid importing this package as it has regular breaking changes.
-            - pkg: github.com/smartcontractkit/chainlink-*/deployment
+            - pkg: github.com/smartcontractkit/chainlink-[^/]+/deployment(/.*)?$
               desc: We want to avoid importing this package as it creates import cycles
     goconst:
       min-len: 5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,6 +81,8 @@ linters:
               desc: Use github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger instead
             - pkg: github.com/smartcontractkit/chainlink-common
               desc: We want to avoid importing this package as it has regular breaking changes.
+            - pkg: github.com/smartcontractkit/chainlink-*/deployment
+              desc: We want to avoid importing this package as it creates import cycles
     goconst:
       min-len: 5
     govet:

--- a/engine/cld/mcms/proposalutils/timelock_config.go
+++ b/engine/cld/mcms/proposalutils/timelock_config.go
@@ -28,7 +28,7 @@ type SolanaMCMSWithTimelock interface {
 	TimelockPrograms() MCMSWithTimelockPrograms
 }
 
-// MCMSSuiteState holds the state of a single MCMS deployment - currently includes all contracts addresses.
+// MCMSSuiteState holds the state of a single MCMS deployment - currently includes all contract addresses.
 type MCMSSuiteState struct {
 	// 3x MCMS contracts, each gets a role in the timelock
 	Proposer  *address.Address

--- a/engine/cld/mcms/proposalutils/timelock_config.go
+++ b/engine/cld/mcms/proposalutils/timelock_config.go
@@ -28,8 +28,8 @@ type SolanaMCMSWithTimelock interface {
 	TimelockPrograms() MCMSWithTimelockPrograms
 }
 
-// MCMSSuiteState holds the state of a single MCMS deployment - currently includes all contract addresses.
-type MCMSSuiteState struct {
+// TonMCMSSuiteState holds the state of a single MCMS deployment - currently includes all contracts addresses.
+type TonMCMSSuiteState struct {
 	// 3x MCMS contracts, each gets a role in the timelock
 	Proposer  *address.Address
 	Canceller *address.Address
@@ -75,7 +75,7 @@ func (tc *TimelockConfig) MCMBasedOnActionSolana(s SolanaMCMSWithTimelock) (stri
 	}
 }
 
-func (tc *TimelockConfig) MCMBasedOnActionTon(s *MCMSSuiteState) (string, error) {
+func (tc *TimelockConfig) MCMBasedOnActionTon(s *TonMCMSSuiteState) (string, error) {
 	// if MCMSAction is not set, default to timelock.Schedule, this is to ensure no breaking changes for existing code
 	if tc.MCMSAction == "" {
 		tc.MCMSAction = mcmstypes.TimelockActionSchedule

--- a/engine/cld/mcms/proposalutils/timelock_config.go
+++ b/engine/cld/mcms/proposalutils/timelock_config.go
@@ -8,9 +8,9 @@ import (
 	"github.com/aptos-labs/aptos-go-sdk"
 	"github.com/gagliardetto/solana-go"
 	ownerhelpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
-	tonstate "github.com/smartcontractkit/chainlink-ton/deployment/state"
 	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
+	"github.com/xssnick/tonutils-go/address"
 
 	cldf_aptos "github.com/smartcontractkit/chainlink-deployments-framework/chain/aptos"
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
@@ -26,6 +26,17 @@ type EVMMCMSWithTimelock interface {
 // SolanaMCMSWithTimelock adapts Solana MCMS-with-timelock state for TimelockConfig helpers.
 type SolanaMCMSWithTimelock interface {
 	TimelockPrograms() MCMSWithTimelockPrograms
+}
+
+// MCMSSuiteState holds the state of a single MCMS deployment - currently includes all contracts addresses.
+type MCMSSuiteState struct {
+	// 3x MCMS contracts, each gets a role in the timelock
+	Proposer  *address.Address
+	Canceller *address.Address
+	Bypasser  *address.Address
+
+	// Timelock contract address for this MCMS suite
+	Timelock *address.Address
 }
 
 // MCMSWithTimelockPrograms holds the Solana program and PDA seed values needed to resolve MCMS role addresses.
@@ -64,7 +75,7 @@ func (tc *TimelockConfig) MCMBasedOnActionSolana(s SolanaMCMSWithTimelock) (stri
 	}
 }
 
-func (tc *TimelockConfig) MCMBasedOnActionTon(s *tonstate.MCMSSuiteState) (string, error) {
+func (tc *TimelockConfig) MCMBasedOnActionTon(s *MCMSSuiteState) (string, error) {
 	// if MCMSAction is not set, default to timelock.Schedule, this is to ensure no breaking changes for existing code
 	if tc.MCMSAction == "" {
 		tc.MCMSAction = mcmstypes.TimelockActionSchedule

--- a/engine/cld/mcms/proposalutils/timelock_config.go
+++ b/engine/cld/mcms/proposalutils/timelock_config.go
@@ -28,7 +28,7 @@ type SolanaMCMSWithTimelock interface {
 	TimelockPrograms() MCMSWithTimelockPrograms
 }
 
-// TonMCMSSuiteState holds the state of a single MCMS deployment - currently includes all contracts addresses.
+// TonMCMSSuiteState holds the state of a single MCMS deployment - currently includes all contract addresses.
 type TonMCMSSuiteState struct {
 	// 3x MCMS contracts, each gets a role in the timelock
 	Proposer  *address.Address

--- a/engine/cld/mcms/proposalutils/timelock_config_test.go
+++ b/engine/cld/mcms/proposalutils/timelock_config_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gagliardetto/solana-go"
 	ownerhelpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
 	chainsel "github.com/smartcontractkit/chain-selectors"
-	tonstate "github.com/smartcontractkit/chainlink-ton/deployment/state"
+
 	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
@@ -166,7 +166,7 @@ func TestTimelockConfigMCMBasedOnActionTONDefaultsToSchedule(t *testing.T) {
 	cfg := TimelockConfig{}
 	proposer := testTONAddress(0)
 
-	got, err := cfg.MCMBasedOnActionTon(&tonstate.MCMSSuiteState{
+	got, err := cfg.MCMBasedOnActionTon(&MCMSSuiteState{
 		Proposer: proposer,
 	})
 
@@ -185,13 +185,13 @@ func TestTimelockConfigMCMBasedOnActionTONSelectsRole(t *testing.T) {
 	tests := []struct {
 		name   string
 		action mcmstypes.TimelockAction
-		state  *tonstate.MCMSSuiteState
+		state  *MCMSSuiteState
 		want   string
 	}{
 		{
 			name:   "schedule",
 			action: mcmstypes.TimelockActionSchedule,
-			state: &tonstate.MCMSSuiteState{
+			state: &MCMSSuiteState{
 				Proposer: proposer,
 			},
 			want: proposer.String(),
@@ -199,7 +199,7 @@ func TestTimelockConfigMCMBasedOnActionTONSelectsRole(t *testing.T) {
 		{
 			name:   "cancel",
 			action: mcmstypes.TimelockActionCancel,
-			state: &tonstate.MCMSSuiteState{
+			state: &MCMSSuiteState{
 				Canceller: canceller,
 			},
 			want: canceller.String(),
@@ -207,7 +207,7 @@ func TestTimelockConfigMCMBasedOnActionTONSelectsRole(t *testing.T) {
 		{
 			name:   "bypass",
 			action: mcmstypes.TimelockActionBypass,
-			state: &tonstate.MCMSSuiteState{
+			state: &MCMSSuiteState{
 				Bypasser: bypasser,
 			},
 			want: bypasser.String(),
@@ -259,7 +259,7 @@ func TestTimelockConfigMCMBasedOnActionTONErrorsOnMissingRole(t *testing.T) {
 
 			cfg := TimelockConfig{MCMSAction: tt.action}
 
-			_, err := cfg.MCMBasedOnActionTon(&tonstate.MCMSSuiteState{})
+			_, err := cfg.MCMBasedOnActionTon(&MCMSSuiteState{})
 
 			require.EqualError(t, err, tt.want)
 		})

--- a/engine/cld/mcms/proposalutils/timelock_config_test.go
+++ b/engine/cld/mcms/proposalutils/timelock_config_test.go
@@ -166,7 +166,7 @@ func TestTimelockConfigMCMBasedOnActionTONDefaultsToSchedule(t *testing.T) {
 	cfg := TimelockConfig{}
 	proposer := testTONAddress(0)
 
-	got, err := cfg.MCMBasedOnActionTon(&MCMSSuiteState{
+	got, err := cfg.MCMBasedOnActionTon(&TonMCMSSuiteState{
 		Proposer: proposer,
 	})
 
@@ -185,13 +185,13 @@ func TestTimelockConfigMCMBasedOnActionTONSelectsRole(t *testing.T) {
 	tests := []struct {
 		name   string
 		action mcmstypes.TimelockAction
-		state  *MCMSSuiteState
+		state  *TonMCMSSuiteState
 		want   string
 	}{
 		{
 			name:   "schedule",
 			action: mcmstypes.TimelockActionSchedule,
-			state: &MCMSSuiteState{
+			state: &TonMCMSSuiteState{
 				Proposer: proposer,
 			},
 			want: proposer.String(),
@@ -199,7 +199,7 @@ func TestTimelockConfigMCMBasedOnActionTONSelectsRole(t *testing.T) {
 		{
 			name:   "cancel",
 			action: mcmstypes.TimelockActionCancel,
-			state: &MCMSSuiteState{
+			state: &TonMCMSSuiteState{
 				Canceller: canceller,
 			},
 			want: canceller.String(),
@@ -207,7 +207,7 @@ func TestTimelockConfigMCMBasedOnActionTONSelectsRole(t *testing.T) {
 		{
 			name:   "bypass",
 			action: mcmstypes.TimelockActionBypass,
-			state: &MCMSSuiteState{
+			state: &TonMCMSSuiteState{
 				Bypasser: bypasser,
 			},
 			want: bypasser.String(),
@@ -259,7 +259,7 @@ func TestTimelockConfigMCMBasedOnActionTONErrorsOnMissingRole(t *testing.T) {
 
 			cfg := TimelockConfig{MCMSAction: tt.action}
 
-			_, err := cfg.MCMBasedOnActionTon(&MCMSSuiteState{})
+			_, err := cfg.MCMBasedOnActionTon(&TonMCMSSuiteState{})
 
 			require.EqualError(t, err, tt.want)
 		})

--- a/engine/cld/mcms/proposalutils/timelock_config_test.go
+++ b/engine/cld/mcms/proposalutils/timelock_config_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gagliardetto/solana-go"
 	ownerhelpers "github.com/smartcontractkit/ccip-owner-contracts/pkg/gethwrappers"
 	chainsel "github.com/smartcontractkit/chain-selectors"
-
 	mcmssolanasdk "github.com/smartcontractkit/mcms/sdk/solana"
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.16.0
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5
 	github.com/smartcontractkit/chainlink-ton v1.0.5-0.20260430134932-681b7a7fe426
-	github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260430134932-681b7a7fe426
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513
 	github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad
 	github.com/smartcontractkit/libocr v0.0.0-20250912173940-f3ab0246e23d
@@ -94,7 +93,8 @@ require (
 	github.com/moby/moby/client v0.4.0 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260415165642-49f23e4d76cc // indirect
+	github.com/onsi/ginkgo/v2 v2.22.1 // indirect
+	github.com/onsi/gomega v1.36.2 // indirect
 	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260406055916-9aa6b6c0ae81 // indirect
 	github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 // indirect
 	github.com/smartcontractkit/chainlink-protos/cre/go v0.0.0-20260326111235-8c09d1a4491f // indirect

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
-github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
+github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad h1:a6HEuzUHeKH6hwfN/ZoQgRgVIWFJljSWa/zetS2WTvg=
+github.com/google/pprof v0.0.0-20241210010833-40e02aabc2ad/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -757,8 +757,6 @@ github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-8
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d/go.mod h1:bgmqE7x9xwmIVr8PqLbC0M5iPm4AV2DBl596lO6S5Sw=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5 h1:Z4t2ZY+ZyGWxtcXvPr11y4o3CGqhg3frJB5jXkCSvWA=
 github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20250912190424-fd2e35d7deb5/go.mod h1:xtZNi6pOKdC3sLvokDvXOhgHzT+cyBqH/gWwvxTxqrg=
-github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260415165642-49f23e4d76cc h1:entc0pB4VQEkhJf/ymOfnUh6zcu1sj1OU4YW3iPEW4s=
-github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260415165642-49f23e4d76cc/go.mod h1:Ex2OUp35VJuCcRAjuBKwP+cevEPOSjy1pZXm3ncV4kQ=
 github.com/smartcontractkit/chainlink-common v0.11.2-0.20260406055916-9aa6b6c0ae81 h1:qBQxh/dndRMJX41xWEihr8FkvPL21luWwTFn/0Nl3RU=
 github.com/smartcontractkit/chainlink-common v0.11.2-0.20260406055916-9aa6b6c0ae81/go.mod h1:Ob7ZRLEvPkDwGUjKdDIiHy0Mxu4+UG6oMBkR7Jv/U6o=
 github.com/smartcontractkit/chainlink-common/pkg/chipingress v0.0.10 h1:FJAFgXS9oqASnkS03RE1HQwYQQxrO4l46O5JSzxqLgg=
@@ -781,8 +779,6 @@ github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5 h1:RwZXxdIA
 github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.5/go.mod h1:kHYJnZUqiPF7/xN5273prV+srrLJkS77GbBXHLKQpx0=
 github.com/smartcontractkit/chainlink-ton v1.0.5-0.20260430134932-681b7a7fe426 h1:DeQpkYzNYqAXfXnMwXmh5LfF86jDgvbvtB+zCgtovWA=
 github.com/smartcontractkit/chainlink-ton v1.0.5-0.20260430134932-681b7a7fe426/go.mod h1:ueY5pFIW//gVJS8/rh8qIs2gdlntxfAiOZfBSvJRjXk=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260430134932-681b7a7fe426 h1:X8MNLLrViwwhBRPwhSVywI1ym2/WBMdhnaBAIkTpwaU=
-github.com/smartcontractkit/chainlink-ton/deployment v0.0.0-20260430134932-681b7a7fe426/go.mod h1:Y4xFqbrdQX+LjVzY5jHBnbTlP3erihUqYiH4h9XMWxU=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513 h1:XRNxgcNqagXu6e4smJuS1crRK5cUAcCVd7u+iLduHDM=
 github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250908203554-5bd9d2fe9513/go.mod h1:ccjEgNeqOO+bjPddnL4lUrNLzyCvGCxgBjJdhFX3wa8=
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.4 h1:J4qtAo0ZmgX5pIr8Y5mdC+J2rj2e/6CTUC263t6mGOM=


### PR DESCRIPTION
We are recreating `MCMSSuiteState` locally to avoid importing chainlink-ton/deployment. This should not happen as it creates module import cycles