### PR TITLE
feat: add cre api keys multiple named secret

### DIFF
--- a/.changeset/tricky-women-admire.md
+++ b/.changeset/tricky-women-admire.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+add support for named api keys on cre api key secret

--- a/cre/cli/runner.go
+++ b/cre/cli/runner.go
@@ -112,7 +112,6 @@ func parseNamedAPIKeys(raw string) (namedAPIKeys, bool) {
 // registered under name. the clone preserves the underlying name->key map so further WithNamedAPIKey
 // calls remain valid.
 func (r cliRunner) WithNamedAPIKey(name string) (fcre.CLIRunner, error) {
-
 	if len(r.apiKeysByName) == 0 {
 		return nil, errors.New("cre cli: runner is not configured with named API keys")
 	}

--- a/cre/cli/runner.go
+++ b/cre/cli/runner.go
@@ -3,10 +3,13 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 
 	fcre "github.com/smartcontractkit/chainlink-deployments-framework/cre"
@@ -20,11 +23,31 @@ const envCREAPIKey = "CRE_API_KEY" //nolint:gosec // G101: env var name, not a s
 // CLIRunnerOption configures a [cliRunner] from [NewCLIRunner].
 type CLIRunnerOption func(*cliRunner)
 
+// namedAPIKeys is the parsed form of CRE_API_KEY when it carries multiple named API keys
+type namedAPIKeys map[string]string
+
+// sortedNames returns the configured names in lexical order.
+func (n namedAPIKeys) sortedNames() []string {
+	names := make([]string, 0, len(n))
+	for name := range n {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return names
+}
+
 // cliRunner runs the CRE CLI via os/exec. Run executes the binary and captures stdout/stderr.
 // It implements [fcre.CLIRunner].
 type cliRunner struct {
-	binaryPath               string
-	apiKey                   string
+	binaryPath string
+	// apiKey is the resolved single API key value used by Run. In named-keys
+	// mode it is empty until a name is selected via WithNamedAPIKey, which
+	// returns a clone with apiKey populated from apiKeysByName.
+	apiKey string
+	// apiKeysByName is populated only when CRE_API_KEY decoded as a JSON object
+	// of {name: apiKey} entries. nil in single-key mode.
+	apiKeysByName            namedAPIKeys
 	defaultContextRegistries []fcre.ContextRegistryEntry
 	// Stdout, if set, receives a real-time copy of the process stdout while it runs.
 	Stdout io.Writer
@@ -45,15 +68,60 @@ func NewCLIRunner(binaryPath string, apiKey string, opts ...CLIRunnerOption) *cl
 	// formatting (newlines/indentation) during manual durable-pipeline runs.
 	r := &cliRunner{
 		binaryPath: binaryPath,
-		apiKey:     apiKey,
 		Stdout:     os.Stdout,
 		Stderr:     os.Stderr,
+	}
+	if named, ok := parseNamedAPIKeys(apiKey); ok {
+		r.apiKeysByName = named
+	} else {
+		r.apiKey = apiKey
 	}
 	for _, o := range opts {
 		o(r)
 	}
 
 	return r
+}
+
+// parseNamedAPIKeys decodes raw as a JSON object of {name: apiKey} entries.
+// Returns (map, true) only when raw is a non-empty JSON object with no empty
+// keys or values. Any other shape — non-JSON values, JSON arrays/strings/
+// numbers, empty objects, or entries with empty values — returns (nil, false)
+func parseNamedAPIKeys(raw string) (namedAPIKeys, bool) {
+	var keys namedAPIKeys
+	if err := json.Unmarshal([]byte(raw), &keys); err != nil {
+		return nil, false
+	}
+	if len(keys) == 0 {
+		return nil, false
+	}
+	for name, value := range keys {
+		if name == "" || value == "" {
+			return nil, false
+		}
+	}
+
+	return keys, true
+}
+
+// WithNamedAPIKey returns a clone of this runner that uses the API key
+// registered under name. the clone preserves the underlying name->key map so further WithNamedAPIKey
+// calls remain valid.
+func (r *cliRunner) WithNamedAPIKey(name string) (fcre.CLIRunner, error) {
+	if r == nil {
+		return nil, errors.New("cre cli: runner is nil")
+	}
+	if len(r.apiKeysByName) == 0 {
+		return nil, errors.New("cre cli: runner is not configured with named API keys")
+	}
+	key, ok := r.apiKeysByName[name]
+	if !ok {
+		return nil, fmt.Errorf("cre cli: API key %q not configured (available: %v)", name, r.apiKeysByName.sortedNames())
+	}
+	clone := *r
+	clone.apiKey = key
+
+	return &clone, nil
 }
 
 // WithContextRegistries sets domain-level registry entries for CRE context.yaml generation
@@ -131,6 +199,10 @@ func envForCRECLI(apiKey string, extraEnv map[string]string) []string {
 // exit code != 0 returns (res, *fcre.ExitError) so callers get both result and error.
 // CLI invocation failures (binary not found, context canceled) return (nil, err).
 func (r *cliRunner) Run(ctx context.Context, env map[string]string, args ...string) (*fcre.CallResult, error) {
+	if r.apiKey == "" && len(r.apiKeysByName) > 0 {
+		return nil, fmt.Errorf("cre cli: named API keys configured but no name selected; call CLIRunner.WithNamedAPIKey(<name>) first (available: %v)", r.apiKeysByName.sortedNames())
+	}
+
 	//nolint:gosec // G204: This is intentional - we're running a CLI tool with user-provided arguments.
 	// The binary path is controlled via configuration, and args are expected to be user-provided CLI arguments.
 	cmd := exec.CommandContext(ctx, r.binaryPath, args...)

--- a/cre/cli/runner.go
+++ b/cre/cli/runner.go
@@ -109,7 +109,7 @@ func parseNamedAPIKeys(raw string) (namedAPIKeys, bool) {
 }
 
 // WithNamedAPIKey returns a clone of this runner that uses the API key
-// registered under name. the clone preserves the underlying name->key map so further WithNamedAPIKey
+// registered under name. The clone preserves the underlying name->key map so further WithNamedAPIKey
 // calls remain valid.
 func (r cliRunner) WithNamedAPIKey(name string) (fcre.CLIRunner, error) {
 	if len(r.apiKeysByName) == 0 {

--- a/cre/cli/runner.go
+++ b/cre/cli/runner.go
@@ -41,6 +41,9 @@ func (n namedAPIKeys) sortedNames() []string {
 // It implements [fcre.CLIRunner].
 type cliRunner struct {
 	binaryPath string
+	// rawAPIKey preserves the original value passed to NewCLIRunner verbatim,
+	// regardless of which mode (single-key or named-keys) was selected.
+	rawAPIKey string
 	// apiKey is the resolved single API key value used by Run. In named-keys
 	// mode it is empty until a name is selected via WithNamedAPIKey, which
 	// returns a clone with apiKey populated from apiKeysByName.
@@ -68,10 +71,11 @@ func NewCLIRunner(binaryPath string, apiKey string, opts ...CLIRunnerOption) *cl
 	// formatting (newlines/indentation) during manual durable-pipeline runs.
 	r := &cliRunner{
 		binaryPath: binaryPath,
+		rawAPIKey:  apiKey,
 		Stdout:     os.Stdout,
 		Stderr:     os.Stderr,
 	}
-	if named, ok := parseNamedAPIKeys(apiKey); ok {
+	if named, ok := parseNamedAPIKeys(r.rawAPIKey); ok {
 		r.apiKeysByName = named
 	} else {
 		r.apiKey = apiKey
@@ -107,10 +111,8 @@ func parseNamedAPIKeys(raw string) (namedAPIKeys, bool) {
 // WithNamedAPIKey returns a clone of this runner that uses the API key
 // registered under name. the clone preserves the underlying name->key map so further WithNamedAPIKey
 // calls remain valid.
-func (r *cliRunner) WithNamedAPIKey(name string) (fcre.CLIRunner, error) {
-	if r == nil {
-		return nil, errors.New("cre cli: runner is nil")
-	}
+func (r cliRunner) WithNamedAPIKey(name string) (fcre.CLIRunner, error) {
+
 	if len(r.apiKeysByName) == 0 {
 		return nil, errors.New("cre cli: runner is not configured with named API keys")
 	}
@@ -118,10 +120,9 @@ func (r *cliRunner) WithNamedAPIKey(name string) (fcre.CLIRunner, error) {
 	if !ok {
 		return nil, fmt.Errorf("cre cli: API key %q not configured (available: %v)", name, r.apiKeysByName.sortedNames())
 	}
-	clone := *r
-	clone.apiKey = key
+	r.apiKey = key
 
-	return &clone, nil
+	return &r, nil
 }
 
 // WithContextRegistries sets domain-level registry entries for CRE context.yaml generation

--- a/cre/cli/runner_test.go
+++ b/cre/cli/runner_test.go
@@ -31,6 +31,7 @@ func TestNewCLIRunner(t *testing.T) {
 			r := NewCLIRunner(tt.binaryPath, tt.apiKey)
 			require.Equal(t, tt.wantPath, r.binaryPath)
 			require.Equal(t, tt.wantKey, r.apiKey)
+			require.Equal(t, tt.apiKey, r.rawAPIKey)
 			require.Nil(t, r.apiKeysByName)
 		})
 	}
@@ -78,9 +79,11 @@ func Test_parseNamedAPIKeys(t *testing.T) {
 func TestNewCLIRunner_NamedKeysMode(t *testing.T) {
 	t.Parallel()
 
-	r := NewCLIRunner("/bin/sh", `{"prod-1":"k1","prod-2":"k2"}`)
+	raw := `{"prod-1":"k1","prod-2":"k2"}`
+	r := NewCLIRunner("/bin/sh", raw)
 	require.Empty(t, r.apiKey, "apiKey must be empty until a name is selected")
 	require.Equal(t, namedAPIKeys{"prod-1": "k1", "prod-2": "k2"}, r.apiKeysByName)
+	require.Equal(t, raw, r.rawAPIKey, "rawAPIKey preserves the original value for debugging")
 }
 
 func TestNewCLIRunner_SingleKeyMode_PreservesUnparseableValues(t *testing.T) {
@@ -99,6 +102,7 @@ func TestNewCLIRunner_SingleKeyMode_PreservesUnparseableValues(t *testing.T) {
 			t.Parallel()
 			r := NewCLIRunner("/bin/sh", raw)
 			require.Equal(t, raw, r.apiKey)
+			require.Equal(t, raw, r.rawAPIKey)
 			require.Nil(t, r.apiKeysByName)
 		})
 	}

--- a/cre/cli/runner_test.go
+++ b/cre/cli/runner_test.go
@@ -31,8 +31,150 @@ func TestNewCLIRunner(t *testing.T) {
 			r := NewCLIRunner(tt.binaryPath, tt.apiKey)
 			require.Equal(t, tt.wantPath, r.binaryPath)
 			require.Equal(t, tt.wantKey, r.apiKey)
+			require.Nil(t, r.apiKeysByName)
 		})
 	}
+}
+
+func Test_parseNamedAPIKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		ok   bool
+		want namedAPIKeys
+	}{
+		{name: "valid_map_two_names", raw: `{"prod-1":"k1","prod-2":"k2"}`, ok: true, want: namedAPIKeys{"prod-1": "k1", "prod-2": "k2"}},
+		{name: "valid_map_one_name", raw: `{"prod-1":"k1"}`, ok: true, want: namedAPIKeys{"prod-1": "k1"}},
+		{name: "whitespace_around_object", raw: "  \n{\"prod-1\":\"k1\"}\n  ", ok: true, want: namedAPIKeys{"prod-1": "k1"}},
+		{name: "not_json_plain_string", raw: "abcd"},
+		{name: "json_string_literal", raw: `"abcd"`},
+		{name: "json_array", raw: `["a","b"]`},
+		{name: "json_number", raw: `42`},
+		{name: "json_null", raw: `null`},
+		{name: "empty_map", raw: `{}`},
+		{name: "empty_value_rejected", raw: `{"prod-1":""}`},
+		{name: "empty_key_rejected", raw: `{"":"k1"}`},
+		{name: "empty_string", raw: ""},
+		{name: "malformed_object", raw: `{"prod-1":`},
+		{name: "object_with_non_string_value", raw: `{"prod-1":123}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := parseNamedAPIKeys(tt.raw)
+			require.Equal(t, tt.ok, ok)
+			if tt.ok {
+				require.Equal(t, tt.want, got)
+			} else {
+				require.Nil(t, got)
+			}
+		})
+	}
+}
+
+func TestNewCLIRunner_NamedKeysMode(t *testing.T) {
+	t.Parallel()
+
+	r := NewCLIRunner("/bin/sh", `{"prod-1":"k1","prod-2":"k2"}`)
+	require.Empty(t, r.apiKey, "apiKey must be empty until a name is selected")
+	require.Equal(t, namedAPIKeys{"prod-1": "k1", "prod-2": "k2"}, r.apiKeysByName)
+}
+
+func TestNewCLIRunner_SingleKeyMode_PreservesUnparseableValues(t *testing.T) {
+	t.Parallel()
+
+	// Values that look JSON-ish but don't parse as an object of strings stay as
+	// the literal single key value — backward compatible.
+	cases := []string{
+		"plain-secret",
+		`{"prod-1":""}`,
+		`{}`,
+		`{not-json`,
+	}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			r := NewCLIRunner("/bin/sh", raw)
+			require.Equal(t, raw, r.apiKey)
+			require.Nil(t, r.apiKeysByName)
+		})
+	}
+}
+
+func TestCLIRunner_Run_NamedKeysWithoutSelection_Errors(t *testing.T) {
+	t.Parallel()
+
+	r := NewCLIRunner("/bin/sh", `{"prod-1":"k1","prod-2":"k2"}`)
+	res, err := r.Run(t.Context(), nil, "-c", "echo unreachable")
+	require.Nil(t, res)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "named API keys configured but no name selected")
+	// Available names are listed in sorted order.
+	require.ErrorContains(t, err, "[prod-1 prod-2]")
+}
+
+func TestCLIRunner_WithNamedAPIKey_ResolvesKeyForSubprocess(t *testing.T) {
+	// Cannot use t.Parallel: relies on a known parent env state via t.Setenv.
+	t.Setenv(envCREAPIKey, "from-parent-must-be-overridden")
+
+	r := NewCLIRunner("/bin/sh", `{"prod-1":"k1","prod-2":"k2"}`)
+	selected, err := r.WithNamedAPIKey("prod-2")
+	require.NoError(t, err)
+
+	res, err := selected.Run(t.Context(), nil, "-c", `printf '%s' "$`+envCREAPIKey+`"`)
+	require.NoError(t, err)
+	require.Equal(t, 0, res.ExitCode)
+	require.Equal(t, "k2", string(res.Stdout))
+}
+
+func TestCLIRunner_WithNamedAPIKey_UnknownNameErrors(t *testing.T) {
+	t.Parallel()
+
+	r := NewCLIRunner("/bin/sh", `{"prod-1":"k1","prod-2":"k2"}`)
+	got, err := r.WithNamedAPIKey("missing")
+	require.Nil(t, got)
+	require.Error(t, err)
+	require.ErrorContains(t, err, `API key "missing" not configured`)
+	require.ErrorContains(t, err, "[prod-1 prod-2]")
+}
+
+func TestCLIRunner_WithNamedAPIKey_SingleKeyRunnerErrors(t *testing.T) {
+	t.Parallel()
+
+	r := NewCLIRunner("/bin/sh", "plain-secret")
+	got, err := r.WithNamedAPIKey("prod-1")
+	require.Nil(t, got)
+	require.ErrorContains(t, err, "not configured with named API keys")
+}
+
+func TestCLIRunner_WithNamedAPIKey_DoesNotMutateParent(t *testing.T) {
+	t.Parallel()
+
+	parent := NewCLIRunner("/bin/sh", `{"prod-1":"k1","prod-2":"k2"}`)
+	_, err := parent.WithNamedAPIKey("prod-1")
+	require.NoError(t, err)
+
+	// Parent still rejects Run because no name has been selected on it.
+	res, err := parent.Run(t.Context(), nil, "-c", "echo unreachable")
+	require.Nil(t, res)
+	require.ErrorContains(t, err, "named API keys configured but no name selected")
+}
+
+func TestCLIRunner_WithNamedAPIKey_CanRebindOnClone(t *testing.T) {
+	t.Parallel()
+
+	parent := NewCLIRunner("/bin/sh", `{"prod-1":"k1","prod-2":"k2"}`)
+	first, err := parent.WithNamedAPIKey("prod-1")
+	require.NoError(t, err)
+	second, err := first.WithNamedAPIKey("prod-2")
+	require.NoError(t, err)
+
+	res, err := second.Run(t.Context(), nil, "-c", `printf '%s' "$`+envCREAPIKey+`"`)
+	require.NoError(t, err)
+	require.Equal(t, "k2", string(res.Stdout))
 }
 
 func TestCLIRunner_APIKeyEnv(t *testing.T) {

--- a/cre/mocks/mock_cli_runner.go
+++ b/cre/mocks/mock_cli_runner.go
@@ -166,3 +166,65 @@ func (_c *MockCLIRunner_Run_Call) RunAndReturn(run func(ctx context.Context, env
 	_c.Call.Return(run)
 	return _c
 }
+
+// WithNamedAPIKey provides a mock function for the type MockCLIRunner
+func (_mock *MockCLIRunner) WithNamedAPIKey(name string) (cre.CLIRunner, error) {
+	ret := _mock.Called(name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for WithNamedAPIKey")
+	}
+
+	var r0 cre.CLIRunner
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) (cre.CLIRunner, error)); ok {
+		return returnFunc(name)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) cre.CLIRunner); ok {
+		r0 = returnFunc(name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(cre.CLIRunner)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(name)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockCLIRunner_WithNamedAPIKey_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithNamedAPIKey'
+type MockCLIRunner_WithNamedAPIKey_Call struct {
+	*mock.Call
+}
+
+// WithNamedAPIKey is a helper method to define mock.On call
+//   - name string
+func (_e *MockCLIRunner_Expecter) WithNamedAPIKey(name interface{}) *MockCLIRunner_WithNamedAPIKey_Call {
+	return &MockCLIRunner_WithNamedAPIKey_Call{Call: _e.mock.On("WithNamedAPIKey", name)}
+}
+
+func (_c *MockCLIRunner_WithNamedAPIKey_Call) Run(run func(name string)) *MockCLIRunner_WithNamedAPIKey_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockCLIRunner_WithNamedAPIKey_Call) Return(cLIRunner cre.CLIRunner, err error) *MockCLIRunner_WithNamedAPIKey_Call {
+	_c.Call.Return(cLIRunner, err)
+	return _c
+}
+
+func (_c *MockCLIRunner_WithNamedAPIKey_Call) RunAndReturn(run func(name string) (cre.CLIRunner, error)) *MockCLIRunner_WithNamedAPIKey_Call {
+	_c.Call.Return(run)
+	return _c
+}

--- a/cre/runner.go
+++ b/cre/runner.go
@@ -118,6 +118,10 @@ type CLIRunner interface {
 	Run(ctx context.Context, env map[string]string, args ...string) (*CallResult, error)
 	// ContextRegistries returns workflow registries defined from domain.yaml.
 	ContextRegistries() []ContextRegistryEntry
+	// WithNamedAPIKey returns a CLIRunner that uses the API key registered under
+	// the given name. The name is an arbitrary label chosen by the operator when
+	// configuring CRE_API_KEY as a JSON object (e.g. {"prod":"...","stg":"..."}).
+	WithNamedAPIKey(name string) (CLIRunner, error)
 }
 
 func isValidRegistryType(value string) bool {


### PR DESCRIPTION
This pull request introduces support for multiple named API keys in the `cre/cli` package, allowing the `CLIRunner` to handle a JSON object of named keys via the `CRE_API_KEY` environment variable. It adds methods to select a key by name, ensures backward compatibility with single-key usage, and provides comprehensive tests for both modes. Mock support for the new interface is also included.

**Support for multiple named API keys:**

* Enhanced `CLIRunner` to accept a JSON object of named API keys via `CRE_API_KEY`, enabling selection of a specific key by name using the new `WithNamedAPIKey` method. This allows workflows to switch between environments or credentials without changing environment variables. [[1]](diffhunk://#diff-73ff3f2caac893a764145fc2bce4bc67f6075239f9a83220e0ba8b0fcf4683d0R26-R50) [[2]](diffhunk://#diff-73ff3f2caac893a764145fc2bce4bc67f6075239f9a83220e0ba8b0fcf4683d0L48-R126) [[3]](diffhunk://#diff-80d026f64febe793cf0db33af0c56a73aac78222777f846e4c1f8a19158445f5R121-R124)
* Added logic to ensure that if multiple named keys are provided, a key must be selected before running commands; otherwise, an error is returned listing available names.

**Testing and compatibility:**

* Added extensive tests for both single-key and named-keys modes, including edge cases, error handling, and ensuring that parent runners are not mutated by key selection.
* Maintained backward compatibility by preserving previous behavior when the API key is not a valid JSON object.

**Mock and interface updates:**

* Updated the `CLIRunner` interface and its mocks to include the new `WithNamedAPIKey` method for use in testing and downstream code. [[1]](diffhunk://#diff-80d026f64febe793cf0db33af0c56a73aac78222777f846e4c1f8a19158445f5R121-R124) [[2]](diffhunk://#diff-93de2268096b1c2158867923a8bdd1f1d9017a3569e7c18e1457a7b53b1d27aaR169-R230)