### PR TITLE
[CLD-2462]: feat(deployment): new changeset output builder

### DIFF
--- a/.changeset/output-builder-mcms.md
+++ b/.changeset/output-builder-mcms.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat(deployment): add OutputBuilder for changeset output and MCMS timelock proposals

--- a/deployment/output_builder.go
+++ b/deployment/output_builder.go
@@ -1,0 +1,236 @@
+package deployment
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+
+	"github.com/smartcontractkit/mcms"
+	mcms_types "github.com/smartcontractkit/mcms/types"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+)
+
+// MCMSTimelockProposalSpec is the input for building one MCMS timelock proposal.
+type MCMSTimelockProposalSpec struct {
+	Input    MCMSTimelockProposalInput
+	BatchOps []mcms_types.BatchOperation
+}
+
+// OutputBuilder builds a ChangesetOutput, including MCMS timelock proposals from MCMSTimelockProposalSpec entries.
+//
+// Multiple proposals: call WithTimelockProposal once per proposal. Each spec is built independently.
+//
+// StartingOpCount: GetChainMetadata is invoked per proposal from current environment state. This builder does
+// not advance op counts across proposals. When multiple proposals target the same chain in one changeset,
+// coordinate StartingOpCount outside the builder before Build.
+type OutputBuilder struct {
+	registry        *MCMSReaderRegistry
+	environment     Environment
+	proposalSpecs   []MCMSTimelockProposalSpec
+	changesetOutput ChangesetOutput
+}
+
+// NewOutputBuilder creates a new OutputBuilder with the given environment and data store.
+func NewOutputBuilder(e Environment, newDS datastore.MutableDataStore) *OutputBuilder {
+	return &OutputBuilder{
+		environment:   e,
+		proposalSpecs: []MCMSTimelockProposalSpec{},
+		changesetOutput: ChangesetOutput{
+			DataStore: newDS,
+		},
+	}
+}
+
+// WithOperationsReports sets the reports on the ChangesetOutput.
+func (b *OutputBuilder) WithOperationsReports(reports []operations.Report[any, any]) *OutputBuilder {
+	b.changesetOutput.Reports = reports
+	return b
+}
+
+// WithMCMSReaderRegistry overrides the MCMS reader registry used during Build (default: GetMCMSReaderRegistry).
+// In most cases, you should not need to use this method.
+func (b *OutputBuilder) WithMCMSReaderRegistry(registry *MCMSReaderRegistry) *OutputBuilder {
+	b.registry = registry
+	return b
+}
+
+type batchOpsConfig struct {
+	mergePerChain bool
+}
+
+// BatchOpsOption configures how batch operations are processed for a timelock proposal.
+type BatchOpsOption func(*batchOpsConfig)
+
+// WithoutMergeBatchOpsPerChain keeps batch operations as provided, only filtering out empty operations.
+func WithoutMergeBatchOpsPerChain() BatchOpsOption {
+	return func(c *batchOpsConfig) {
+		c.mergePerChain = false
+	}
+}
+
+// WithTimelockProposal appends an MCMS timelock proposal to build at the end of Build.
+// Empty batch operations (no transactions) are filtered out. By default, multiple batch operations for the same
+// chain are merged into one, preserving transaction order. Use WithoutMergeBatchOpsPerChain to keep operations
+// separate per chain.
+func (b *OutputBuilder) WithTimelockProposal(
+	input MCMSTimelockProposalInput,
+	ops []mcms_types.BatchOperation,
+	opts ...BatchOpsOption,
+) *OutputBuilder {
+	b.proposalSpecs = append(b.proposalSpecs, MCMSTimelockProposalSpec{
+		Input:    input,
+		BatchOps: processBatchOps(ops, opts...),
+	})
+
+	return b
+}
+
+// Build constructs the final ChangesetOutput, including one MCMS timelock proposal per non-empty spec.
+// On error, returns the accumulated ChangesetOutput (data store, reports, and any proposals built so far)
+// together with an error. The error index refers to the position in the appended proposal spec list (including
+// specs skipped because they have no batch operations after processing).
+func (b *OutputBuilder) Build() (ChangesetOutput, error) {
+	proposals := make([]mcms.TimelockProposal, 0, len(b.proposalSpecs))
+	for i, spec := range b.proposalSpecs {
+		if len(spec.BatchOps) == 0 {
+			continue
+		}
+		proposal, err := b.buildTimelockProposal(spec)
+		if err != nil {
+			b.changesetOutput.MCMSTimelockProposals = proposals
+			return b.changesetOutput, fmt.Errorf("timelock proposal spec at index %d: %w", i, err)
+		}
+		proposals = append(proposals, proposal)
+	}
+
+	b.changesetOutput.MCMSTimelockProposals = proposals
+
+	return b.changesetOutput, nil
+}
+
+func (b *OutputBuilder) buildTimelockProposal(spec MCMSTimelockProposalSpec) (mcms.TimelockProposal, error) {
+	if err := spec.Input.Validate(); err != nil {
+		return mcms.TimelockProposal{}, fmt.Errorf("failed to validate MCMS timelock proposal input: %w", err)
+	}
+
+	timelockAddresses, chainMetadata, err := b.resolveMCMSPerChain(spec.Input, spec.BatchOps)
+	if err != nil {
+		return mcms.TimelockProposal{}, err
+	}
+
+	proposal, err := mcms.NewTimelockProposalBuilder().
+		SetVersion("v1").
+		SetDescription(spec.Input.Description).
+		SetOverridePreviousRoot(spec.Input.OverridePreviousRoot).
+		SetValidUntil(spec.Input.ValidUntil).
+		SetDelay(spec.Input.TimelockDelay).
+		SetAction(spec.Input.TimelockAction).
+		SetOperations(spec.BatchOps).
+		SetTimelockAddresses(timelockAddresses).
+		SetChainMetadata(chainMetadata).
+		Build()
+	if err != nil {
+		return mcms.TimelockProposal{}, fmt.Errorf("failed to build MCMS proposal: %w", err)
+	}
+
+	return *proposal, nil
+}
+
+func (b *OutputBuilder) mcmsRegistry() *MCMSReaderRegistry {
+	if b.registry != nil {
+		return b.registry
+	}
+
+	return GetMCMSReaderRegistry()
+}
+
+func processBatchOps(ops []mcms_types.BatchOperation, opts ...BatchOpsOption) []mcms_types.BatchOperation {
+	cfg := batchOpsConfig{mergePerChain: true}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	if cfg.mergePerChain {
+		return mergeBatchOpsPerChain(ops)
+	}
+
+	return filterNonEmptyBatchOps(ops)
+}
+
+func filterNonEmptyBatchOps(ops []mcms_types.BatchOperation) []mcms_types.BatchOperation {
+	filtered := make([]mcms_types.BatchOperation, 0, len(ops))
+	for _, op := range ops {
+		if len(op.Transactions) > 0 {
+			filtered = append(filtered, op)
+		}
+	}
+
+	return filtered
+}
+
+func mergeBatchOpsPerChain(ops []mcms_types.BatchOperation) []mcms_types.BatchOperation {
+	txPerChain := make(map[mcms_types.ChainSelector][]mcms_types.Transaction)
+	chainOrder := make([]mcms_types.ChainSelector, 0)
+	for _, op := range ops {
+		if len(op.Transactions) == 0 {
+			continue
+		}
+		if _, seen := txPerChain[op.ChainSelector]; !seen {
+			chainOrder = append(chainOrder, op.ChainSelector)
+		}
+		txPerChain[op.ChainSelector] = append(txPerChain[op.ChainSelector], op.Transactions...)
+	}
+
+	merged := make([]mcms_types.BatchOperation, 0, len(chainOrder))
+	for _, chainSelector := range chainOrder {
+		merged = append(merged, mcms_types.BatchOperation{
+			ChainSelector: chainSelector,
+			Transactions:  txPerChain[chainSelector],
+		})
+	}
+
+	return merged
+}
+
+func (b *OutputBuilder) resolveMCMSPerChain(
+	input MCMSTimelockProposalInput,
+	ops []mcms_types.BatchOperation,
+) (map[mcms_types.ChainSelector]string, map[mcms_types.ChainSelector]mcms_types.ChainMetadata, error) {
+	timelocks := make(map[mcms_types.ChainSelector]string)
+	metadata := make(map[mcms_types.ChainSelector]mcms_types.ChainMetadata)
+	seen := make(map[mcms_types.ChainSelector]struct{})
+
+	for _, op := range ops {
+		if _, ok := seen[op.ChainSelector]; ok {
+			continue
+		}
+		seen[op.ChainSelector] = struct{}{}
+		chainSelector := op.ChainSelector
+
+		family, err := chain_selectors.GetSelectorFamily(uint64(chainSelector))
+		if err != nil {
+			return nil, nil, fmt.Errorf("chain family for selector %d: %w", chainSelector, err)
+		}
+		reader, ok := b.mcmsRegistry().Get(family)
+		if !ok {
+			return nil, nil, fmt.Errorf("no MCMS reader registered for chain family '%s'", family)
+		}
+
+		timelockRef, err := reader.GetTimelockRef(b.environment, uint64(chainSelector), input)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get timelock ref for chain %d: %w", chainSelector, err)
+		}
+		timelocks[chainSelector] = timelockRef.Address
+
+		chainMetadata, err := reader.GetChainMetadata(b.environment, uint64(chainSelector), input)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get chain metadata for chain %d: %w", chainSelector, err)
+		}
+		metadata[chainSelector] = chainMetadata
+	}
+
+	return timelocks, metadata, nil
+}

