### PR TITLE
ci: bump action versions to latest

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -33,7 +33,7 @@ jobs:
       actions: read
     steps:
       - name: Linting Go
-        uses: smartcontractkit/.github/actions/ci-lint-go@ci-lint-go/v2 # ci-lint-go@2.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-go@ci-lint-go/v2 # ci-lint-go/v2
         with:
           only-new-issues: "false"
           golangci-lint-version: v2.12.2
@@ -49,7 +49,7 @@ jobs:
       actions: read
     steps:
       - name: Linting operations-gen
-        uses: smartcontractkit/.github/actions/ci-lint-go@ci-lint-go/v2 # ci-lint-go@2.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-go@ci-lint-go/v2 # ci-lint-go/v2
         with:
           only-new-issues: "false"
           golangci-lint-version: v2.12.2
@@ -62,7 +62,7 @@ jobs:
       contents: read
     steps:
       - name: Linting Misc (yaml + sh files)
-        uses: smartcontractkit/.github/actions/ci-lint-misc@eeb76b5870e3c17856d5a60fd064a053c023b5f5 # ci-lint-misc@1.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-misc@ci-lint-misc/v1 # ci-lint-misc/v1
 
   ci-test-operations-gen:
     name: Tests operations-gen
@@ -76,7 +76,7 @@ jobs:
       actions: read
     steps:
       - name: Build and test operations-gen
-        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1 # ci-test-go/v1
         with:
           go-test-cmd: cd tools/operations-gen && go test -race ./...
           use-go-cache: true
@@ -92,7 +92,7 @@ jobs:
       actions: read
     steps:
       - name: Build and test
-        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1 # ci-test-go/v1
         with:
           # disable the checkptr runtime check due a false positive in github.com/xssnick/tonutils-go
           # causing tests in ci to fail "fatal error: checkptr: pointer arithmetic result points to invalid allocation"
@@ -112,7 +112,7 @@ jobs:
       actions: read
     steps:
       - name: Build and test evm provider packages
-        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1 # ci-test-go/v1
         with:
           go-test-cmd: go test -race -coverprofile=coverage.txt ./chain/evm/...
           use-go-cache: true
@@ -128,7 +128,7 @@ jobs:
       actions: read
     steps:
       - name: Build and test solana provider packages
-        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1 # ci-test-go/v1
         with:
           go-test-cmd: go test -race -coverprofile=coverage.txt ./chain/solana/...
           use-go-cache: true
@@ -149,7 +149,7 @@ jobs:
           CLI_VERSION: 9.2.0
 
       - name: Build and test aptos provider packages
-        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1 # ci-test-go/v1
         with:
           go-test-cmd: go test -race -coverprofile=coverage.txt ./chain/aptos/...
           use-go-cache: true
@@ -177,7 +177,7 @@ jobs:
           rm -f sui.tgz
 
       - name: Build and test sui provider packages
-        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1 # ci-test-go/v1
         with:
           go-test-cmd: go test -race -coverprofile=coverage.txt ./chain/sui/...
           use-go-cache: true
@@ -193,7 +193,7 @@ jobs:
       actions: read
     steps:
       - name: Build and test canton provider packages
-        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1 # ci-test-go/v1
         with:
           go-test-cmd: go test -race -coverprofile=coverage.txt ./chain/canton/...
           use-go-cache: true
@@ -209,7 +209,7 @@ jobs:
       actions: read
     steps:
       - name: Build and test ton provider packages
-        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1 # ci-test-go/v1
         with:
           # disable the checkptr runtime check due a false positive in github.com/xssnick/tonutils-go
           # causing tests in ci to fail "fatal error: checkptr: pointer arithmetic result points to invalid allocation"
@@ -228,7 +228,7 @@ jobs:
       actions: read
     steps:
       - name: Build and test tron provider packages
-        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1 # ci-test-go/v1
         with:
           go-test-cmd: go test -race -coverprofile=coverage.txt ./chain/tron/...
           use-go-cache: true
@@ -244,7 +244,7 @@ jobs:
       actions: read
     steps:
       - name: Build and test stellar provider packages
-        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1 # ci-test-go/v1
         with:
           go-test-cmd: go test -race -coverprofile=coverage.txt ./chain/stellar/...
           use-go-cache: true
@@ -260,7 +260,7 @@ jobs:
       actions: read
     steps:
       - name: Build and test provider packages
-        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1 # ci-test-go/v1
         with:
           # -p 2 -parallel 3 = 2 packages, 3 tests max = 6 containers max
           # Run all provider tests EXCEPT slow ones (evm, solana, aptos, sui, canton, ton, tron, stellar) which have dedicated jobs
@@ -314,7 +314,7 @@ jobs:
           echo "tag=${LATEST_TAG}" >> "${GITHUB_OUTPUT}"
 
       - name: Pull Catalog Service ECR Image
