### PR TITLE
[CLD-2461]: feat(datastore): new WriteMetadata util

### DIFF
--- a/datastore/memory_datastore.go
+++ b/datastore/memory_datastore.go
@@ -56,6 +56,12 @@ func (s *MemoryDataStore) EnvMetadata() MutableEnvMetadataStore {
 	return s.EnvMetadataStore
 }
 
+// WriteMetadata writes address refs and upserts contract and chain metadata and sets env metadata.
+// Address refs use Add by default; pass WithUpsertAddressRefs to insert or replace by key.
+func (s *MemoryDataStore) WriteMetadata(bundle MetadataBundle, opts ...WriteMetadataOption) error {
+	return WriteMetadataToDataStore(s, bundle, opts...)
+}
+
 // Merge merges the given mutable data store into the current MemoryDataStore.
 func (s *MemoryDataStore) Merge(other DataStore) error {
 	// Fetch address ref records from the other data store

--- a/datastore/write_metadata.go
+++ b/datastore/write_metadata.go
@@ -1,0 +1,93 @@
+package datastore
+
+import "fmt"
+
+// MetadataBundle is address refs plus contract, chain, and env metadata.
+type MetadataBundle struct {
+	// Addresses are the contract addresses that were deployed.
+	Addresses []AddressRef
+	// Contracts defines any metadata pertaining to contracts that were deployed.
+	Contracts []ContractMetadata
+	// Chains defines metadata pertaining to chains that were operated against.
+	Chains []ChainMetadata
+	// Env defines any metadata pertaining to the environment that was deployed to.
+	Env *EnvMetadata
+}
+
+type addressRefWriteMode int
+
+const (
+	addressRefWriteAdd addressRefWriteMode = iota
+	addressRefWriteUpsert
+)
+
+type writeMetadataConfig struct {
+	addressRefMode addressRefWriteMode
+}
+
+// WriteMetadataOption configures WriteMetadataToDatastore.
+type WriteMetadataOption func(*writeMetadataConfig)
+
+// WithUpsertAddressRefs writes address refs with Upsert instead of the default Add.
+// Upsert replaces the full record for an existing key (chain, type, version, qualifier),
+// including Address.
+func WithUpsertAddressRefs() WriteMetadataOption {
+	return func(cfg *writeMetadataConfig) {
+		cfg.addressRefMode = addressRefWriteUpsert
+	}
+}
+
+func applyWriteMetadataOptions(opts []WriteMetadataOption) writeMetadataConfig {
+	cfg := writeMetadataConfig{addressRefMode: addressRefWriteAdd}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	return cfg
+}
+
+// WriteMetadataToDataStore writes address refs and upserts contract and chain metadata and sets env metadata.
+// Address refs use Add by default; pass WithUpsertAddressRefs to insert or replace by key.
+func WriteMetadataToDataStore(ds MutableDataStore, bundle MetadataBundle, opts ...WriteMetadataOption) error {
+	cfg := applyWriteMetadataOptions(opts)
+
+	for _, ref := range bundle.Addresses {
+		var err error
+		switch cfg.addressRefMode {
+		case addressRefWriteAdd:
+			err = ds.Addresses().Add(ref)
+		case addressRefWriteUpsert:
+			err = ds.Addresses().Upsert(ref)
+		default:
+			err = fmt.Errorf("unknown address ref write mode: %d", cfg.addressRefMode)
+		}
+		if err != nil {
+			verb := "add"
+			if cfg.addressRefMode == addressRefWriteUpsert {
+				verb = "upsert"
+			}
+
+			return fmt.Errorf("failed to %s %s %v at %s on chain %d to datastore: %w",
+				verb, ref.Type, ref.Version, ref.Address, ref.ChainSelector, err)
+		}
+	}
+	for _, contract := range bundle.Contracts {
+		if err := ds.ContractMetadata().Upsert(contract); err != nil {
+			return fmt.Errorf("failed to upsert contract metadata for %s on chain %d to datastore: %w",
+				contract.Address, contract.ChainSelector, err)
+		}
+	}
+	for _, chain := range bundle.Chains {
+		if err := ds.ChainMetadata().Upsert(chain); err != nil {
+			return fmt.Errorf("failed to upsert chain metadata for chain %d to datastore: %w",
+				chain.ChainSelector, err)
+		}
+	}
+	if bundle.Env != nil {
+		if err := ds.EnvMetadata().Set(*bundle.Env); err != nil {
+			return fmt.Errorf("failed to set env metadata to datastore: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/datastore/write_metadata_test.go
+++ b/datastore/write_metadata_test.go
@@ -1,0 +1,201 @@
+package datastore
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteMetadataToDataStore(t *testing.T) {
+	t.Parallel()
+
+	contractOne := ContractMetadata{
+		Address:       "0xaaa",
+		ChainSelector: 1,
+		Metadata:      testMetadata{Field: "contract-one", ChainSelector: 1},
+	}
+	contractTwo := ContractMetadata{
+		Address:       "0xbbb",
+		ChainSelector: 2,
+		Metadata:      testMetadata{Field: "contract-two", ChainSelector: 2},
+	}
+	chainMD := ChainMetadata{
+		ChainSelector: 1,
+		Metadata:      testMetadata{Field: "chain", ChainSelector: 1},
+	}
+	envMD := EnvMetadata{
+		Metadata: testMetadata{Field: "env", ChainSelector: 0},
+	}
+
+	t.Run("via mutable interface", func(t *testing.T) {
+		t.Parallel()
+		var ds MutableDataStore = NewMemoryDataStore()
+		require.NoError(t, WriteMetadataToDataStore(ds, MetadataBundle{}))
+	})
+
+	t.Run("writes addresses and contract metadata", func(t *testing.T) {
+		t.Parallel()
+		ds := NewMemoryDataStore()
+		ref := AddressRef{
+			Address:       "0xabc",
+			ChainSelector: 1,
+			Type:          "Timelock",
+			Version:       semver.MustParse("1.0.0"),
+		}
+		contractMD := ContractMetadata{
+			Address:       "0xabc",
+			ChainSelector: 1,
+			Metadata:      testMetadata{Field: "contract", ChainSelector: 1},
+		}
+
+		require.NoError(t, WriteMetadataToDataStore(ds, MetadataBundle{
+			Addresses: []AddressRef{ref},
+			Contracts: []ContractMetadata{contractMD},
+		}))
+
+		refs, err := ds.Addresses().Fetch()
+		require.NoError(t, err)
+		require.Len(t, refs, 1)
+
+		contracts, err := ds.ContractMetadata().Fetch()
+		require.NoError(t, err)
+		require.Len(t, contracts, 1)
+
+		err = WriteMetadataToDataStore(ds, MetadataBundle{Addresses: []AddressRef{ref}})
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrAddressRefExists)
+	})
+
+	t.Run("memory datastore convenience method", func(t *testing.T) {
+		t.Parallel()
+		ds := NewMemoryDataStore()
+		require.NoError(t, ds.WriteMetadata(MetadataBundle{}))
+	})
+
+	t.Run("empty bundle is a no-op", func(t *testing.T) {
+		t.Parallel()
+		ds := NewMemoryDataStore()
+		require.NoError(t, WriteMetadataToDataStore(ds, MetadataBundle{}))
+
+		contracts, err := ds.ContractMetadata().Fetch()
+		require.NoError(t, err)
+		require.Empty(t, contracts)
+
+		chains, err := ds.ChainMetadata().Fetch()
+		require.NoError(t, err)
+		require.Empty(t, chains)
+
+		_, err = ds.EnvMetadata().Get()
+		require.ErrorIs(t, err, ErrEnvMetadataNotSet)
+	})
+
+	t.Run("writes multiple chain metadata entries", func(t *testing.T) {
+		t.Parallel()
+		ds := NewMemoryDataStore()
+		chainTwo := ChainMetadata{
+			ChainSelector: 2,
+			Metadata:      testMetadata{Field: "chain-two", ChainSelector: 2},
+		}
+
+		require.NoError(t, WriteMetadataToDataStore(ds, MetadataBundle{
+			Chains: []ChainMetadata{chainMD, chainTwo},
+		}))
+
+		chains, err := ds.ChainMetadata().Fetch()
+		require.NoError(t, err)
+		require.Len(t, chains, 2)
+	})
+
+	t.Run("writes contracts chain and env", func(t *testing.T) {
+		t.Parallel()
+		ds := NewMemoryDataStore()
+		require.NoError(t, WriteMetadataToDataStore(ds, MetadataBundle{
+			Contracts: []ContractMetadata{contractOne, contractTwo},
+			Chains:    []ChainMetadata{chainMD},
+			Env:       &envMD,
+		}))
+
+		contracts, err := ds.ContractMetadata().Fetch()
+		require.NoError(t, err)
+		require.Len(t, contracts, 2)
+
+		chains, err := ds.ChainMetadata().Fetch()
+		require.NoError(t, err)
+		require.Len(t, chains, 1)
+		require.Equal(t, uint64(1), chains[0].ChainSelector)
+
+		gotEnv, err := ds.EnvMetadata().Get()
+		require.NoError(t, err)
+		gotEnvMD, err := As[testMetadata](gotEnv.Metadata)
+		require.NoError(t, err)
+		require.Equal(t, "env", gotEnvMD.Field)
+	})
+
+	t.Run("WithUpsertAddressRefs overwrites existing address ref", func(t *testing.T) {
+		t.Parallel()
+		ds := NewMemoryDataStore()
+		ref := AddressRef{
+			Address:       "0xabc",
+			ChainSelector: 1,
+			Type:          "Timelock",
+			Version:       semver.MustParse("1.0.0"),
+		}
+		updatedRef := ref
+		updatedRef.Address = "0xdef"
+
+		require.NoError(t, WriteMetadataToDataStore(ds, MetadataBundle{Addresses: []AddressRef{ref}}))
+		require.NoError(t, WriteMetadataToDataStore(ds, MetadataBundle{Addresses: []AddressRef{updatedRef}}, WithUpsertAddressRefs()))
+
+		refs, err := ds.Addresses().Fetch()
+		require.NoError(t, err)
+		require.Len(t, refs, 1)
+		require.Equal(t, "0xdef", refs[0].Address)
+	})
+
+	t.Run("upserts overwrite existing records", func(t *testing.T) {
+		t.Parallel()
+		ds := NewMemoryDataStore()
+		require.NoError(t, WriteMetadataToDataStore(ds, MetadataBundle{
+			Contracts: []ContractMetadata{contractOne},
+			Chains:    []ChainMetadata{chainMD},
+			Env:       &envMD,
+		}))
+
+		updatedContract := contractOne
+		updatedContract.Metadata = testMetadata{Field: "updated", ChainSelector: 1}
+		updatedChain := ChainMetadata{
+			ChainSelector: 1,
+			Metadata:      testMetadata{Field: "updated-chain", ChainSelector: 1},
+		}
+		updatedEnv := EnvMetadata{
+			Metadata: testMetadata{Field: "updated-env", ChainSelector: 0},
+		}
+
+		require.NoError(t, WriteMetadataToDataStore(ds, MetadataBundle{
+			Contracts: []ContractMetadata{updatedContract},
+			Chains:    []ChainMetadata{updatedChain},
+			Env:       &updatedEnv,
+		}))
+
+		contracts, err := ds.ContractMetadata().Fetch()
+		require.NoError(t, err)
+		require.Len(t, contracts, 1)
+		gotContractMD, err := As[testMetadata](contracts[0].Metadata)
+		require.NoError(t, err)
+		require.Equal(t, "updated", gotContractMD.Field)
+
+		chains, err := ds.ChainMetadata().Fetch()
+		require.NoError(t, err)
+		require.Len(t, chains, 1)
+		gotChainMD, err := As[testMetadata](chains[0].Metadata)
+		require.NoError(t, err)
+		require.Equal(t, "updated-chain", gotChainMD.Field)
+
+		gotEnv, err := ds.EnvMetadata().Get()
+		require.NoError(t, err)
+		gotEnvMD, err := As[testMetadata](gotEnv.Metadata)
+		require.NoError(t, err)
+		require.Equal(t, "updated-env", gotEnvMD.Field)
+	})
+}


### PR DESCRIPTION
Chainlink CCIP tooling api provides [WriteMetadataToDatastore util](https://github.com/smartcontractkit/chainlink-ccip/blob/298ed1c38d5cda61a688beb2494a96a5409daf3d/deployment/utils/sequences/sequences.go#L76), this is heavily used in their changets.

I have integrated this into the datastore package with the MutableDatastore and added the ability to add addresses as well as that is a common pattern.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-2461