--- a/deployment/output_builder_test.go
+++ b/deployment/output_builder_test.go
@@ -1,0 +1,413 @@
+package deployment
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	mcms_types "github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+)
+
+const ethMainnetSelector = 5009297550715157269
+
+func TestNewOutputBuilder_fromMutableDataStore(t *testing.T) {
+	t.Parallel()
+	ds := datastore.NewMemoryDataStore()
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: ethMainnetSelector,
+		Type:          "Timelock",
+		Version:       semver.MustParse("1.0.0"),
+		Address:       "0xabc",
+	}))
+
+	b := requireTestOutputBuilder(t, ds)
+
+	out, err := b.Build()
+	require.NoError(t, err)
+	refs, err := out.DataStore.Addresses().Fetch()
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	require.Equal(t, "0xabc", refs[0].Address)
+}
+
+func TestWithOperationsReports(t *testing.T) {
+	t.Parallel()
+	b := newTestOutputBuilder(t)
+	reports := []operations.Report[any, any]{{}}
+	out, err := b.WithOperationsReports(reports).Build()
+	require.NoError(t, err)
+	require.Len(t, out.Reports, 1)
+}
+
+func TestBuild_noTimelockProposals(t *testing.T) {
+	t.Parallel()
+	b := newTestOutputBuilder(t)
+	out, err := b.Build()
+	require.NoError(t, err)
+	require.Empty(t, out.MCMSTimelockProposals)
+}
+
+func TestBuild_invalidMCMSInput(t *testing.T) {
+	t.Parallel()
+	b := newTestOutputBuilder(t)
+	b.WithMCMSReaderRegistry(testMCMSRegistry(t))
+	_, err := b.WithTimelockProposal(MCMSTimelockProposalInput{
+		TimelockAction: mcms_types.TimelockActionSchedule,
+		ValidUntil:     1,
+		TimelockDelay:  mcms_types.NewDuration(time.Hour),
+	}, []mcms_types.BatchOperation{sampleBatchOp()}).Build()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to validate MCMS timelock proposal input")
+	require.ErrorIs(t, err, ErrInvalidMCMSTimelockProposalInput)
+}
+
+func TestWithTimelockProposal_filtersEmptyTransactions(t *testing.T) {
+	t.Parallel()
+
+	emptyThenSample := []mcms_types.BatchOperation{
+		{ChainSelector: ethMainnetSelector, Transactions: nil},
+		sampleBatchOp(),
+	}
+
+	tests := []struct {
+		name string
+		opts []BatchOpsOption
+	}{
+		{name: "merge by default"},
+		{
+			name: "without merge",
+			opts: []BatchOpsOption{WithoutMergeBatchOpsPerChain()},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			b := newTestOutputBuilder(t)
+			b.WithMCMSReaderRegistry(testMCMSRegistry(t))
+			out, err := b.WithTimelockProposal(validMCMSProposalInput(), emptyThenSample, tt.opts...).Build()
+			require.NoError(t, err)
+			require.Len(t, out.MCMSTimelockProposals, 1)
+			require.Len(t, out.MCMSTimelockProposals[0].Operations, 1)
+			require.Len(t, out.MCMSTimelockProposals[0].Operations[0].Transactions, 1)
+		})
+	}
+}
+
+func TestWithTimelockProposal_withoutMerge_keepsSeparateOpsPerChain(t *testing.T) {
+	t.Parallel()
+	b := newTestOutputBuilder(t)
+	b.WithMCMSReaderRegistry(testMCMSRegistry(t))
+	out, err := b.WithTimelockProposal(validMCMSProposalInput(), []mcms_types.BatchOperation{
+		sampleBatchOp(),
+		sampleBatchOp(),
+	}, WithoutMergeBatchOpsPerChain()).Build()
+	require.NoError(t, err)
+	require.Len(t, out.MCMSTimelockProposals[0].Operations, 2)
+}
+
+func TestBuild_allEmptyBatchOpsSkipsProposal(t *testing.T) {
+	t.Parallel()
+	b := newTestOutputBuilder(t)
+	b.WithMCMSReaderRegistry(testMCMSRegistry(t))
+	out, err := b.WithTimelockProposal(validMCMSProposalInput(), []mcms_types.BatchOperation{
+		{ChainSelector: ethMainnetSelector, Transactions: nil},
+		{ChainSelector: ethMainnetSelector, Transactions: []mcms_types.Transaction{}},
+	}).Build()
+	require.NoError(t, err)
+	require.Empty(t, out.MCMSTimelockProposals)
+}
+
+func TestBuild_unregisteredChainFamily(t *testing.T) {
+	t.Parallel()
+	b := newTestOutputBuilder(t)
+	b.WithMCMSReaderRegistry(newMCMSReaderRegistry())
+	_, err := b.WithTimelockProposal(validMCMSProposalInput(), []mcms_types.BatchOperation{sampleBatchOp()}).Build()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no MCMS reader registered for chain family")
+}
+
+func TestBuild_invalidChainSelector(t *testing.T) {
+	t.Parallel()
+	b := newTestOutputBuilder(t)
+	b.WithMCMSReaderRegistry(testMCMSRegistry(t))
+	_, err := b.WithTimelockProposal(validMCMSProposalInput(), []mcms_types.BatchOperation{
+		{
+			ChainSelector: 0,
+			Transactions: []mcms_types.Transaction{
+				{To: "0x01", Data: []byte("0x01"), AdditionalFields: json.RawMessage{}},
+			},
+		},
+	}).Build()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "chain family for selector 0")
+}
+
+func TestBuild_getTimelockRefError(t *testing.T) {
+	t.Parallel()
+	readerErr := errors.New("timelock ref failed")
+	registry := newMCMSReaderRegistry()
+	require.NoError(t, registry.Register("evm", &failingTimelockReader{err: readerErr}))
+
+	b := newTestOutputBuilder(t)
+	b.WithMCMSReaderRegistry(registry)
+	_, err := b.WithTimelockProposal(validMCMSProposalInput(), []mcms_types.BatchOperation{sampleBatchOp()}).Build()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "get timelock ref for chain")
+	require.ErrorIs(t, err, readerErr)
+}
+
+func TestBuild_getChainMetadataError(t *testing.T) {
+	t.Parallel()
+	readerErr := errors.New("chain metadata failed")
+	registry := newMCMSReaderRegistry()
+	require.NoError(t, registry.Register("evm", &failingMetadataReader{err: readerErr}))
+
+	b := newTestOutputBuilder(t)
+	b.WithMCMSReaderRegistry(registry)
+	_, err := b.WithTimelockProposal(validMCMSProposalInput(), []mcms_types.BatchOperation{sampleBatchOp()}).Build()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "get chain metadata for chain")
+	require.ErrorIs(t, err, readerErr)
+}
+
+func TestBuild_deduplicatesReaderCallsPerChain(t *testing.T) {
+	t.Parallel()
+	reader := &countingReader{}
+	registry := newMCMSReaderRegistry()
+	require.NoError(t, registry.Register("evm", reader))
+
+	b := newTestOutputBuilder(t)
+	b.WithMCMSReaderRegistry(registry)
+	_, err := b.WithTimelockProposal(validMCMSProposalInput(), []mcms_types.BatchOperation{
+		sampleBatchOp(),
+		sampleBatchOp(),
+	}).Build()
+	require.NoError(t, err)
+	require.Equal(t, 1, reader.timelockCalls)
+	require.Equal(t, 1, reader.metadataCalls)
+}
+
+func TestWithTimelockProposal(t *testing.T) {
+	t.Parallel()
+	input := validMCMSProposalInput()
+	b := newTestOutputBuilder(t)
+	b.WithMCMSReaderRegistry(testMCMSRegistry(t))
+	out, err := b.WithTimelockProposal(input, []mcms_types.BatchOperation{sampleBatchOp()}).Build()
+	require.NoError(t, err)
+	require.Len(t, out.MCMSTimelockProposals, 1)
+
+	prop := out.MCMSTimelockProposals[0]
+	require.Equal(t, input.Description, prop.Description)
+	require.Equal(t, input.ValidUntil, prop.ValidUntil)
+	require.Equal(t, input.OverridePreviousRoot, prop.OverridePreviousRoot)
+	require.Equal(t, input.TimelockAction, prop.Action)
+	require.Equal(t, input.TimelockDelay, prop.Delay)
+	require.Equal(t, "0x01", prop.TimelockAddresses[ethMainnetSelector])
+	require.Equal(t, testOpCount, prop.ChainMetadata[ethMainnetSelector].StartingOpCount)
+	require.Len(t, prop.Operations, 1)
+	require.Len(t, prop.Operations[0].Transactions, 1)
+}
+
+func TestWithTimelockProposal_mergePerChain(t *testing.T) {
+	t.Parallel()
+	const chainA = ethMainnetSelector
+	const chainB = uint64(4340886533089894000)
+
+	b := newTestOutputBuilder(t)
+	b.WithMCMSReaderRegistry(testMCMSRegistry(t))
+	batchOps := []mcms_types.BatchOperation{
+		{
+			ChainSelector: mcms_types.ChainSelector(chainA),
+			Transactions: []mcms_types.Transaction{
+				{To: "0x01", Data: []byte("0xdeadbeef"), AdditionalFields: json.RawMessage{}},
+			},
+		},
+		{
+			ChainSelector: mcms_types.ChainSelector(chainA),
+			Transactions: []mcms_types.Transaction{
+				{To: "0x01", Data: []byte("0xcafebabe"), AdditionalFields: json.RawMessage{}},
+			},
+		},
+		{
+			ChainSelector: mcms_types.ChainSelector(chainB),
+			Transactions: []mcms_types.Transaction{
+				{To: "0x03", Data: []byte("0xface"), AdditionalFields: json.RawMessage{}},
+			},
+		},
+	}
+	out, err := b.WithTimelockProposal(validMCMSProposalInput(), batchOps).Build()
+	require.NoError(t, err)
+	require.Len(t, out.MCMSTimelockProposals, 1)
+	require.Len(t, out.MCMSTimelockProposals[0].Operations, 2)
+
+	prop := out.MCMSTimelockProposals[0]
+	require.Equal(t, mcms_types.ChainSelector(chainA), prop.Operations[0].ChainSelector)
+	require.Equal(t, mcms_types.ChainSelector(chainB), prop.Operations[1].ChainSelector)
+
+	var txCountChainA, txCountChainB int
+	for _, op := range prop.Operations {
+		switch op.ChainSelector {
+		case mcms_types.ChainSelector(chainA):
+			txCountChainA = len(op.Transactions)
+		case mcms_types.ChainSelector(chainB):
+			txCountChainB = len(op.Transactions)
+		}
+	}
+	require.Equal(t, 2, txCountChainA)
+	require.Equal(t, 1, txCountChainB)
+
+	var chainATxs []mcms_types.Transaction
+	for _, op := range prop.Operations {
+		if op.ChainSelector == mcms_types.ChainSelector(chainA) {
+			chainATxs = op.Transactions
+			break
+		}
+	}
+	require.Equal(t, []byte("0xdeadbeef"), chainATxs[0].Data)
+	require.Equal(t, []byte("0xcafebabe"), chainATxs[1].Data)
+}
+
+func TestWithTimelockProposal_multipleSpecs(t *testing.T) {
+	t.Parallel()
+
+	scheduleInput := validMCMSProposalInput()
+	cancelInput := validMCMSProposalInput()
+	cancelInput.Description = "Cancel proposal"
+	cancelInput.TimelockAction = mcms_types.TimelockActionCancel
+	cancelInput.TimelockDelay = mcms_types.NewDuration(0)
+
+	b := newTestOutputBuilder(t)
+	b.WithMCMSReaderRegistry(testMCMSRegistry(t))
+	b.WithTimelockProposal(scheduleInput, []mcms_types.BatchOperation{sampleBatchOp()})
+	b.WithTimelockProposal(cancelInput, []mcms_types.BatchOperation{
+		{
+			ChainSelector: ethMainnetSelector,
+			Transactions: []mcms_types.Transaction{
+				{To: "0x02", Data: []byte("0x01"), AdditionalFields: json.RawMessage{}},
+				{To: "0x02", Data: []byte("0x02"), AdditionalFields: json.RawMessage{}},
+			},
+		},
+	})
+
+	out, err := b.Build()
+	require.NoError(t, err)
+	require.Len(t, out.MCMSTimelockProposals, 2)
+	require.Equal(t, scheduleInput.Description, out.MCMSTimelockProposals[0].Description)
+	require.Equal(t, cancelInput.Description, out.MCMSTimelockProposals[1].Description)
+	require.Len(t, out.MCMSTimelockProposals[0].Operations[0].Transactions, 1)
+	require.Len(t, out.MCMSTimelockProposals[1].Operations[0].Transactions, 2)
+}
+
+func TestBuild_returnsPartialOutputOnProposalFailure(t *testing.T) {
+	t.Parallel()
+
+	ds := datastore.NewMemoryDataStore()
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: ethMainnetSelector,
+		Type:          "Timelock",
+		Version:       semver.MustParse("1.0.0"),
+		Address:       "0xabc",
+	}))
+	reports := []operations.Report[any, any]{{}}
+
+	b := NewOutputBuilder(Environment{}, ds).
+		WithOperationsReports(reports).
+		WithMCMSReaderRegistry(testMCMSRegistry(t))
+	b.WithTimelockProposal(validMCMSProposalInput(), []mcms_types.BatchOperation{sampleBatchOp()})
+	b.WithTimelockProposal(MCMSTimelockProposalInput{
+		TimelockAction: mcms_types.TimelockActionSchedule,
+		ValidUntil:     1,
+		TimelockDelay:  mcms_types.NewDuration(time.Hour),
+	}, []mcms_types.BatchOperation{sampleBatchOp()})
+
+	out, err := b.Build()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "timelock proposal spec at index 1")
+	require.NotNil(t, out.DataStore)
+	refs, fetchErr := out.DataStore.Addresses().Fetch()
+	require.NoError(t, fetchErr)
+	require.Len(t, refs, 1)
+	require.Equal(t, reports, out.Reports)
+	require.Len(t, out.MCMSTimelockProposals, 1)
+}
+
+func validMCMSProposalInput() MCMSTimelockProposalInput {
+	input := validTestMCMSInput()
+	input.OverridePreviousRoot = false
+	input.TimelockDelay = mcms_types.NewDuration(3 * time.Hour)
+	input.Description = "Proposal"
+
+	return input
+}
+
+func sampleBatchOp() mcms_types.BatchOperation {
+	return mcms_types.BatchOperation{
+		ChainSelector: ethMainnetSelector,
+		Transactions: []mcms_types.Transaction{
+			{To: "0x01", Data: []byte("0xdeadbeef"), AdditionalFields: json.RawMessage{}},
+		},
+	}
+}
+
+func newTestOutputBuilder(t *testing.T) *OutputBuilder {
+	t.Helper()
+
+	return requireTestOutputBuilder(t, datastore.NewMemoryDataStore())
+}
+
+func requireTestOutputBuilder(t *testing.T, ds datastore.MutableDataStore) *OutputBuilder {
+	t.Helper()
+
+	return NewOutputBuilder(Environment{}, ds)
+}
+
+func testMCMSRegistry(t *testing.T) *MCMSReaderRegistry {
+	t.Helper()
+	r := newMCMSReaderRegistry()
+	require.NoError(t, r.Register("evm", &mockReader{}))
+
+	return r
+}
+
+// ---- Mock Readers ----
+
+type failingTimelockReader struct {
+	mockReader
+	err error
+}
+
+func (r *failingTimelockReader) GetTimelockRef(_ Environment, _ uint64, _ MCMSTimelockProposalInput) (datastore.AddressRef, error) {
+	return datastore.AddressRef{}, r.err
+}
+
+type failingMetadataReader struct {
+	mockReader
+	err error
+}
+
+func (r *failingMetadataReader) GetChainMetadata(_ Environment, _ uint64, _ MCMSTimelockProposalInput) (mcms_types.ChainMetadata, error) {
+	return mcms_types.ChainMetadata{}, r.err
+}
+
+type countingReader struct {
+	mockReader
+	timelockCalls int
+	metadataCalls int
+}
+
+func (r *countingReader) GetTimelockRef(e Environment, selector uint64, input MCMSTimelockProposalInput) (datastore.AddressRef, error) {
+	r.timelockCalls++
+	return r.mockReader.GetTimelockRef(e, selector, input)
+}
+
+func (r *countingReader) GetChainMetadata(e Environment, selector uint64, input MCMSTimelockProposalInput) (mcms_types.ChainMetadata, error) {
+	r.metadataCalls++
+	return r.mockReader.GetChainMetadata(e, selector, input)
+}


### PR DESCRIPTION
In deployment package, implemented a changeset output builder util which simplifies how users construct changeset output, including MCMS timelock proposals. This was taken from [CCIP tooling api](https://github.com/smartcontractkit/chainlink-ccip/blob/4374eb0449fb361e611a71aa16dd5eb896554537/deployment/utils/changesets/output.go#L86) and refactored to suit CLDF.

```go
	return deployment.NewOutputBuilder(env, datastore).
		WithOperationsReports(r.ExecutionReports).
		WithTimelockProposal(input, batchOps).
		Build()
```

For multiple proposals in one changeset, call `WithTimelockProposal` once per proposal. Batch operations on the same chain are merged by default unless `WithoutMergeBatchOpsPerChain()` is used.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-2462