### PR TITLE
feat: add ExecChangeset function to runtime

### DIFF
--- a/engine/test/runtime/runtime.go
+++ b/engine/test/runtime/runtime.go
@@ -92,10 +92,19 @@ func (r *Runtime) Exec(executables ...Executable) error {
 // Go does not allow type parameters on methods.
 //
 // Returns the task ID and error if the changeset execution fails.
-func ExecChangeset[C any](r *Runtime, changeset fdeployment.ChangeSetV2[C], config C) (string, error) {
+func ExecChangeset[C any](r *Runtime, changeset fdeployment.ChangeSetV2[C], config C) (fdeployment.ChangesetOutput, error) {
 	task := ChangesetTask(changeset, config)
 
-	return task.ID(), r.Exec(task)
+	if err := r.Exec(task); err != nil {
+		return fdeployment.ChangesetOutput{}, err
+	}
+
+	output, ok := r.state.Outputs[task.ID()]
+	if !ok {
+		return fdeployment.ChangesetOutput{}, fmt.Errorf("changeset output not found for task %s", task.ID())
+	}
+
+	return output, nil
 }
 
 // State returns the current state of the runtime.

--- a/engine/test/runtime/runtime_test.go
+++ b/engine/test/runtime/runtime_test.go
@@ -354,10 +354,9 @@ func TestRuntime_ExecChangeset(t *testing.T) {
 	changeset := &mockChangeset[mockChangesetConfig]{}
 	config := mockChangesetConfig{Value: "test"}
 
-	taskID, err := ExecChangeset(runtime, changeset, config)
+	output, err := ExecChangeset(runtime, changeset, config)
 	require.NoError(t, err)
-	require.NotEmpty(t, taskID)
-	require.Contains(t, runtime.state.Outputs, taskID)
+	require.NotNil(t, output)
 }
 
 func TestRuntime_State(t *testing.T) {


### PR DESCRIPTION
This updates the ExecChangeset function to return the changeset output instead of the task ID. This is more useful for testing purposes than the task ID.