### PR TITLE
[CLD-2461]: feat(deployment): introduce mcms registry

### DIFF
--- a/deployment/mcms_registry.go
+++ b/deployment/mcms_registry.go
@@ -1,0 +1,147 @@
+package deployment
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+)
+
+var (
+	// ErrInvalidMCMSTimelockProposalInput indicates MCMSTimelockProposalInput failed validation.
+	ErrInvalidMCMSTimelockProposalInput = errors.New("invalid MCMS timelock proposal input")
+	// ErrDuplicateMCMSReader indicates a reader is already registered for a chain family.
+	ErrDuplicateMCMSReader = errors.New("MCMS reader already registered for chain family")
+	// ErrEmptyChainFamily indicates Register was called with an empty chain family.
+	ErrEmptyChainFamily = errors.New("chain family must not be empty")
+	// ErrNilMCMSReader indicates Register was called with a nil reader.
+	ErrNilMCMSReader = errors.New("MCMS reader must not be nil")
+)
+
+// MCMSTimelockProposalInput is an input for creating an MCMS timelock proposal.
+type MCMSTimelockProposalInput struct {
+	// OverridePreviousRoot indicates whether to override the root of the MCMS contract.
+	OverridePreviousRoot bool
+	// ValidUntil is a Unix timestamp indicating when the proposal expires.
+	// Root can't be set or executed after this time.
+	ValidUntil uint32
+	// TimelockDelay is the amount of time each operation in the proposal must wait before it can be executed.
+	TimelockDelay mcmstypes.Duration
+	// TimelockAction is the action to perform on the timelock contract (schedule, bypass, or cancel).
+	TimelockAction mcmstypes.TimelockAction
+	// Qualifier is a string used to qualify the MCMS + Timelock contract addresses.
+	Qualifier string
+	// Description is a human-readable description of the proposal.
+	Description string
+}
+
+// minValidUntil returns the earliest ValidUntil timestamp accepted by Validate.
+func minValidUntil(now time.Time) uint32 {
+	return uint32(now.Add(10 * time.Minute).UTC().Unix()) //nolint:gosec // Unix timestamp fits uint32 until year 2106
+}
+
+// Validate validates the MCMSTimelockProposalInput.
+func (c *MCMSTimelockProposalInput) Validate() error {
+	return c.validateAt(time.Now())
+}
+
+func (c *MCMSTimelockProposalInput) validateAt(now time.Time) error {
+	if c.TimelockAction != mcmstypes.TimelockActionSchedule &&
+		c.TimelockAction != mcmstypes.TimelockActionBypass &&
+		c.TimelockAction != mcmstypes.TimelockActionCancel {
+		return fmt.Errorf("%w: invalid timelock action %q", ErrInvalidMCMSTimelockProposalInput, c.TimelockAction)
+	}
+	if c.TimelockDelay.Duration < 0 {
+		return fmt.Errorf("%w: timelock delay must not be negative", ErrInvalidMCMSTimelockProposalInput)
+	}
+	if c.TimelockAction == mcmstypes.TimelockActionSchedule && c.TimelockDelay.Duration <= 0 {
+		return fmt.Errorf("%w: timelock delay must be positive for schedule action", ErrInvalidMCMSTimelockProposalInput)
+	}
+	if c.ValidUntil == 0 {
+		return fmt.Errorf("%w: valid until must be set", ErrInvalidMCMSTimelockProposalInput)
+	}
+	// valid until must be far enough in the future to account for clock drift and proposal creation delay.
+	if c.ValidUntil < minValidUntil(now) {
+		return fmt.Errorf("%w: valid until must be at least 10 minutes in the future", ErrInvalidMCMSTimelockProposalInput)
+	}
+
+	return nil
+}
+
+// MCMSReader is an interface for reading MCMS state from a chain type.
+type MCMSReader interface {
+	// GetChainMetadata returns the chain metadata for a given MCMS input.
+	// Each chain family defines its own implementation of this method.
+	GetChainMetadata(e Environment, chainSelector uint64, input MCMSTimelockProposalInput) (mcmstypes.ChainMetadata, error)
+	// GetTimelockRef returns the timelock contract address reference for a given MCMS input.
+	GetTimelockRef(e Environment, chainSelector uint64, input MCMSTimelockProposalInput) (datastore.AddressRef, error)
+	// GetMCMSRef returns the MCMS contract address reference for a given MCMS input.
+	GetMCMSRef(e Environment, chainSelector uint64, input MCMSTimelockProposalInput) (datastore.AddressRef, error)
+}
+
+// MCMSReaderRegistry maintains a registry of MCMS readers.
+type MCMSReaderRegistry struct {
+	mu sync.RWMutex
+	m  map[string]MCMSReader
+}
+
+func newMCMSReaderRegistry() *MCMSReaderRegistry {
+	return &MCMSReaderRegistry{
+		m: make(map[string]MCMSReader),
+	}
+}
+
+var (
+	singletonRegistry *MCMSReaderRegistry
+	once              sync.Once
+)
+
+// GetMCMSReaderRegistry returns the global singleton MCMS reader registry.
+// The first call creates the registry; subsequent calls return the same pointer.
+// This is the recommended way to get the registry, as it ensures a single instance is created and shared.
+func GetMCMSReaderRegistry() *MCMSReaderRegistry {
+	once.Do(func() {
+		singletonRegistry = newMCMSReaderRegistry()
+	})
+
+	return singletonRegistry
+}
+
+// Register registers an MCMSReader for a specific chain family.
+func (r *MCMSReaderRegistry) Register(chainFamily string, reader MCMSReader) error {
+	chainFamily = strings.TrimSpace(chainFamily)
+	if chainFamily == "" {
+		return ErrEmptyChainFamily
+	}
+	if reader == nil {
+		return ErrNilMCMSReader
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.m == nil {
+		r.m = make(map[string]MCMSReader)
+	}
+	if _, exists := r.m[chainFamily]; exists {
+		return fmt.Errorf("%w: %q", ErrDuplicateMCMSReader, chainFamily)
+	}
+	r.m[chainFamily] = reader
+
+	return nil
+}
+
+// Get retrieves an MCMSReader for a specific chain family.
+func (r *MCMSReaderRegistry) Get(chainFamily string) (MCMSReader, bool) {
+	chainFamily = strings.TrimSpace(chainFamily)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	reader, ok := r.m[chainFamily]
+
+	return reader, ok
+}

--- a/deployment/mcms_registry_test.go
+++ b/deployment/mcms_registry_test.go
@@ -1,0 +1,236 @@
+package deployment
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	mcms_types "github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+)
+
+// testValidUntilUnix is a stable far-future timestamp for tests (year 2057).
+const testValidUntilUnix = uint32(2756219818)
+
+const testOpCount = uint64(42)
+
+func validTestMCMSInput() MCMSTimelockProposalInput {
+	return MCMSTimelockProposalInput{
+		TimelockAction: mcms_types.TimelockActionSchedule,
+		ValidUntil:     testValidUntilUnix,
+		TimelockDelay:  mcms_types.NewDuration(time.Hour),
+		Description:    "proposal",
+	}
+}
+
+func TestMCMSTimelockProposalInput_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   MCMSTimelockProposalInput
+		wantErr error
+		errMsg  string
+	}{
+		{
+			name:  "valid schedule",
+			input: validTestMCMSInput(),
+		},
+		{
+			name: "valid bypass with zero delay",
+			input: MCMSTimelockProposalInput{
+				TimelockAction: mcms_types.TimelockActionBypass,
+				ValidUntil:     testValidUntilUnix,
+				TimelockDelay:  mcms_types.NewDuration(0),
+			},
+		},
+		{
+			name: "valid cancel with zero delay",
+			input: MCMSTimelockProposalInput{
+				TimelockAction: mcms_types.TimelockActionCancel,
+				ValidUntil:     testValidUntilUnix,
+				TimelockDelay:  mcms_types.NewDuration(0),
+			},
+		},
+		{
+			name: "invalid timelock action",
+			input: MCMSTimelockProposalInput{
+				TimelockAction: "not-an-action",
+				ValidUntil:     testValidUntilUnix,
+				TimelockDelay:  mcms_types.NewDuration(time.Hour),
+			},
+			wantErr: ErrInvalidMCMSTimelockProposalInput,
+			errMsg:  "invalid timelock action",
+		},
+		{
+			name: "schedule requires positive delay",
+			input: MCMSTimelockProposalInput{
+				TimelockAction: mcms_types.TimelockActionSchedule,
+				ValidUntil:     testValidUntilUnix,
+				TimelockDelay:  mcms_types.NewDuration(0),
+			},
+			wantErr: ErrInvalidMCMSTimelockProposalInput,
+			errMsg:  "timelock delay must be positive for schedule action",
+		},
+		{
+			name: "negative timelock delay",
+			input: MCMSTimelockProposalInput{
+				TimelockAction: mcms_types.TimelockActionSchedule,
+				ValidUntil:     testValidUntilUnix,
+				TimelockDelay:  mcms_types.NewDuration(-time.Hour),
+			},
+			wantErr: ErrInvalidMCMSTimelockProposalInput,
+			errMsg:  "timelock delay must not be negative",
+		},
+		{
+			name: "valid until zero",
+			input: MCMSTimelockProposalInput{
+				TimelockAction: mcms_types.TimelockActionSchedule,
+				ValidUntil:     0,
+				TimelockDelay:  mcms_types.NewDuration(time.Hour),
+			},
+			wantErr: ErrInvalidMCMSTimelockProposalInput,
+			errMsg:  "valid until must be set",
+		},
+		{
+			name: "valid until in the past",
+			input: MCMSTimelockProposalInput{
+				TimelockAction: mcms_types.TimelockActionSchedule,
+				ValidUntil:     1,
+				TimelockDelay:  mcms_types.NewDuration(time.Hour),
+			},
+			wantErr: ErrInvalidMCMSTimelockProposalInput,
+			errMsg:  "valid until must be at least 10 minutes in the future",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.input.Validate()
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tt.wantErr)
+			require.ErrorContains(t, err, tt.errMsg)
+		})
+	}
+}
+
+func TestMCMSTimelockProposalInput_Validate_validUntilBoundary(t *testing.T) {
+	t.Parallel()
+
+	fixedNow := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	input := validTestMCMSInput()
+	input.ValidUntil = minValidUntil(fixedNow)
+	require.NoError(t, input.validateAt(fixedNow))
+
+	input.ValidUntil = minValidUntil(fixedNow) - 1
+	err := input.validateAt(fixedNow)
+	require.ErrorIs(t, err, ErrInvalidMCMSTimelockProposalInput)
+	require.ErrorContains(t, err, "valid until must be at least 10 minutes in the future")
+}
+
+func TestMCMSReaderRegistry_RegisterAndGet(t *testing.T) {
+	t.Parallel()
+
+	registry := newMCMSReaderRegistry()
+	reader := &mockReader{}
+	require.NoError(t, registry.Register("evm", reader))
+
+	got, ok := registry.Get("evm")
+	require.True(t, ok)
+	require.Same(t, reader, got)
+
+	got, ok = registry.Get("  evm  ")
+	require.True(t, ok)
+	require.Same(t, reader, got)
+
+	_, ok = registry.Get("solana")
+	require.False(t, ok)
+}
+
+func TestMCMSReaderRegistry_RegisterDuplicateReturnsError(t *testing.T) {
+	t.Parallel()
+
+	registry := newMCMSReaderRegistry()
+	require.NoError(t, registry.Register("evm", &mockReader{}))
+
+	err := registry.Register("evm", &mockReader{})
+	require.ErrorIs(t, err, ErrDuplicateMCMSReader)
+	require.ErrorContains(t, err, "evm")
+
+	got, ok := registry.Get("evm")
+	require.True(t, ok)
+	require.NotNil(t, got)
+}
+
+func TestMCMSReaderRegistry_RegisterRejectsEmptyChainFamily(t *testing.T) {
+	t.Parallel()
+
+	registry := newMCMSReaderRegistry()
+	err := registry.Register("", &mockReader{})
+	require.ErrorIs(t, err, ErrEmptyChainFamily)
+}
+
+func TestMCMSReaderRegistry_RegisterRejectsNilReader(t *testing.T) {
+	t.Parallel()
+
+	registry := newMCMSReaderRegistry()
+	err := registry.Register("evm", nil)
+	require.ErrorIs(t, err, ErrNilMCMSReader)
+}
+
+func TestMCMSReaderRegistry_GetWithNilMap(t *testing.T) {
+	t.Parallel()
+
+	registry := &MCMSReaderRegistry{}
+	_, ok := registry.Get("evm")
+	require.False(t, ok)
+}
+
+func TestMCMSReaderRegistry_RegisterOnZeroValue(t *testing.T) {
+	t.Parallel()
+
+	registry := &MCMSReaderRegistry{}
+	require.NoError(t, registry.Register("evm", &mockReader{}))
+
+	got, ok := registry.Get("evm")
+	require.True(t, ok)
+	require.NotNil(t, got)
+}
+
+func TestGetMCMSReaderRegistry_ReturnsSingleton(t *testing.T) {
+	t.Parallel()
+
+	first := GetMCMSReaderRegistry()
+	second := GetMCMSReaderRegistry()
+	require.Same(t, first, second)
+}
+
+type mockReader struct{}
+
+func (m *mockReader) GetChainMetadata(_ Environment, _ uint64, _ MCMSTimelockProposalInput) (mcms_types.ChainMetadata, error) {
+	return mcms_types.ChainMetadata{StartingOpCount: testOpCount}, nil
+}
+
+func (m *mockReader) GetTimelockRef(_ Environment, selector uint64, _ MCMSTimelockProposalInput) (datastore.AddressRef, error) {
+	return datastore.AddressRef{
+		ChainSelector: selector,
+		Address:       "0x01",
+		Type:          datastore.ContractType("Timelock"),
+		Version:       semver.MustParse("1.0.0"),
+	}, nil
+}
+
+func (m *mockReader) GetMCMSRef(_ Environment, selector uint64, _ MCMSTimelockProposalInput) (datastore.AddressRef, error) {
+	return datastore.AddressRef{
+		ChainSelector: selector,
+		Address:       "0x02",
+		Type:          datastore.ContractType("MCM"),
+		Version:       semver.MustParse("1.0.0"),
+	}, nil
+}


### PR DESCRIPTION
As part of integrating the utils from Chainlink CCIP tooling API, we are bringing in the [MCMSInput](https://github.com/smartcontractkit/chainlink-ccip/blob/58d2d8467c93ef8db4a434da71062189fd74312c/deployment/utils/mcms) and [MCMSRegistry](https://github.com/smartcontractkit/chainlink-ccip/blob/58d2d8467c93ef8db4a434da71062189fd74312c/deployment/utils/changesets/output.go#L31) plus some code changes, this will be used by the incoming ChangesetOutput.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-2461