### PR TITLE
feat(operations): new sequence utils [CLD-2463]

### DIFF
--- a/.changeset/sequenceutils-onchain-changeset.md
+++ b/.changeset/sequenceutils-onchain-changeset.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat(changeset): add sequenceutils.NewOnChainChangesetFromSequence for on-chain sequence changesets

--- a/changeset/sequenceutils/changeset.go
+++ b/changeset/sequenceutils/changeset.go
@@ -1,0 +1,290 @@
+// Package sequenceutils provides helpers for building deployment changesets from operations sequences.
+//
+// Use NewOnChainChangesetFromSequence to wrap a sequence that returns OnChainOutput into a
+// ChangeSetV2 with datastore and MCMS timelock proposal integration.
+package sequenceutils
+
+import (
+	"errors"
+	"fmt"
+
+	mcms_types "github.com/smartcontractkit/mcms/types"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+)
+
+var (
+	// ErrBatchOpsWithoutMCMSInput indicates the sequence returned batch operations without MCMS timelock proposal input.
+	ErrBatchOpsWithoutMCMSInput = errors.New("batch operations require MCMS timelock proposal input")
+)
+
+// OnChainOutput is a standard output type for sequences that deploy contracts on-chain and perform write operations.
+type OnChainOutput struct {
+	// Metadata is written to the changeset datastore (see datastore.MetadataBundle).
+	//   - Addresses: deployed contract addresses (Added)
+	//   - Contracts: contract metadata keyed by address + chain selector (Upserted)
+	//   - Chains: chain metadata keyed by chain selector (Upserted)
+	//   - Env: one env metadata record per environment (Set)
+	// If writing to a particular key, ensure that you populate all required fields.
+	Metadata datastore.MetadataBundle
+	// BatchOps are MCMS batch operations for a single timelock proposal. MCMS input comes from the changeset config.
+	BatchOps []mcms_types.BatchOperation
+}
+
+type WithMCMS[CFG any] struct {
+	// MCMS, when non-nil, is validated at verification time and used to build the timelock proposal when the
+	// sequence returns batch operations with transactions. Apply fails if the sequence returns non-empty batch
+	// operations without MCMS input.
+	MCMS *deployment.MCMSTimelockProposalInput
+	Cfg  CFG
+}
+
+// NewOnChainChangesetFromSequenceParams configures NewOnChainChangesetFromSequence.
+type NewOnChainChangesetFromSequenceParams[IN any, DEP any, CFG any] struct {
+	// Sequence is the operations.Sequence to execute.
+	Sequence *operations.Sequence[IN, OnChainOutput, DEP]
+	// ResolveInput resolves the input for the sequence based on the environment and changeset config.
+	ResolveInput func(e deployment.Environment, cfg CFG) (IN, error)
+	// ResolveDep resolves the dependencies for the sequence based on the environment and changeset config.
+	ResolveDep func(e deployment.Environment, cfg CFG) (DEP, error)
+	// Verify, if non-nil, performs additional validation beyond built-in MCMS checks, params, environment, and resolve.
+	Verify func(e deployment.Environment, wrapped WithMCMS[CFG]) error
+}
+
+type onChainChangesetConfig struct {
+	mcmsRegistry *deployment.MCMSReaderRegistry
+}
+
+// OnChainChangesetFromSequenceOption configures NewOnChainChangesetFromSequence.
+type OnChainChangesetFromSequenceOption func(*onChainChangesetConfig)
+
+// WithMCMSRegistry overrides the default MCMS reader registry (deployment.GetMCMSReaderRegistry).
+// In most cases, you should not need to use this method.
+func WithMCMSRegistry(registry *deployment.MCMSReaderRegistry) OnChainChangesetFromSequenceOption {
+	return func(c *onChainChangesetConfig) {
+		c.mcmsRegistry = registry
+	}
+}
+
+// NewOnChainChangesetFromSequence creates a ChangeSetV2 from an operations.Sequence that
+// deploys contracts on-chain and performs write operations. It executes the sequence,
+// writes OnChainOutput.Metadata to a datastore, and optionally builds an MCMS timelock
+// proposal from OnChainOutput.BatchOps.
+//
+// Config is passed as WithMCMS[CFG], which wraps the deployment-specific config (Cfg) and
+// an optional MCMS timelock proposal input (MCMS). When the sequence returns batch
+// operations with transactions, MCMS must be set or Apply returns
+// ErrBatchOpsWithoutMCMSInput.
+//
+// Usage:
+//
+//	deploySeq := operations.NewSequence(
+//	    "deploy-timelock",
+//	    semver.MustParse("1.0.0"),
+//	    "Deploy timelock contracts",
+//	    func(b operations.Bundle, deps DeployDeps, in DeployInput) (OnChainOutput, error) {
+//	        // Run operations and collect addresses and/or MCMS batch operations.
+//	        return OnChainOutput{
+//	            Metadata: datastore.MetadataBundle{
+//	                Addresses: []datastore.AddressRef{timelockRef},
+//	            },
+//	            BatchOps: batchOps, // omit when no MCMS proposal is needed
+//	        }, nil
+//	    },
+//	)
+//
+//	cs := NewOnChainChangesetFromSequence(
+//	    NewOnChainChangesetFromSequenceParams[DeployInput, DeployDeps, DeployConfig]{
+//	        Sequence: deploySeq,
+//	        ResolveInput: func(e deployment.Environment, cfg DeployConfig) (DeployInput, error) {
+//	            return DeployInput{ChainSelector: cfg.ChainSelector}, nil
+//	        },
+//	        ResolveDep: func(e deployment.Environment, cfg DeployConfig) (DeployDeps, error) {
+//	            return DeployDeps{Chain: e.BlockChains.EVMChains()[cfg.ChainSelector]}, nil
+//	        },
+//	    },
+//	)
+//
+//	wrapped := WithMCMS[DeployConfig]{
+//	    Cfg: DeployConfig{ChainSelector: ethMainnetSelector},
+//	    MCMS: &deployment.MCMSTimelockProposalInput{
+//	        TimelockAction: mcms_types.TimelockActionSchedule,
+//	        ValidUntil:     validUntil,
+//	        TimelockDelay:  mcms_types.NewDuration(time.Hour),
+//	        Description:    "schedule timelock ops",
+//	    },
+//	}
+//	if err := cs.VerifyPreconditions(env, wrapped); err != nil {
+//	    return err
+//	}
+//	out, err := cs.Apply(env, wrapped)
+//	// out.DataStore holds deployed addresses; out.MCMSTimelockProposals holds proposals.
+func NewOnChainChangesetFromSequence[IN any, DEP any, CFG any](
+	params NewOnChainChangesetFromSequenceParams[IN, DEP, CFG],
+	opts ...OnChainChangesetFromSequenceOption,
+) deployment.ChangeSetV2[WithMCMS[CFG]] {
+	cfg := onChainChangesetConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	sequenceID := func() string {
+		if params.Sequence != nil {
+			return params.Sequence.ID()
+		}
+
+		return "<nil>"
+	}
+
+	resolveSeqInputAndDeps := func(e deployment.Environment, wrapped WithMCMS[CFG]) (IN, DEP, error) {
+		in, err := params.ResolveInput(e, wrapped.Cfg)
+		if err != nil {
+			var dep DEP
+			return in, dep, fmt.Errorf("%w: failed to resolve input for sequence %s: %w",
+				deployment.ErrInvalidConfig, sequenceID(), err)
+		}
+		dep, err := params.ResolveDep(e, wrapped.Cfg)
+		if err != nil {
+			return in, dep, fmt.Errorf("%w: failed to resolve dependencies for sequence %s: %w",
+				deployment.ErrInvalidConfig, sequenceID(), err)
+		}
+
+		return in, dep, nil
+	}
+
+	verifyMCMS := func(wrapped WithMCMS[CFG]) error {
+		if wrapped.MCMS == nil {
+			return nil
+		}
+		if err := wrapped.MCMS.Validate(); err != nil {
+			return fmt.Errorf("%w: invalid MCMS timelock proposal input for sequence %s: %w",
+				deployment.ErrInvalidConfig, sequenceID(), err)
+		}
+
+		return nil
+	}
+
+	verify := func(e deployment.Environment, wrapped WithMCMS[CFG]) error {
+		if err := verifyMCMS(wrapped); err != nil {
+			return err
+		}
+		if params.Verify != nil {
+			return params.Verify(e, wrapped)
+		}
+
+		return nil
+	}
+
+	validate := func(e deployment.Environment, wrapped WithMCMS[CFG]) error {
+		if err := validateOnChainParams(params); err != nil {
+			return err
+		}
+		if err := validateEnvironment(e); err != nil {
+			return err
+		}
+		if err := verify(e, wrapped); err != nil {
+			return err
+		}
+		_, _, err := resolveSeqInputAndDeps(e, wrapped)
+
+		return err
+	}
+
+	changesetApply := func(e deployment.Environment, wrapped WithMCMS[CFG]) (deployment.ChangesetOutput, error) {
+		input, deps, err := resolveSeqInputAndDeps(e, wrapped)
+		if err != nil {
+			return deployment.ChangesetOutput{}, err
+		}
+		report, err := operations.ExecuteSequence(e.OperationsBundle, params.Sequence, deps, input)
+		if err != nil {
+			return deployment.ChangesetOutput{Reports: report.ExecutionReports},
+				fmt.Errorf("failed to execute sequence with ID %s: %w", params.Sequence.ID(), err)
+		}
+
+		return buildOnChainChangesetOutput(e, cfg, wrapped.MCMS, params.Sequence.ID(), report)
+	}
+
+	return deployment.CreateChangeSet(changesetApply, validate)
+}
+
+func buildOnChainChangesetOutput[IN any](
+	e deployment.Environment,
+	cfg onChainChangesetConfig,
+	mcmsInput *deployment.MCMSTimelockProposalInput,
+	sequenceID string,
+	report operations.SequenceReport[IN, OnChainOutput],
+) (deployment.ChangesetOutput, error) {
+	ds := datastore.NewMemoryDataStore()
+	if metaErr := ds.WriteMetadata(report.Output.Metadata); metaErr != nil {
+		return deployment.ChangesetOutput{Reports: report.ExecutionReports},
+			fmt.Errorf("failed to write metadata to datastore: %w", metaErr)
+	}
+
+	partialOutput := deployment.ChangesetOutput{
+		Reports:   report.ExecutionReports,
+		DataStore: ds,
+	}
+
+	builder := deployment.NewOutputBuilder(e, ds).
+		WithOperationsReports(report.ExecutionReports)
+
+	if cfg.mcmsRegistry != nil {
+		builder = builder.WithMCMSReaderRegistry(cfg.mcmsRegistry)
+	}
+
+	if hasNonEmptyBatchOps(report.Output.BatchOps) {
+		if mcmsInput == nil {
+			return partialOutput,
+				fmt.Errorf("%w: sequence %s returned batch operations: %w",
+					deployment.ErrInvalidConfig, sequenceID, ErrBatchOpsWithoutMCMSInput)
+		}
+		builder = builder.WithTimelockProposal(*mcmsInput, report.Output.BatchOps)
+	}
+
+	out, err := builder.Build()
+	if err != nil {
+		return out, err
+	}
+
+	return out, nil
+}
+
+func hasNonEmptyBatchOps(ops []mcms_types.BatchOperation) bool {
+	for _, op := range ops {
+		if len(op.Transactions) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func validateOnChainParams[IN any, DEP any, CFG any](params NewOnChainChangesetFromSequenceParams[IN, DEP, CFG]) error {
+	if params.Sequence == nil {
+		return fmt.Errorf("%w: sequence is required", deployment.ErrInvalidConfig)
+	}
+	if params.ResolveInput == nil {
+		return fmt.Errorf("%w: ResolveInput is required", deployment.ErrInvalidConfig)
+	}
+	if params.ResolveDep == nil {
+		return fmt.Errorf("%w: ResolveDep is required", deployment.ErrInvalidConfig)
+	}
+
+	return nil
+}
+
+func validateEnvironment(e deployment.Environment) error {
+	if e.Logger == nil {
+		return fmt.Errorf("%w: logger is required", deployment.ErrInvalidEnvironment)
+	}
+	if e.GetContext == nil {
+		return fmt.Errorf("%w: GetContext is required", deployment.ErrInvalidEnvironment)
+	}
+	if e.OperationsBundle.Logger == nil || e.OperationsBundle.GetContext == nil {
+		return fmt.Errorf("%w: OperationsBundle is not configured", deployment.ErrInvalidEnvironment)
+	}
+
+	return nil
+}

--- a/changeset/sequenceutils/changeset_test.go
+++ b/changeset/sequenceutils/changeset_test.go
@@ -1,0 +1,540 @@
+package sequenceutils
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	mcms_types "github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger"
+)
+
+const ethMainnetSelector = 5009297550715157269
+
+const testValidUntilUnix = uint32(2756219818)
+
+type testCfg struct{}
+
+func TestNewOnChainChangesetFromSequence_verifyParams(t *testing.T) {
+	t.Parallel()
+
+	env := testEnvironment(t)
+	cfg := testCfg{}
+
+	t.Run("nil sequence", func(t *testing.T) {
+		t.Parallel()
+		cs := NewOnChainChangesetFromSequence(newTestChangesetParams(nil, nil, nil))
+		err := cs.VerifyPreconditions(env, WithMCMS[testCfg]{Cfg: cfg})
+		require.ErrorIs(t, err, deployment.ErrInvalidConfig)
+		require.ErrorContains(t, err, "sequence is required")
+	})
+
+	t.Run("nil ResolveInput", func(t *testing.T) {
+		t.Parallel()
+		seq := testSequence(t, func(_ operations.Bundle, _ struct{}, _ struct{}) (OnChainOutput, error) {
+			return OnChainOutput{}, nil
+		})
+		cs := NewOnChainChangesetFromSequence(NewOnChainChangesetFromSequenceParams[struct{}, struct{}, testCfg]{
+			Sequence:   seq,
+			ResolveDep: func(deployment.Environment, testCfg) (struct{}, error) { return struct{}{}, nil },
+		})
+		err := cs.VerifyPreconditions(env, WithMCMS[testCfg]{Cfg: cfg})
+		require.ErrorIs(t, err, deployment.ErrInvalidConfig)
+		require.ErrorContains(t, err, "ResolveInput is required")
+	})
+
+	t.Run("nil ResolveDep", func(t *testing.T) {
+		t.Parallel()
+		seq := testSequence(t, func(_ operations.Bundle, _ struct{}, _ struct{}) (OnChainOutput, error) {
+			return OnChainOutput{}, nil
+		})
+		cs := NewOnChainChangesetFromSequence(NewOnChainChangesetFromSequenceParams[struct{}, struct{}, testCfg]{
+			Sequence:     seq,
+			ResolveInput: func(deployment.Environment, testCfg) (struct{}, error) { return struct{}{}, nil },
+		})
+		err := cs.VerifyPreconditions(env, WithMCMS[testCfg]{Cfg: cfg})
+		require.ErrorIs(t, err, deployment.ErrInvalidConfig)
+		require.ErrorContains(t, err, "ResolveDep is required")
+	})
+}
+
+func TestNewOnChainChangesetFromSequence_verifyEnvironment(t *testing.T) {
+	t.Parallel()
+
+	seq := testSequence(t, func(_ operations.Bundle, _ struct{}, _ struct{}) (OnChainOutput, error) {
+		return OnChainOutput{}, nil
+	})
+	cs := NewOnChainChangesetFromSequence(newTestChangesetParams(seq, nil, nil))
+	cfg := testCfg{}
+
+	t.Run("missing logger", func(t *testing.T) {
+		t.Parallel()
+		env := testEnvironment(t)
+		env.Logger = nil
+		err := cs.VerifyPreconditions(env, WithMCMS[testCfg]{Cfg: cfg})
+		require.ErrorIs(t, err, deployment.ErrInvalidEnvironment)
+		require.ErrorContains(t, err, "logger is required")
+	})
+
+	t.Run("missing GetContext", func(t *testing.T) {
+		t.Parallel()
+		env := testEnvironment(t)
+		env.GetContext = nil
+		err := cs.VerifyPreconditions(env, WithMCMS[testCfg]{Cfg: cfg})
+		require.ErrorIs(t, err, deployment.ErrInvalidEnvironment)
+		require.ErrorContains(t, err, "GetContext is required")
+	})
+
+	t.Run("unconfigured OperationsBundle", func(t *testing.T) {
+		t.Parallel()
+		err := cs.VerifyPreconditions(deployment.Environment{
+			Logger:     logger.Test(t),
+			GetContext: func() context.Context { return t.Context() },
+		}, WithMCMS[testCfg]{Cfg: cfg})
+		require.ErrorIs(t, err, deployment.ErrInvalidEnvironment)
+		require.ErrorContains(t, err, "OperationsBundle is not configured")
+	})
+}
+
+func TestNewOnChainChangesetFromSequence_verifyResolveErrors(t *testing.T) {
+	t.Parallel()
+
+	resolveErr := errors.New("resolve failed")
+	seq := testSequence(t, func(_ operations.Bundle, _ struct{}, _ struct{}) (OnChainOutput, error) {
+		return OnChainOutput{}, nil
+	})
+	env := testEnvironment(t)
+	cfg := testCfg{}
+
+	t.Run("ResolveInput failure", func(t *testing.T) {
+		t.Parallel()
+		cs := NewOnChainChangesetFromSequence(newTestChangesetParams(seq,
+			func(deployment.Environment, testCfg) (struct{}, error) {
+				return struct{}{}, resolveErr
+			},
+			func(deployment.Environment, testCfg) (struct{}, error) { return struct{}{}, nil },
+		))
+		err := cs.VerifyPreconditions(env, WithMCMS[testCfg]{Cfg: cfg})
+		require.ErrorIs(t, err, deployment.ErrInvalidConfig)
+		require.ErrorIs(t, err, resolveErr)
+		require.ErrorContains(t, err, "failed to resolve input")
+		require.ErrorContains(t, err, seq.ID())
+	})
+
+	t.Run("ResolveDep failure", func(t *testing.T) {
+		t.Parallel()
+		cs := NewOnChainChangesetFromSequence(newTestChangesetParams(seq,
+			func(deployment.Environment, testCfg) (struct{}, error) { return struct{}{}, nil },
+			func(deployment.Environment, testCfg) (struct{}, error) {
+				return struct{}{}, resolveErr
+			},
+		))
+		err := cs.VerifyPreconditions(env, WithMCMS[testCfg]{Cfg: cfg})
+		require.ErrorIs(t, err, deployment.ErrInvalidConfig)
+		require.ErrorIs(t, err, resolveErr)
+		require.ErrorContains(t, err, "failed to resolve dependencies")
+	})
+}
+
+func TestNewOnChainChangesetFromSequence_verifyMCMS(t *testing.T) {
+	t.Parallel()
+
+	seq := testSequence(t, func(_ operations.Bundle, _ struct{}, _ struct{}) (OnChainOutput, error) {
+		return OnChainOutput{}, nil
+	})
+	env := testEnvironment(t)
+	cfg := testCfg{}
+
+	t.Run("invalid MCMS input", func(t *testing.T) {
+		t.Parallel()
+		cs := NewOnChainChangesetFromSequence(newTestChangesetParams(seq, nil, nil))
+		err := cs.VerifyPreconditions(env, WithMCMS[testCfg]{
+			Cfg:  cfg,
+			MCMS: &deployment.MCMSTimelockProposalInput{},
+		})
+		require.ErrorIs(t, err, deployment.ErrInvalidConfig)
+		require.ErrorIs(t, err, deployment.ErrInvalidMCMSTimelockProposalInput)
+	})
+
+	t.Run("custom Verify hook", func(t *testing.T) {
+		t.Parallel()
+		verifyErr := errors.New("on-chain verify failed")
+		params := newTestChangesetParams(seq, nil, nil)
+		params.Verify = func(deployment.Environment, WithMCMS[testCfg]) error {
+			return verifyErr
+		}
+		cs := NewOnChainChangesetFromSequence(params)
+		err := cs.VerifyPreconditions(env, WithMCMS[testCfg]{Cfg: cfg})
+		require.ErrorIs(t, err, verifyErr)
+	})
+
+	t.Run("valid config", func(t *testing.T) {
+		t.Parallel()
+		cs := NewOnChainChangesetFromSequence(newTestChangesetParams(seq, nil, nil))
+		err := cs.VerifyPreconditions(env, WithMCMS[testCfg]{
+			Cfg:  cfg,
+			MCMS: ptr(validMCMSProposalInput()),
+		})
+		require.NoError(t, err)
+	})
+}
+
+func TestNewOnChainChangesetFromSequence_applySuccess(t *testing.T) {
+	t.Parallel()
+
+	env := testEnvironment(t)
+	cfg := testCfg{}
+	ref := datastore.AddressRef{
+		Address:       "0xabc",
+		ChainSelector: 1,
+		Type:          "Timelock",
+		Version:       semver.MustParse("1.0.0"),
+	}
+	seq := testSequence(t, func(_ operations.Bundle, _ struct{}, _ struct{}) (OnChainOutput, error) {
+		return OnChainOutput{
+			Metadata: datastore.MetadataBundle{Addresses: []datastore.AddressRef{ref}},
+		}, nil
+	})
+	cs := NewOnChainChangesetFromSequence(newTestChangesetParams(seq, nil, nil))
+
+	out, err := cs.Apply(env, WithMCMS[testCfg]{Cfg: cfg})
+	require.NoError(t, err)
+	require.NotEmpty(t, out.Reports)
+
+	refs, fetchErr := out.DataStore.Addresses().Fetch()
+	require.NoError(t, fetchErr)
+	require.Len(t, refs, 1)
+	require.Equal(t, "0xabc", refs[0].Address)
+	require.Empty(t, out.MCMSTimelockProposals)
+}
+
+func TestNewOnChainChangesetFromSequence_applyWithBatchOpsAndMCMS(t *testing.T) {
+	t.Parallel()
+
+	env := testEnvironment(t)
+	cfg := testCfg{}
+	mcmsInput := validMCMSProposalInput()
+	seq := testSequence(t, func(_ operations.Bundle, _ struct{}, _ struct{}) (OnChainOutput, error) {
+		return OnChainOutput{BatchOps: []mcms_types.BatchOperation{sampleBatchOp()}}, nil
+	})
+	cs := NewOnChainChangesetFromSequence(
+		newTestChangesetParams(seq, nil, nil),
+		WithMCMSRegistry(testMCMSRegistry(t)),
+	)
+
+	out, err := cs.Apply(env, WithMCMS[testCfg]{Cfg: cfg, MCMS: &mcmsInput})
+	require.NoError(t, err)
+	require.NotEmpty(t, out.Reports)
+	require.NotNil(t, out.DataStore)
+	require.Len(t, out.MCMSTimelockProposals, 1)
+
+	prop := out.MCMSTimelockProposals[0]
+	require.Equal(t, mcmsInput.Description, prop.Description)
+	require.Equal(t, mcmsInput.ValidUntil, prop.ValidUntil)
+	require.Equal(t, mcmsInput.TimelockAction, prop.Action)
+	require.Equal(t, "0x01", prop.TimelockAddresses[ethMainnetSelector])
+	require.Equal(t, uint64(42), prop.ChainMetadata[ethMainnetSelector].StartingOpCount)
+	require.Len(t, prop.Operations, 1)
+	require.Len(t, prop.Operations[0].Transactions, 1)
+}
+
+func TestNewOnChainChangesetFromSequence_applyBatchOpsWithoutMCMS(t *testing.T) {
+	t.Parallel()
+
+	env := testEnvironment(t)
+	cfg := testCfg{}
+	seq := testSequence(t, func(_ operations.Bundle, _ struct{}, _ struct{}) (OnChainOutput, error) {
+		return OnChainOutput{BatchOps: []mcms_types.BatchOperation{sampleBatchOp()}}, nil
+	})
+	cs := NewOnChainChangesetFromSequence(newTestChangesetParams(seq, nil, nil))
+
+	err := cs.VerifyPreconditions(env, WithMCMS[testCfg]{Cfg: cfg})
+	require.NoError(t, err)
+
+	_, err = cs.Apply(env, WithMCMS[testCfg]{Cfg: cfg})
+	require.Error(t, err)
+	require.ErrorIs(t, err, deployment.ErrInvalidConfig)
+	require.ErrorIs(t, err, ErrBatchOpsWithoutMCMSInput)
+}
+
+func TestNewOnChainChangesetFromSequence_applyBatchOpsWithoutMCMS_preservesMetadata(t *testing.T) {
+	t.Parallel()
+
+	env := testEnvironment(t)
+	cfg := testCfg{}
+	ref := datastore.AddressRef{
+		Address:       "0xabc",
+		ChainSelector: 1,
+		Type:          "Timelock",
+		Version:       semver.MustParse("1.0.0"),
+	}
+	seq := testSequence(t, func(_ operations.Bundle, _ struct{}, _ struct{}) (OnChainOutput, error) {
+		return OnChainOutput{
+			Metadata: datastore.MetadataBundle{Addresses: []datastore.AddressRef{ref}},
+			BatchOps: []mcms_types.BatchOperation{sampleBatchOp()},
+		}, nil
+	})
+	cs := NewOnChainChangesetFromSequence(newTestChangesetParams(seq, nil, nil))
+
+	out, err := cs.Apply(env, WithMCMS[testCfg]{Cfg: cfg})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrBatchOpsWithoutMCMSInput)
+	require.NotEmpty(t, out.Reports)
+	require.NotNil(t, out.DataStore)
+
+	refs, fetchErr := out.DataStore.Addresses().Fetch()
+	require.NoError(t, fetchErr)
+	require.Len(t, refs, 1)
+	require.Equal(t, "0xabc", refs[0].Address)
+}
+
+func TestNewOnChainChangesetFromSequence_applyEmptyBatchOpsWithoutMCMS(t *testing.T) {
+	t.Parallel()
+
+	env := testEnvironment(t)
+	cfg := testCfg{}
+	seq := testSequence(t, func(_ operations.Bundle, _ struct{}, _ struct{}) (OnChainOutput, error) {
+		return OnChainOutput{
+			BatchOps: []mcms_types.BatchOperation{
+				{ChainSelector: ethMainnetSelector, Transactions: nil},
+			},
+		}, nil
+	})
+	cs := NewOnChainChangesetFromSequence(newTestChangesetParams(seq, nil, nil))
+
+	out, err := cs.Apply(env, WithMCMS[testCfg]{Cfg: cfg})
+	require.NoError(t, err)
+	require.NotEmpty(t, out.Reports)
+	require.Empty(t, out.MCMSTimelockProposals)
+}
+
+func TestNewOnChainChangesetFromSequence_applyMCMSBuildFailure(t *testing.T) {
+	t.Parallel()
+
+	env := testEnvironment(t)
+	cfg := testCfg{}
+	mcmsInput := validMCMSProposalInput()
+	ref := datastore.AddressRef{
+		Address:       "0xabc",
+		ChainSelector: 1,
+		Type:          "Timelock",
+		Version:       semver.MustParse("1.0.0"),
+	}
+	readerErr := errors.New("timelock ref failed")
+	registry := &deployment.MCMSReaderRegistry{}
+	require.NoError(t, registry.Register("evm", &failingTimelockReader{err: readerErr}))
+
+	seq := testSequence(t, func(_ operations.Bundle, _ struct{}, _ struct{}) (OnChainOutput, error) {
+		return OnChainOutput{
+			Metadata: datastore.MetadataBundle{Addresses: []datastore.AddressRef{ref}},
+			BatchOps: []mcms_types.BatchOperation{sampleBatchOp()},
+		}, nil
+	})
+	cs := NewOnChainChangesetFromSequence(
+		newTestChangesetParams(seq, nil, nil),
+		WithMCMSRegistry(registry),
+	)
+
+	out, err := cs.Apply(env, WithMCMS[testCfg]{Cfg: cfg, MCMS: &mcmsInput})
+	require.Error(t, err)
+	require.ErrorIs(t, err, readerErr)
+	require.ErrorContains(t, err, "get timelock ref for chain")
+	require.NotEmpty(t, out.Reports)
+	require.NotNil(t, out.DataStore)
+
+	refs, fetchErr := out.DataStore.Addresses().Fetch()
+	require.NoError(t, fetchErr)
+	require.Len(t, refs, 1)
+	require.Equal(t, "0xabc", refs[0].Address)
+	require.Empty(t, out.MCMSTimelockProposals)
+}
+
+func TestNewOnChainChangesetFromSequence_applySequenceError(t *testing.T) {
+	t.Parallel()
+
+	seqErr := errors.New("sequence failed")
+	seq := testSequence(t, func(_ operations.Bundle, _ struct{}, _ struct{}) (OnChainOutput, error) {
+		return OnChainOutput{}, seqErr
+	})
+	cs := NewOnChainChangesetFromSequence(newTestChangesetParams(seq, nil, nil))
+
+	out, err := cs.Apply(testEnvironment(t), WithMCMS[testCfg]{Cfg: testCfg{}})
+	require.Error(t, err)
+	require.ErrorContains(t, err, seqErr.Error())
+	require.ErrorContains(t, err, "failed to execute sequence")
+	require.NotEmpty(t, out.Reports)
+	require.Nil(t, out.DataStore)
+}
+
+func TestNewOnChainChangesetFromSequence_applyWriteMetadataError(t *testing.T) {
+	t.Parallel()
+
+	seq := testSequence(t, func(_ operations.Bundle, _ struct{}, _ struct{}) (OnChainOutput, error) {
+		return OnChainOutput{
+			Metadata: datastore.MetadataBundle{
+				Addresses: []datastore.AddressRef{{
+					Address:       "0xabc",
+					ChainSelector: 1,
+					Type:          "Timelock",
+				}},
+			},
+		}, nil
+	})
+	cs := NewOnChainChangesetFromSequence(newTestChangesetParams(seq, nil, nil))
+
+	out, err := cs.Apply(testEnvironment(t), WithMCMS[testCfg]{Cfg: testCfg{}})
+	require.Error(t, err)
+	require.ErrorIs(t, err, datastore.ErrAddressRefVersionRequired)
+	require.ErrorContains(t, err, "failed to write metadata to datastore")
+	require.NotEmpty(t, out.Reports)
+	require.Nil(t, out.DataStore)
+}
+
+func TestNewOnChainChangesetFromSequence_applyResolveErrorEmptyOutput(t *testing.T) {
+	t.Parallel()
+
+	resolveErr := errors.New("bad config")
+	seq := testSequence(t, func(_ operations.Bundle, _ struct{}, _ struct{}) (OnChainOutput, error) {
+		return OnChainOutput{}, nil
+	})
+	cs := NewOnChainChangesetFromSequence(newTestChangesetParams(seq,
+		func(deployment.Environment, testCfg) (struct{}, error) {
+			return struct{}{}, resolveErr
+		},
+		func(deployment.Environment, testCfg) (struct{}, error) { return struct{}{}, nil },
+	))
+
+	out, err := cs.Apply(testEnvironment(t), WithMCMS[testCfg]{Cfg: testCfg{}})
+	require.Error(t, err)
+	require.ErrorIs(t, err, deployment.ErrInvalidConfig)
+	require.Empty(t, out.Reports)
+	require.Nil(t, out.DataStore)
+}
+
+func newTestChangesetParams(
+	seq *operations.Sequence[struct{}, OnChainOutput, struct{}],
+	resolveInput func(deployment.Environment, testCfg) (struct{}, error),
+	resolveDep func(deployment.Environment, testCfg) (struct{}, error),
+) NewOnChainChangesetFromSequenceParams[struct{}, struct{}, testCfg] {
+	if resolveInput == nil {
+		resolveInput = func(deployment.Environment, testCfg) (struct{}, error) { return struct{}{}, nil }
+	}
+	if resolveDep == nil {
+		resolveDep = func(deployment.Environment, testCfg) (struct{}, error) { return struct{}{}, nil }
+	}
+
+	return NewOnChainChangesetFromSequenceParams[struct{}, struct{}, testCfg]{
+		Sequence:     seq,
+		ResolveInput: resolveInput,
+		ResolveDep:   resolveDep,
+	}
+}
+
+func testEnvironment(t *testing.T) deployment.Environment {
+	t.Helper()
+
+	lggr := logger.Test(t)
+
+	return deployment.Environment{
+		Logger:     lggr,
+		GetContext: func() context.Context { return t.Context() },
+		OperationsBundle: operations.NewBundle(
+			func() context.Context { return t.Context() },
+			lggr,
+			operations.NewMemoryReporter(),
+		),
+	}
+}
+
+func testSequence(
+	t *testing.T,
+	handler operations.SequenceHandler[struct{}, OnChainOutput, struct{}],
+) *operations.Sequence[struct{}, OnChainOutput, struct{}] {
+	t.Helper()
+
+	return operations.NewSequence(
+		"test-seq",
+		semver.MustParse("1.0.0"),
+		"test sequence",
+		handler,
+	)
+}
+
+func validMCMSProposalInput() deployment.MCMSTimelockProposalInput {
+	return deployment.MCMSTimelockProposalInput{
+		TimelockAction: mcms_types.TimelockActionSchedule,
+		ValidUntil:     testValidUntilUnix,
+		TimelockDelay:  mcms_types.NewDuration(time.Hour),
+		Description:    "proposal",
+	}
+}
+
+func sampleBatchOp() mcms_types.BatchOperation {
+	return mcms_types.BatchOperation{
+		ChainSelector: ethMainnetSelector,
+		Transactions: []mcms_types.Transaction{
+			{To: "0x01", Data: []byte("0xdeadbeef"), AdditionalFields: json.RawMessage("{}")},
+		},
+	}
+}
+
+func testMCMSRegistry(t *testing.T) *deployment.MCMSReaderRegistry {
+	t.Helper()
+
+	r := &deployment.MCMSReaderRegistry{}
+	require.NoError(t, r.Register("evm", &testMCMSReader{}))
+
+	return r
+}
+
+type testMCMSReader struct{}
+
+func (m *testMCMSReader) GetChainMetadata(_ deployment.Environment, _ uint64, _ deployment.MCMSTimelockProposalInput) (mcms_types.ChainMetadata, error) {
+	return mcms_types.ChainMetadata{StartingOpCount: 42}, nil
+}
+
+func (m *testMCMSReader) GetTimelockRef(_ deployment.Environment, selector uint64, _ deployment.MCMSTimelockProposalInput) (datastore.AddressRef, error) {
+	return datastore.AddressRef{
+		ChainSelector: selector,
+		Address:       "0x01",
+		Type:          datastore.ContractType("Timelock"),
+		Version:       semver.MustParse("1.0.0"),
+	}, nil
+}
+
+func (m *testMCMSReader) GetMCMSRef(_ deployment.Environment, selector uint64, _ deployment.MCMSTimelockProposalInput) (datastore.AddressRef, error) {
+	return datastore.AddressRef{
+		ChainSelector: selector,
+		Address:       "0x02",
+		Type:          datastore.ContractType("MCM"),
+		Version:       semver.MustParse("1.0.0"),
+	}, nil
+}
+
+type failingTimelockReader struct {
+	err error
+}
+
+func (r *failingTimelockReader) GetChainMetadata(_ deployment.Environment, _ uint64, _ deployment.MCMSTimelockProposalInput) (mcms_types.ChainMetadata, error) {
+	return mcms_types.ChainMetadata{}, nil
+}
+
+func (r *failingTimelockReader) GetTimelockRef(_ deployment.Environment, _ uint64, _ deployment.MCMSTimelockProposalInput) (datastore.AddressRef, error) {
+	return datastore.AddressRef{}, r.err
+}
+
+func (r *failingTimelockReader) GetMCMSRef(_ deployment.Environment, _ uint64, _ deployment.MCMSTimelockProposalInput) (datastore.AddressRef, error) {
+	return datastore.AddressRef{}, nil
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
Introducing `NewOnChainChangesetFromSequence` which is a util that wraps a sequence into a changeset and handles logic such as MCMS and output builder internally.

`NewOnChainChangesetFromSequence`  is useful for sequence which interacts with onchain and optionally creates MCMS proposals

This is also inspired from CHainlink CCIP tooling API [here](https://github.com/smartcontractkit/chainlink-ccip/blob/298ed1c38d5cda61a688beb2494a96a5409daf3d/deployment/utils/changesets/changesets.go#L31) but with some modifications.

Usage:
```go
	deploySeq := operations.NewSequence(
	    "deploy-timelock",
	    semver.MustParse("1.0.0"),
	    "Deploy timelock contracts",
	    func(b operations.Bundle, deps DeployDeps, in DeployInput) (OnChainOutput, error) {
	        // Run operations and collect addresses and/or MCMS batch operations.
	        return OnChainOutput{
	            Metadata: datastore.MetadataBundle{
	                Addresses: []datastore.AddressRef{timelockRef},
	            },
	            BatchOps: batchOps, // omit when no MCMS proposal is needed
	        }, nil
	    },
	)

	cs := NewOnChainChangesetFromSequence(
	    NewOnChainChangesetFromSequenceParams[DeployInput, DeployDeps, DeployConfig]{
	        Sequence: deploySeq,
	        ResolveInput: func(e deployment.Environment, cfg DeployConfig) (DeployInput, error) {
	            return DeployInput{ChainSelector: cfg.ChainSelector}, nil
	        },
	        ResolveDep: func(e deployment.Environment, cfg DeployConfig) (DeployDeps, error) {
	            return DeployDeps{Chain: e.BlockChains.EVMChains()[cfg.ChainSelector]}, nil
	        },
	    },
	)

	wrapped := WithMCMS[DeployConfig]{
	    Cfg: DeployConfig{ChainSelector: ethMainnetSelector},
	    MCMS: &deployment.MCMSTimelockProposalInput{
	        TimelockAction: mcms_types.TimelockActionSchedule,
	        ValidUntil:     validUntil,
	        TimelockDelay:  mcms_types.NewDuration(time.Hour),
	        Description:    "schedule timelock ops",
	    },
	}
	registry.Add("test_changeset", changeset.Configure(cs).With(wrapped))
	// out.DataStore holds deployed addresses; out.MCMSTimelockProposals holds proposals.
```

JIRA:https://smartcontract-it.atlassian.net/browse/CLD-2463