### PR TITLE
feat: add ExecChangeset function to test runtime

### DIFF
--- a/.changeset/thick-trees-hear.md
+++ b/.changeset/thick-trees-hear.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat: add `ExecChangeset` function to test runtime

--- a/engine/test/runtime/runtime.go
+++ b/engine/test/runtime/runtime.go
@@ -83,6 +83,21 @@ func (r *Runtime) Exec(executables ...Executable) error {
 	return nil
 }
 
+// ExecChangeset executes a Changeset and returns the task ID and error.
+//
+// The task ID is returned so that the caller can use it to retrieve the output
+// of the changeset from the state.
+//
+// It is implemented as a free function rather than a method on Runtime because
+// Go does not allow type parameters on methods.
+//
+// Returns the task ID and error if the changeset execution fails.
+func ExecChangeset[C any](r *Runtime, changeset fdeployment.ChangeSetV2[C], config C) (string, error) {
+	task := ChangesetTask(changeset, config)
+
+	return task.ID(), r.Exec(task)
+}
+
 // State returns the current state of the runtime.
 func (r *Runtime) State() *State {
 	return r.state

--- a/engine/test/runtime/runtime_test.go
+++ b/engine/test/runtime/runtime_test.go
@@ -343,6 +343,23 @@ func TestRuntime_Exec_Concurrent(t *testing.T) {
 	require.Len(t, runtime.state.Outputs, numOps)
 }
 
+func TestRuntime_ExecChangeset(t *testing.T) {
+	t.Parallel()
+
+	runtime := NewFromEnvironment(fdeployment.Environment{
+		Name:   "test-env",
+		Logger: logger.Nop(),
+	})
+
+	changeset := &mockChangeset[mockChangesetConfig]{}
+	config := mockChangesetConfig{Value: "test"}
+
+	taskID, err := ExecChangeset(runtime, changeset, config)
+	require.NoError(t, err)
+	require.NotEmpty(t, taskID)
+	require.Contains(t, runtime.state.Outputs, taskID)
+}
+
 func TestRuntime_State(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Add a free function ExecChangeset to the Runtime type that executes a Changeset and returns the task ID and error.

It is implemented as a free function rather than a method on Runtime because Go does not allow type parameters on methods.

The task ID is returned so that the caller can use it to retrieve the output of the changeset from the state.