### PR TITLE
ci(tests): increase step timeout

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -105,7 +105,7 @@ jobs:
   ci-test-provider-evm:
     name: Chain Tests - EVM
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     permissions:
       id-token: write
       contents: read
@@ -202,7 +202,7 @@ jobs:
   ci-test-provider-ton:
     name: Chain Tests - TON
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     permissions:
       id-token: write
       contents: read
@@ -221,7 +221,7 @@ jobs:
   ci-test-provider-tron:
     name: Chain Tests - TRON
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Looks like for the provider tests, the 5 minutes timeout is no longer enough, we tend to finish just over 5 minutes, increasing the timeout to 8 minutes for now.

We should investigate to see any performance improvement we can do here, but i want atleast keep the test running for now.

<img width="903" height="211" alt="Screenshot 2026-06-17 at 12 53 27 pm" src="https://github.com/user-attachments/assets/48b9ab18-82bb-47d7-9aa3-45a1e91d81a3" />
