### PR TITLE
feat: add WithName option for test environment loader

### DIFF
--- a/engine/test/environment/components.go
+++ b/engine/test/environment/components.go
@@ -16,6 +16,7 @@ import (
 type components struct {
 	mu sync.Mutex
 
+	Name           string
 	Chains         []fchain.BlockChain
 	AddressBook    fdeployment.AddressBook
 	Datastore      fdatastore.DataStore

--- a/engine/test/environment/environment.go
+++ b/engine/test/environment/environment.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	environmentName = "test_environment"
+	DefaultEnvironmentName = "test_environment"
 )
 
 // New creates a new environment for testing.
@@ -67,9 +67,14 @@ func (l *Loader) Load(ctx context.Context, opts ...LoadOpt) (*fdeployment.Enviro
 		oc = foffchain.NewMemoryJobDistributor()
 	}
 
+	name := cmps.Name
+	if name == "" {
+		name = DefaultEnvironmentName
+	}
+
 	// CRERunner may be nil; tests that need CRE use WithCRERunner(cre.NewRunner(cre.WithCLI(cremocks.NewMockCLIRunner(t)))).
 	return &fdeployment.Environment{
-		Name:              environmentName,
+		Name:              name,
 		Logger:            cmps.Logger,
 		BlockChains:       fchain.NewBlockChainsFromSlice(cmps.Chains),
 		ExistingAddresses: ab,

--- a/engine/test/environment/environment_test.go
+++ b/engine/test/environment/environment_test.go
@@ -151,6 +151,17 @@ func TestLoader_Load_NodeIDsOption(t *testing.T) {
 	require.Equal(t, nodeIDs, env.NodeIDs)
 }
 
+func TestLoader_Load_NameOption(t *testing.T) {
+	t.Parallel()
+
+	name := "test-name"
+	loader := NewLoader()
+	env, err := loader.Load(t.Context(), WithName(name))
+	require.NoError(t, err)
+	require.NotNil(t, env)
+	require.Equal(t, name, env.Name)
+}
+
 func TestLoader_Load_AddressBookOption(t *testing.T) {
 	t.Parallel()
 

--- a/engine/test/environment/options.go
+++ b/engine/test/environment/options.go
@@ -234,6 +234,14 @@ func WithNodeIDs(nodeIDs []string) LoadOpt {
 	}
 }
 
+// WithName sets the name for the environment.
+func WithName(name string) LoadOpt {
+	return func(cmps *components) error {
+		cmps.Name = name
+		return nil
+	}
+}
+
 // withChainLoader creates a LoadOpt that loads chains using the provided loader and selectors.
 func withChainLoader(t *testing.T, loader *onchain.ChainLoader, selectors []uint64) LoadOpt {
 	t.Helper()


### PR DESCRIPTION
Allow tests to set a custom environment name via `WithName`, falling back to the default name when unset.

The default name has also been exposed as a public constant