-        uses: smartcontractkit/.github/actions/pull-private-ecr-image@2f8f0baf38e46140c6a119eb551a56eaaabcc09e # pull-private-ecr-image@1.0.0
+        uses: smartcontractkit/.github/actions/pull-private-ecr-image@pull-private-ecr-image/v1 # pull-private-ecr-image/v1
         with:
           aws-account-number: ${{ secrets.AWS_ACCOUNT_NUMBER_PROD }}
           aws-region: ${{ secrets.AWS_REGION }}
@@ -323,7 +323,7 @@ jobs:
           image-tag: ${{ steps.get-catalog-tag.outputs.tag }}
 
       - name: Run Catalog Remote Integration Tests
-        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1 # ci-test-go@v1
         with:
           # Must cd into datastore/catalog/remote because TestMain only runs from package directory
           go-test-cmd: cd datastore/catalog/remote && go test -v -race -timeout 10m -gcflags=all=-d=checkptr=0 -coverprofile=../../../coverage.txt
@@ -346,7 +346,7 @@ jobs:
       actions: read
     steps:
       - name: Scan with Sonarqube
-        uses: smartcontractkit/.github/actions/ci-sonarqube-go@01d931b0455a754d12e7143cc54a5a3521a8f6f6 # ci-sonarqube-go@0.3.1
+        uses: smartcontractkit/.github/actions/ci-sonarqube-go@82f9a1703246639b70da5fd5a3e489363b04a0d6 # ci-sonarqube-go@0.6.1
         with:
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           sonar-host-url: ${{ secrets.SONAR_HOST_URL }}

--- a/.github/workflows/push-tag-release-operations-gen.yml
+++ b/.github/workflows/push-tag-release-operations-gen.yml
@@ -14,7 +14,7 @@ jobs:
       actions: read
     steps:
       - name: cicd-publish-release-operations-gen
-        uses: smartcontractkit/.github/actions/cicd-build-publish-artifacts-go@b4737861584f88fa9569d6978f70fedf8b1ae67c # cicd-build-publish-artifacts-go@0.4.0
+        uses: smartcontractkit/.github/actions/cicd-build-publish-artifacts-go@4475ad7c475bacb1aefeccb132645149201ababd # cicd-build-publish-artifacts-go/0.7.0
         with:
           # general inputs
           app-name: operations-gen

--- a/.github/workflows/push-tag-release.yml
+++ b/.github/workflows/push-tag-release.yml
@@ -14,7 +14,7 @@ jobs:
       actions: read
     steps:
       - name: cicd-publish-release
-        uses: smartcontractkit/.github/actions/cicd-build-publish-artifacts-go@b4737861584f88fa9569d6978f70fedf8b1ae67c # cicd-build-publish-artifacts-go@0.4.0
+        uses: smartcontractkit/.github/actions/cicd-build-publish-artifacts-go@4475ad7c475bacb1aefeccb132645149201ababd # cicd-build-publish-artifacts-go/0.7.0
         with:
           # general inputs
           app-name: chainlink-deployments-framework

--- a/.github/workflows/schedule-main.yml
+++ b/.github/workflows/schedule-main.yml
@@ -16,7 +16,7 @@ jobs:
       actions: read
     steps:
       - name: Linting Go
-        uses: smartcontractkit/.github/actions/ci-lint-go@ci-lint-go/v2 # ci-lint-go@2.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-go@ci-lint-go/v2 # ci-lint-go/v2
         with:
           only-new-issues: "false"
           golangci-lint-version: v2.12.2
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
       - name: Linting Misc (yaml + sh files)
-        uses: smartcontractkit/.github/actions/ci-lint-misc@eeb76b5870e3c17856d5a60fd064a053c023b5f5 # ci-lint-misc@1.0.0
+        uses: smartcontractkit/.github/actions/ci-lint-misc@ci-lint-misc/v1 # ci-lint-misc/v1
 
   ci-test:
     name: Tests
@@ -40,7 +40,7 @@ jobs:
       actions: read
     steps:
       - name: Build and test
-        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1 # ci-test-go/v1
         with:
           # disable the checkptr runtime check due a false positive in github.com/xssnick/tonutils-go
           # Exclude provider packages which use Docker containers and remote catalog tests
@@ -58,7 +58,7 @@ jobs:
       actions: read
     steps:
       - name: Build and test provider packages
-        uses: smartcontractkit/.github/actions/ci-test-go@dfcba48f05933158428bce867d790e3d5a9baa6b # ci-test-go@1.1.0
+        uses: smartcontractkit/.github/actions/ci-test-go@ci-test-go/v1 # ci-test-go/v1
         with:
           # disable the checkptr runtime check due a false positive in github.com/xssnick/tonutils-go
           # -p 2 -parallel 3 = 2 packages, 3 tests max = 6 containers max


### PR DESCRIPTION
Bumps the following actions to their latest versions:

- ci-lint-go/v2
- ci-lint-misc/v1
- ci-test-go/v1
- cicd-build-publish-artifacts-go/0.7.0
- pull-private-ecr-image/v1
- ci-sonarqube-go/0.6.1

Where possible we pin the CLL owned actions to a flexible version tag.