### PR TITLE
fix(fork-tests): don't use AddressBook/DataStore to filter chains

### DIFF
--- a/.changeset/nine-swans-see.md
+++ b/.changeset/nine-swans-see.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix(fork-tests): don't use AddressBook/DataStore to filter chains

--- a/engine/cld/environment/anvil.go
+++ b/engine/cld/environment/anvil.go
@@ -26,8 +26,6 @@ import (
 	fchain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	fevm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	evmprov "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider"
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	fdeployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cfgenv "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/config/env"
 	cfgnet "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/config/network"
 )
@@ -130,8 +128,6 @@ type AnvilChainsOutput struct {
 func newAnvilChains(
 	ctx context.Context,
 	lggr logger.Logger,
-	addressBook fdeployment.AddressBook,
-	dataStore datastore.DataStore,
 	evmNetworks *cfgnet.Config,
 	blockNumbers map[uint64]*big.Int,
 	onchainConfig cfgenv.OnchainConfig,
@@ -162,17 +158,6 @@ func newAnvilChains(
 
 	chainConfigsBySelector := make(map[uint64]ChainConfig)
 	anvilClients := make(map[uint64]ForkedOnchainClient)
-	addressesByChain, err1 := addressBook.Addresses()
-	if err1 != nil {
-		return nil, fmt.Errorf("failed to get addresses by chain selector: %w", err1)
-	}
-	dataStoreAddresses, err1 := dataStore.Addresses().Fetch()
-	if err1 != nil {
-		return nil, fmt.Errorf("failed to get addresses from data store: %w", err1)
-	}
-	for _, address := range dataStoreAddresses {
-		addressesByChain[address.ChainSelector] = map[string]fdeployment.TypeAndVersion{}
-	}
 
 	var once sync.Once
 	blockChains := make([]fchain.BlockChain, 0, len(filteredEvmNetworks))
@@ -222,13 +207,6 @@ func newAnvilChains(
 		}
 		if err = metadata.AnvilConfig.Validate(); err != nil {
 			lggr.Infof("Excluding chain with ID %d from environment due to failed anvil config validation: %s", chainID, err.Error())
-			continue
-		}
-
-		// Skip chains that are not included in the address book
-		if _, ok := addressesByChain[chainSelector]; !ok {
-			lggr.Infof("Excluding chain with selector %d from environment, does not have addresses defined in the address book", chainSelector)
-
 			continue
 		}
 

--- a/engine/cld/environment/fork.go
+++ b/engine/cld/environment/fork.go
@@ -91,8 +91,6 @@ func LoadFork(
 	anvilOutput, err := newAnvilChains(
 		ctx,
 		lggr,
-		addressBook,
-		dataStore,
 		networks,
 		blockNumbers,
 		cfg.Env.Onchain,


### PR DESCRIPTION
We already filter the networks by checking the chain selectors passed when loading the environment via `OnlyChainFor`. The AddressBook and DataStore filters are not needed and actually cause problems if a domain isn't using either of them.