### PR TITLE
de-list common from depguard deny list

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,10 +77,6 @@ linters:
               desc: You must not import this package. There is no alternative.
             - pkg: github.com/smartcontractkit/chainlink/deployment
               desc: You must not import this package. There is no alternative.
-            - pkg: github.com/smartcontractkit/chainlink-common/pkg/logger
-              desc: Use github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger instead
-            - pkg: github.com/smartcontractkit/chainlink-common
-              desc: We want to avoid importing this package as it has regular breaking changes.
             - pkg: github.com/smartcontractkit/chainlink-ccip/deployment
               desc: We want to avoid importing this package as it creates import cycles
             - pkg: github.com/smartcontractkit/chainlink-sui/deployment


### PR DESCRIPTION
The common module does not have regular breaking changes. If you encounter breaking changes, please report them.

There are more changes in https://github.com/smartcontractkit/chainlink-deployments-framework/pull/524 that could be reverted, e.g. embedded `Unimplemented*` types, but this just removes the blocker.