### PR TITLE
feat(datastore): new query helpers

### DIFF
--- a/.changeset/datastore-query-helpers.md
+++ b/.changeset/datastore-query-helpers.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat(datastore): add FindUniqueRef and FindAndFormatRef query helpers

--- a/datastore/address_ref.go
+++ b/datastore/address_ref.go
@@ -45,10 +45,16 @@ type AddressRef struct {
 
 // Clone creates a copy of the AddressRefRecord.
 func (r AddressRef) Clone() AddressRef {
+	var version *semver.Version
+	if r.Version != nil {
+		v := *r.Version
+		version = &v
+	}
+
 	return AddressRef{
 		ChainSelector: r.ChainSelector,
 		Type:          r.Type,
-		Version:       r.Version,
+		Version:       version,
 		Qualifier:     r.Qualifier,
 		Address:       r.Address,
 		Labels:        r.Labels.Clone(),

--- a/datastore/address_ref_test.go
+++ b/datastore/address_ref_test.go
@@ -23,6 +23,7 @@ func TestAddressRef_Clone(t *testing.T) {
 
 	assert.Equal(t, original, clone, "Clone should produce an identical copy")
 	assert.NotSame(t, &original.Labels, &clone.Labels, "Labels should be deeply cloned")
+	assert.NotSame(t, original.Version, clone.Version, "Version should be deeply cloned")
 }
 
 func TestAddressRef_Key(t *testing.T) {

--- a/datastore/query.go
+++ b/datastore/query.go
@@ -1,0 +1,114 @@
+package datastore
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrAddressRefQueryEmpty     = errors.New("address ref query is empty")
+	ErrAddressRefQueryNoMatch   = errors.New("no address ref matched query")
+	ErrAddressRefQueryAmbiguous = errors.New("multiple address refs matched query")
+	ErrAddressRefFormatFailed   = errors.New("failed to format address ref")
+)
+
+// FormatFn formats a resolved AddressRef into type T (for example a chain-native address).
+type FormatFn[T any] func(ref AddressRef) (T, error)
+
+// FindUniqueRef queries store for the single AddressRef whose fields match the non-zero
+// criteria on ref. The returned value is a clone of the record from the store, not a merge with ref.
+//
+// Query criteria (only non-zero / non-nil fields on ref are applied):
+//   - ChainSelector — omitted when 0 (cannot filter by chain selector 0)
+//   - Type, Version, Qualifier, Address
+//
+// Labels on ref are ignored; they are not part of the query.
+//
+// Partial criteria are allowed but may match multiple records and return
+// [ErrAddressRefQueryAmbiguous]. Set ChainSelector when the chain is known, and include
+// Version when multiple versions of the same contract type exist on a chain.
+func FindUniqueRef(store AddressRefStore, ref AddressRef) (AddressRef, error) {
+	return findUniqueRef(store, ref)
+}
+
+// FindAndFormatRef resolves a unique AddressRef via [FindUniqueRef] and formats it with format.
+// Use [FindUniqueRef] when T is AddressRef. format must be non-nil.
+func FindAndFormatRef[T any](store AddressRefStore, ref AddressRef, format FormatFn[T]) (T, error) {
+	var empty T
+	if format == nil {
+		return empty, fmt.Errorf("%w: format function is required", ErrAddressRefFormatFailed)
+	}
+	refFromStore, err := findUniqueRef(store, ref)
+	if err != nil {
+		return empty, err
+	}
+	formattedRef, err := format(refFromStore)
+	if err != nil {
+		return empty, fmt.Errorf("%w: ref %s: %w", ErrAddressRefFormatFailed, sprintQueryRef(refFromStore), err)
+	}
+
+	return formattedRef, nil
+}
+
+func findUniqueRef(store AddressRefStore, ref AddressRef) (AddressRef, error) {
+	if isAddressRefQueryEmpty(ref) {
+		return AddressRef{}, fmt.Errorf("%w", ErrAddressRefQueryEmpty)
+	}
+
+	filterFns := make([]FilterFunc[AddressRefKey, AddressRef], 0, 5)
+	if ref.ChainSelector != 0 {
+		filterFns = append(filterFns, AddressRefByChainSelector(ref.ChainSelector))
+	}
+	if ref.Type != "" {
+		filterFns = append(filterFns, AddressRefByType(ref.Type))
+	}
+	if ref.Version != nil {
+		filterFns = append(filterFns, AddressRefByVersion(ref.Version))
+	}
+	if ref.Qualifier != "" {
+		filterFns = append(filterFns, AddressRefByQualifier(ref.Qualifier))
+	}
+	if ref.Address != "" {
+		filterFns = append(filterFns, AddressRefByAddress(ref.Address))
+	}
+
+	refs := store.Filter(filterFns...)
+	switch len(refs) {
+	case 1:
+		return refs[0].Clone(), nil
+	case 0:
+		return AddressRef{}, fmt.Errorf("%w: expected exactly 1 ref matching query %s, found 0", ErrAddressRefQueryNoMatch, sprintQueryRef(ref))
+	default:
+		return AddressRef{}, fmt.Errorf("%w: expected exactly 1 ref matching query %s, found %d", ErrAddressRefQueryAmbiguous, sprintQueryRef(ref), len(refs))
+	}
+}
+
+func isAddressRefQueryEmpty(ref AddressRef) bool {
+	return ref.ChainSelector == 0 &&
+		ref.Type == "" &&
+		ref.Version == nil &&
+		ref.Qualifier == "" &&
+		ref.Address == ""
+}
+
+func sprintQueryRef(ref AddressRef) string {
+	parts := make([]string, 0, 5)
+	if ref.ChainSelector != 0 {
+		parts = append(parts, fmt.Sprintf("ChainSelector: %d", ref.ChainSelector))
+	}
+	if ref.Type != "" {
+		parts = append(parts, fmt.Sprintf("Type: %s", ref.Type))
+	}
+	if ref.Version != nil {
+		parts = append(parts, fmt.Sprintf("Version: %s", ref.Version))
+	}
+	if ref.Qualifier != "" {
+		parts = append(parts, "Qualifier: "+ref.Qualifier)
+	}
+	if ref.Address != "" {
+		parts = append(parts, "Address: "+ref.Address)
+	}
+
+	return "{" + strings.Join(parts, ", ") + "}"
+}

--- a/datastore/query_test.go
+++ b/datastore/query_test.go
@@ -1,0 +1,389 @@
+package datastore_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+)
+
+var errFormat = errors.New("format failed")
+
+func TestFindUniqueRef(t *testing.T) {
+	t.Parallel()
+	runUniqueRefTests(t, func(store datastore.AddressRefStore, ref datastore.AddressRef) (datastore.AddressRef, error) {
+		return datastore.FindUniqueRef(store, ref)
+	})
+}
+
+func TestFindAndFormatRef(t *testing.T) {
+	t.Parallel()
+	runUniqueRefTests(t, func(store datastore.AddressRefStore, ref datastore.AddressRef) (datastore.AddressRef, error) {
+		return datastore.FindAndFormatRef(store, ref, func(r datastore.AddressRef) (datastore.AddressRef, error) {
+			return r, nil
+		})
+	})
+}
+
+func runUniqueRefTests(t *testing.T, find func(datastore.AddressRefStore, datastore.AddressRef) (datastore.AddressRef, error)) {
+	t.Helper()
+
+	tests := []struct {
+		desc        string
+		makeStore   func(t *testing.T) datastore.AddressRefStore
+		expectedErr error
+		errContains []string
+		ref         datastore.AddressRef
+		want        datastore.AddressRef
+	}{
+		{
+			desc: "find one ref",
+			makeStore: func(t *testing.T) datastore.AddressRefStore {
+				t.Helper()
+				return storeWithRefs(t, datastore.AddressRef{
+					ChainSelector: 4340886533089894000,
+					Address:       "0x01",
+					Type:          datastore.ContractType("TestContract"),
+					Version:       semver.MustParse("1.0.0"),
+					Qualifier:     "For testing",
+				})
+			},
+			ref: datastore.AddressRef{
+				ChainSelector: 4340886533089894000,
+				Address:       "0x01",
+				Type:          datastore.ContractType("TestContract"),
+				Version:       semver.MustParse("1.0.0"),
+				Qualifier:     "For testing",
+			},
+			want: datastore.AddressRef{
+				ChainSelector: 4340886533089894000,
+				Address:       "0x01",
+				Type:          datastore.ContractType("TestContract"),
+				Version:       semver.MustParse("1.0.0"),
+				Qualifier:     "For testing",
+			},
+		},
+		{
+			desc: "ambiguous match",
+			makeStore: func(t *testing.T) datastore.AddressRefStore {
+				t.Helper()
+				return storeWithRefs(t,
+					datastore.AddressRef{
+						ChainSelector: 4340886533089894000,
+						Address:       "0x01",
+						Type:          datastore.ContractType("TestContract"),
+						Version:       semver.MustParse("1.0.0"),
+						Qualifier:     "For testing",
+					},
+					datastore.AddressRef{
+						ChainSelector: 4340886533089894000,
+						Address:       "0x02",
+						Type:          datastore.ContractType("TestContract"),
+						Version:       semver.MustParse("1.0.0"),
+						Qualifier:     "For production",
+					},
+				)
+			},
+			ref: datastore.AddressRef{
+				ChainSelector: 4340886533089894000,
+				Type:          datastore.ContractType("TestContract"),
+				Version:       semver.MustParse("1.0.0"),
+			},
+			expectedErr: datastore.ErrAddressRefQueryAmbiguous,
+			errContains: []string{"found 2"},
+		},
+		{
+			desc: "no match",
+			makeStore: func(t *testing.T) datastore.AddressRefStore {
+				t.Helper()
+				return datastore.NewMemoryDataStore().Seal().Addresses()
+			},
+			ref: datastore.AddressRef{
+				ChainSelector: 4340886533089894000,
+				Type:          datastore.ContractType("TestContract"),
+				Version:       semver.MustParse("1.0.0"),
+				Qualifier:     "For testing",
+			},
+			expectedErr: datastore.ErrAddressRefQueryNoMatch,
+			errContains: []string{"found 0"},
+		},
+		{
+			desc: "empty query criteria",
+			makeStore: func(t *testing.T) datastore.AddressRefStore {
+				t.Helper()
+				return storeWithRefs(t, datastore.AddressRef{
+					ChainSelector: 1,
+					Address:       "0xonly",
+					Type:          datastore.ContractType("Only"),
+					Version:       semver.MustParse("1.0.0"),
+				})
+			},
+			ref:         datastore.AddressRef{},
+			expectedErr: datastore.ErrAddressRefQueryEmpty,
+		},
+		{
+			desc: "cross-chain ambiguous without chain selector",
+			makeStore: func(t *testing.T) datastore.AddressRefStore {
+				t.Helper()
+				return storeWithRefs(t,
+					datastore.AddressRef{
+						ChainSelector: 111,
+						Address:       "0x01",
+						Type:          datastore.ContractType("Router"),
+						Version:       semver.MustParse("1.6.0"),
+					},
+					datastore.AddressRef{
+						ChainSelector: 222,
+						Address:       "0x02",
+						Type:          datastore.ContractType("Router"),
+						Version:       semver.MustParse("1.6.0"),
+					},
+				)
+			},
+			ref: datastore.AddressRef{
+				Type:    datastore.ContractType("Router"),
+				Version: semver.MustParse("1.6.0"),
+			},
+			expectedErr: datastore.ErrAddressRefQueryAmbiguous,
+			errContains: []string{"found 2"},
+		},
+		{
+			desc: "cross-chain unique with chain selector",
+			makeStore: func(t *testing.T) datastore.AddressRefStore {
+				t.Helper()
+				return storeWithRefs(t,
+					datastore.AddressRef{
+						ChainSelector: 111,
+						Address:       "0x01",
+						Type:          datastore.ContractType("Router"),
+						Version:       semver.MustParse("1.6.0"),
+					},
+					datastore.AddressRef{
+						ChainSelector: 222,
+						Address:       "0x02",
+						Type:          datastore.ContractType("Router"),
+						Version:       semver.MustParse("1.6.0"),
+					},
+				)
+			},
+			ref: datastore.AddressRef{
+				ChainSelector: 222,
+				Type:          datastore.ContractType("Router"),
+				Version:       semver.MustParse("1.6.0"),
+			},
+			want: datastore.AddressRef{
+				ChainSelector: 222,
+				Address:       "0x02",
+				Type:          datastore.ContractType("Router"),
+				Version:       semver.MustParse("1.6.0"),
+			},
+		},
+		{
+			desc: "same-chain ambiguous without version",
+			makeStore: func(t *testing.T) datastore.AddressRefStore {
+				t.Helper()
+				return storeWithRefs(t,
+					datastore.AddressRef{
+						ChainSelector: 111,
+						Address:       "0x01",
+						Type:          datastore.ContractType("Router"),
+						Version:       semver.MustParse("1.5.0"),
+					},
+					datastore.AddressRef{
+						ChainSelector: 111,
+						Address:       "0x02",
+						Type:          datastore.ContractType("Router"),
+						Version:       semver.MustParse("1.6.0"),
+					},
+				)
+			},
+			ref: datastore.AddressRef{
+				ChainSelector: 111,
+				Type:          datastore.ContractType("Router"),
+			},
+			expectedErr: datastore.ErrAddressRefQueryAmbiguous,
+			errContains: []string{"found 2"},
+		},
+		{
+			desc: "query labels ignored",
+			makeStore: func(t *testing.T) datastore.AddressRefStore {
+				t.Helper()
+				return storeWithRefs(t, datastore.AddressRef{
+					ChainSelector: 1,
+					Address:       "0xlabeled",
+					Type:          datastore.ContractType("Labeled"),
+					Version:       semver.MustParse("1.0.0"),
+					Labels:        datastore.NewLabelSet("stored"),
+				})
+			},
+			ref: datastore.AddressRef{
+				ChainSelector: 1,
+				Type:          datastore.ContractType("Labeled"),
+				Version:       semver.MustParse("1.0.0"),
+				Labels:        datastore.NewLabelSet("query-only"),
+			},
+			want: datastore.AddressRef{
+				ChainSelector: 1,
+				Address:       "0xlabeled",
+				Type:          datastore.ContractType("Labeled"),
+				Version:       semver.MustParse("1.0.0"),
+				Labels:        datastore.NewLabelSet("stored"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+			store := test.makeStore(t)
+			got, err := find(store, test.ref)
+			if test.expectedErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, test.expectedErr)
+				for _, msg := range test.errContains {
+					require.ErrorContains(t, err, msg)
+				}
+
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.want.ChainSelector, got.ChainSelector)
+			require.Equal(t, test.want.Address, got.Address)
+			require.Equal(t, test.want.Type, got.Type)
+			require.Equal(t, test.want.Qualifier, got.Qualifier)
+			require.True(t, test.want.Version.Equal(got.Version))
+			require.Equal(t, test.want.Labels, got.Labels)
+		})
+	}
+}
+
+func TestFindUniqueRef_errorShowsActiveQueryOnly(t *testing.T) {
+	t.Parallel()
+
+	store := storeWithRefs(t,
+		datastore.AddressRef{
+			ChainSelector: 111,
+			Type:          datastore.ContractType("Router"),
+			Version:       semver.MustParse("1.6.0"),
+		},
+		datastore.AddressRef{
+			ChainSelector: 222,
+			Type:          datastore.ContractType("Router"),
+			Version:       semver.MustParse("1.6.0"),
+		},
+	)
+	ref := datastore.AddressRef{
+		Type:    datastore.ContractType("Router"),
+		Version: semver.MustParse("1.6.0"),
+	}
+
+	_, err := datastore.FindUniqueRef(store, ref)
+	require.ErrorIs(t, err, datastore.ErrAddressRefQueryAmbiguous)
+	require.ErrorContains(t, err, "{Type: Router, Version: 1.6.0}")
+	require.NotContains(t, err.Error(), "ChainSelector: 0")
+}
+
+func TestFindUniqueRef_returnsClone(t *testing.T) {
+	t.Parallel()
+
+	store := storeWithRefs(t, datastore.AddressRef{
+		ChainSelector: 1,
+		Address:       "0xlabeled",
+		Type:          datastore.ContractType("Labeled"),
+		Version:       semver.MustParse("1.0.0"),
+		Labels:        datastore.NewLabelSet("stored"),
+	})
+	ref := datastore.AddressRef{
+		ChainSelector: 1,
+		Type:          datastore.ContractType("Labeled"),
+		Version:       semver.MustParse("1.0.0"),
+	}
+
+	got, err := datastore.FindUniqueRef(store, ref)
+	require.NoError(t, err)
+	got.Labels.Add("mutated")
+	got.Version = semver.MustParse("9.9.9")
+
+	again, err := datastore.FindUniqueRef(store, ref)
+	require.NoError(t, err)
+	require.False(t, again.Labels.Contains("mutated"))
+	require.True(t, again.Labels.Contains("stored"))
+	require.Equal(t, "1.0.0", again.Version.String())
+}
+
+func TestFindAndFormatRef_nilFormat(t *testing.T) {
+	t.Parallel()
+
+	store := storeWithRefs(t, datastore.AddressRef{
+		ChainSelector: 1,
+		Type:          datastore.ContractType("TestContract"),
+		Version:       semver.MustParse("1.0.0"),
+	})
+	ref := datastore.AddressRef{
+		ChainSelector: 1,
+		Type:          datastore.ContractType("TestContract"),
+		Version:       semver.MustParse("1.0.0"),
+	}
+
+	_, err := datastore.FindAndFormatRef[string](store, ref, nil)
+	require.ErrorIs(t, err, datastore.ErrAddressRefFormatFailed)
+	require.ErrorContains(t, err, "format function is required")
+}
+
+func TestFindAndFormatRef_formatError(t *testing.T) {
+	t.Parallel()
+
+	store := storeWithRefs(t, datastore.AddressRef{
+		ChainSelector: 1,
+		Address:       "0x01",
+		Type:          datastore.ContractType("TestContract"),
+		Version:       semver.MustParse("1.0.0"),
+	})
+	ref := datastore.AddressRef{
+		ChainSelector: 1,
+		Type:          datastore.ContractType("TestContract"),
+		Version:       semver.MustParse("1.0.0"),
+	}
+
+	_, err := datastore.FindAndFormatRef(store, ref, func(datastore.AddressRef) (string, error) {
+		return "", errFormat
+	})
+	require.ErrorIs(t, err, datastore.ErrAddressRefFormatFailed)
+	require.ErrorIs(t, err, errFormat)
+	require.ErrorContains(t, err, "ref {ChainSelector: 1")
+}
+
+func TestFindAndFormatRef_typedFormat(t *testing.T) {
+	t.Parallel()
+
+	store := storeWithRefs(t, datastore.AddressRef{
+		ChainSelector: 1,
+		Address:       "0xabc",
+		Type:          datastore.ContractType("TestContract"),
+		Version:       semver.MustParse("2.0.0"),
+	})
+	ref := datastore.AddressRef{
+		ChainSelector: 1,
+		Type:          datastore.ContractType("TestContract"),
+		Version:       semver.MustParse("2.0.0"),
+	}
+
+	got, err := datastore.FindAndFormatRef(store, ref, func(r datastore.AddressRef) (string, error) {
+		return r.Address, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "0xabc", got)
+}
+
+func storeWithRefs(t *testing.T, refs ...datastore.AddressRef) datastore.AddressRefStore {
+	t.Helper()
+	ds := datastore.NewMemoryDataStore()
+	for _, ref := range refs {
+		require.NoError(t, ds.Addresses().Add(ref))
+	}
+
+	return ds.Seal().Addresses()
+}


### PR DESCRIPTION
Inspired by the regular query methods in CCIP tooling api [here](https://github.com/smartcontractkit/chainlink-ccip/blob/6eee37eef754db75bc1aa9baa0be1e3a21730f7d/deployment/utils/datastore/datastore.go) , i integrated the most used utils plus some changes and cleanup

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-2465