### PR TITLE
feat(operations-gen): add deploy_contract_types for same-ABI multi-label deploy

### DIFF
--- a/.changeset/long-times-divide.md
+++ b/.changeset/long-times-divide.md
@@ -1,0 +1,5 @@
+---
+"operations-gen": minor
+---
+
+feat: add deploy_contract_types for same-ABI multi-label deploy

--- a/tools/operations-gen/README.md
+++ b/tools/operations-gen/README.md
@@ -127,6 +127,17 @@ contracts:
         access: owner # Write op with MCMS support
       - name: getTokenPrice
         access: public # Read op (or public write op)
+
+  # Same ABI, multiple datastore labels — one Deploy handles all three.
+  - contract_name: ManyChainMultiSig
+    version: "1.0.0"
+    deploy_contract_types:
+      - ProposerManyChainMultiSig
+      - BypasserManyChainMultiSig
+      - CancellerManyChainMultiSig
+    functions:
+      - name: setConfig
+        access: owner
 ```
 
 ### Top-level fields
@@ -148,8 +159,9 @@ contracts:
 | `gobindings_package` | No       | Optional full Go import path or relative filesystem path override for this contract's abigen-generated bindings package. Required only when `input.gobindings_package` is not set. |
 | `package_name`       | No       | Override the generated Go package name. Defaults to `snake_case(contract_name)`.                                                                       |
 | `version_path`       | No       | Override the directory path derived from the version. Defaults to `v{major}_{minor}_{patch}`.                                                          |
-| `omit_deploy`        | No       | Skip generation of the `Deploy` operation and bytecode constant. Defaults to `false`. Cannot be combined with `zksync_bytecode`.                                                                  |
-| `zksync_bytecode`    | No       | zkSync VM deploy bytecode symbol, or `{package, symbol}`. Package defaults to `input.zksync_bindings_package`, then the contract's `gobindings_package`. |
+| `omit_deploy`           | No       | Skip generation of the `Deploy` operation and bytecode constant. Defaults to `false`. Cannot be combined with `zksync_bytecode` or `deploy_contract_types`. |
+| `deploy_contract_types` | No       | List of `ContractType` labels (e.g. `ProposerManyChainMultiSig`) that share this contract's ABI and bytecode but need distinct datastore entries. Labels must be valid Go exported identifiers. When set, **only** these labels appear as keys in `BytecodeByTypeAndVersion` — the base `contract_name` type is excluded. Each label gets exported `var <Label>ContractType` and `var <Label>TypeAndVersion` vars. An empty list is rejected. Cannot be combined with `omit_deploy`. See [Deploy contract types](#deploy-contract-types). |
+| `zksync_bytecode`       | No       | zkSync VM deploy bytecode symbol, or `{package, symbol}`. Package defaults to `input.zksync_bindings_package`, then the contract's `gobindings_package`. |
 
 ### Function access control
 
@@ -162,6 +174,61 @@ contracts:
 For `access: role`, `DEFAULT_ADMIN_ROLE` maps to the all-zero role and any other
 human-readable role name is hashed as `keccak256("<ROLE_NAME>")`. Raw bytes32
 role hashes are rejected so configs remain readable.
+
+## Deploy contract types
+
+Some contracts are deployed multiple times with different semantic roles, each requiring a distinct
+`ContractType` label in the datastore (e.g. `ProposerManyChainMultiSig`, `BypasserManyChainMultiSig`,
+`CancellerManyChainMultiSig`). Because all three share the same ABI and bytecode, using three
+separate YAML contract entries would generate three near-identical files. `deploy_contract_types`
+solves this: one entry, one generated package, one `Deploy` var — but the `BytecodeByTypeAndVersion`
+map holds a key for every label so the caller can deploy under whichever type it needs.
+
+```yaml
+- contract_name: ManyChainMultiSig
+  version: "1.0.0"
+  deploy_contract_types:
+    - ProposerManyChainMultiSig
+    - BypasserManyChainMultiSig
+    - CancellerManyChainMultiSig
+  functions:
+    - name: setConfig
+      access: owner
+```
+
+This generates:
+
+```go
+var ContractType cldf_deployment.ContractType = "ManyChainMultiSig"
+var ProposerManyChainMultiSigContractType cldf_deployment.ContractType = "ProposerManyChainMultiSig"
+var ProposerManyChainMultiSigTypeAndVersion = cldf_deployment.NewTypeAndVersion(ProposerManyChainMultiSigContractType, *Version)
+var BypasserManyChainMultiSigContractType cldf_deployment.ContractType = "BypasserManyChainMultiSig"
+var BypasserManyChainMultiSigTypeAndVersion = cldf_deployment.NewTypeAndVersion(BypasserManyChainMultiSigContractType, *Version)
+var CancellerManyChainMultiSigContractType cldf_deployment.ContractType = "CancellerManyChainMultiSig"
+var CancellerManyChainMultiSigTypeAndVersion = cldf_deployment.NewTypeAndVersion(CancellerManyChainMultiSigContractType, *Version)
+
+var Deploy = contract.NewDeploy(contract.DeployParams[ConstructorArgs]{
+    BytecodeByTypeAndVersion: map[string]contract.Bytecode{
+        ProposerManyChainMultiSigTypeAndVersion.String(): { /* ... */ },
+        BypasserManyChainMultiSigTypeAndVersion.String(): { /* ... */ },
+        CancellerManyChainMultiSigTypeAndVersion.String(): { /* ... */ },
+    },
+})
+```
+
+The caller selects the role at deploy time by passing the appropriate `TypeAndVersion` to `Deploy`:
+
+```go
+many_chain_multi_sig.Deploy.Execute(b, chain, contract.DeployInput[many_chain_multi_sig.ConstructorArgs]{
+    TypeAndVersion: many_chain_multi_sig.ProposerManyChainMultiSigTypeAndVersion,
+})
+```
+
+**Rules:**
+- Labels must be valid Go exported identifiers, non-empty, unique, and different from `contract_name`.
+- The list must contain at least one entry; an empty list is rejected.
+- Cannot be combined with `omit_deploy: true`.
+- The base `contract_name` type is **not** included in `BytecodeByTypeAndVersion` when this field is set, and `TypeAndVersion` is not emitted (use the per-label `*TypeAndVersion` vars instead).
 
 ## Gobindings requirements
 

--- a/tools/operations-gen/generate/templates/evm/operations.tmpl
+++ b/tools/operations-gen/generate/templates/evm/operations.tmpl
@@ -30,7 +30,13 @@ import (
 
 var ContractType cldf_deployment.ContractType = "{{.ContractType}}"
 var Version = semver.MustParse("{{.Version}}")
+{{- if not .DeployContractTypes}}
 var TypeAndVersion = cldf_deployment.NewTypeAndVersion(ContractType, *Version)
+{{- end}}
+{{- range .DeployContractTypes}}
+var {{.}}ContractType cldf_deployment.ContractType = "{{.}}"
+var {{.}}TypeAndVersion = cldf_deployment.NewTypeAndVersion({{.}}ContractType, *Version)
+{{- end}}
 {{range .StructDefs}}
 type {{.Name}} struct {
 {{- range .Fields}}
@@ -62,12 +68,23 @@ var Deploy = contract.NewDeploy(contract.DeployParams[ConstructorArgs]{
 	Description: "Deploys the {{.ContractType}} contract",
 	ContractMetadata: gobindings.{{.ContractType}}MetaData,
 	BytecodeByTypeAndVersion: map[string]contract.Bytecode{
+{{- if not .DeployContractTypes}}
 		cldf_deployment.NewTypeAndVersion(ContractType, *Version).String(): {
 			EVM: common.FromHex(gobindings.{{.ContractType}}MetaData.Bin),
 {{- if .ZkSyncBytecodeSymbol}}
 			ZkSyncVM: {{if .ZkSyncBytecodeUseGobindings}}gobindings{{else}}zkbindings{{end}}.{{.ZkSyncBytecodeSymbol}},
 {{- end}}
 		},
+{{- else}}
+{{- range .DeployContractTypes}}
+		{{.}}TypeAndVersion.String(): {
+			EVM: common.FromHex(gobindings.{{$.ContractType}}MetaData.Bin),
+{{- if $.ZkSyncBytecodeSymbol}}
+			ZkSyncVM: {{if $.ZkSyncBytecodeUseGobindings}}gobindings{{else}}zkbindings{{end}}.{{$.ZkSyncBytecodeSymbol}},
+{{- end}}
+		},
+{{- end}}
+{{- end}}
 	},
 })
 {{- end}}

--- a/tools/operations-gen/internal/families/evm/codegen.go
+++ b/tools/operations-gen/internal/families/evm/codegen.go
@@ -24,11 +24,14 @@ type templateData struct {
 	NeedsBigInt                 bool
 	HasWriteOps                 bool
 	OmitDeploy                  bool
-	Constructor                 *constructorData
-	StructDefs                  []structDefData
-	ArgStructs                  []argStructData
-	Operations                  []OperationData
-	ContractMethods             []contractMethodData
+	// DeployContractTypes holds additional ContractType labels that share this
+	// contract's ABI and bytecode.
+	DeployContractTypes []string
+	Constructor         *constructorData
+	StructDefs          []structDefData
+	ArgStructs          []argStructData
+	Operations          []OperationData
+	ContractMethods     []contractMethodData
 }
 
 type constructorData struct {
@@ -87,13 +90,14 @@ func generateOperationsFile(info *ContractInfo, tmpl *template.Template) error {
 
 func prepareTemplateData(info *ContractInfo) templateData {
 	data := templateData{
-		PackageName:       info.PackageName,
-		PackageNameHyphen: toKebabCase(info.PackageName),
-		ContractType:      info.Name,
-		Version:           info.Version,
-		GobindingsImport:  info.GobindingsPackage,
-		NeedsBigInt:       ChecksNeedsBigInt(info),
-		OmitDeploy:        info.OmitDeploy,
+		PackageName:         info.PackageName,
+		PackageNameHyphen:   toKebabCase(info.PackageName),
+		ContractType:        info.Name,
+		Version:             info.Version,
+		GobindingsImport:    info.GobindingsPackage,
+		NeedsBigInt:         ChecksNeedsBigInt(info),
+		OmitDeploy:          info.OmitDeploy,
+		DeployContractTypes: info.DeployContractTypes,
 	}
 	if info.ZkSync != nil {
 		data.ZkSyncBytecodeSymbol = info.ZkSync.BytecodeSymbol

--- a/tools/operations-gen/internal/families/evm/config.go
+++ b/tools/operations-gen/internal/families/evm/config.go
@@ -2,15 +2,21 @@ package evm
 
 // EvmContractConfig is the EVM-specific contract configuration decoded from YAML.
 type EvmContractConfig struct {
-	Name              string              `yaml:"contract_name"`
-	Version           string              `yaml:"version"`
-	VersionPath       string              `yaml:"version_path,omitempty"` // Optional: override folder path derived from version
-	PackageName       string              `yaml:"package_name,omitempty"` // Optional: override package name
-	OmitDeploy        bool                `yaml:"omit_deploy,omitempty"`  // Optional: skip Deploy operation
-	GobindingsPackage string              `yaml:"gobindings_package"`     // Optional: override the derived gobindings import path or relative filesystem path for this contract.
-	ZkSyncBytecode    ZkSyncBytecodeRef   `yaml:"zksync_bytecode,omitempty"`
-	Functions         []EvmFunctionConfig `yaml:"functions"`
-	ConfigDir         string              `yaml:"-"`
+	Name              string            `yaml:"contract_name"`
+	Version           string            `yaml:"version"`
+	VersionPath       string            `yaml:"version_path,omitempty"` // Optional: override folder path derived from version
+	PackageName       string            `yaml:"package_name,omitempty"` // Optional: override package name
+	OmitDeploy        bool              `yaml:"omit_deploy,omitempty"`  // Optional: skip Deploy operation
+	GobindingsPackage string            `yaml:"gobindings_package"`     // Optional: override the derived gobindings import path or relative filesystem path for this contract.
+	ZkSyncBytecode    ZkSyncBytecodeRef `yaml:"zksync_bytecode,omitempty"`
+	// DeployContractTypes lists ContractType labels (e.g. "ProposerManyChainMultiSig") that share
+	// the same ABI and bytecode as this contract but need separate datastore entries.
+	// Labels must be valid Go exported identifiers. When non-nil, ONLY these labels appear as
+	// BytecodeByTypeAndVersion keys and each gets <Label>ContractType + <Label>TypeAndVersion vars.
+	// An empty list is rejected. Cannot be set when omit_deploy is true.
+	DeployContractTypes []string            `yaml:"deploy_contract_types,omitempty"`
+	Functions           []EvmFunctionConfig `yaml:"functions"`
+	ConfigDir           string              `yaml:"-"`
 }
 
 type EvmInputConfig struct {

--- a/tools/operations-gen/internal/families/evm/contract.go
+++ b/tools/operations-gen/internal/families/evm/contract.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"golang.org/x/mod/modfile"
@@ -32,10 +34,15 @@ type ContractInfo struct {
 	ZkSync            *ZkSyncContractInfo
 	OutputPath        string
 	OmitDeploy        bool
-	Constructor       *FunctionInfo
-	Functions         map[string]*FunctionInfo
-	FunctionOrder     []string
-	StructDefs        map[string]*structDef
+	// DeployContractTypes holds ContractType labels that share this contract's ABI
+	// and bytecode. When non-empty, ONLY these labels appear as BytecodeByTypeAndVersion
+	// keys — the base ContractType is excluded. Each entry also gets an exported var.
+	// Always empty when OmitDeploy is true.
+	DeployContractTypes []string
+	Constructor         *FunctionInfo
+	Functions           map[string]*FunctionInfo
+	FunctionOrder       []string
+	StructDefs          map[string]*structDef
 }
 
 // ZkSyncContractInfo holds resolved zkSync VM deploy bytecode for code generation.
@@ -108,6 +115,17 @@ func extractContractInfo(cfg EvmContractConfig, input EvmInputConfig, output Evm
 	if cfg.OmitDeploy && !cfg.ZkSyncBytecode.IsZero() {
 		return nil, fmt.Errorf("contract %q: zksync_bytecode cannot be set when omit_deploy is true", cfg.Name)
 	}
+	if cfg.DeployContractTypes != nil {
+		if cfg.OmitDeploy {
+			return nil, fmt.Errorf("contract %q: deploy_contract_types cannot be set when omit_deploy is true", cfg.Name)
+		}
+		if len(cfg.DeployContractTypes) == 0 {
+			return nil, fmt.Errorf("contract %q: deploy_contract_types must contain at least one entry", cfg.Name)
+		}
+		if err = validateDeployContractTypes(cfg.Name, cfg.DeployContractTypes); err != nil {
+			return nil, err
+		}
+	}
 
 	zkSyncPackage, zkSyncSymbol, err := resolveZkSyncBytecode(cfg, input, cfg.GobindingsPackage)
 	if err != nil {
@@ -120,14 +138,15 @@ func extractContractInfo(cfg EvmContractConfig, input EvmInputConfig, output Evm
 	}
 
 	info := &ContractInfo{
-		Name:              cfg.Name,
-		Version:           cfg.Version,
-		PackageName:       packageName,
-		GobindingsPackage: cfg.GobindingsPackage,
-		OutputPath:        core.ContractOutputPath(output.BasePath, versionPath, packageName),
-		OmitDeploy:        cfg.OmitDeploy,
-		Functions:         make(map[string]*FunctionInfo),
-		StructDefs:        make(map[string]*structDef),
+		Name:                cfg.Name,
+		Version:             cfg.Version,
+		PackageName:         packageName,
+		GobindingsPackage:   cfg.GobindingsPackage,
+		OutputPath:          core.ContractOutputPath(output.BasePath, versionPath, packageName),
+		OmitDeploy:          cfg.OmitDeploy,
+		DeployContractTypes: cfg.DeployContractTypes,
+		Functions:           make(map[string]*FunctionInfo),
+		StructDefs:          make(map[string]*structDef),
 	}
 	if zkSyncSymbol != "" {
 		info.ZkSync = &ZkSyncContractInfo{
@@ -301,6 +320,43 @@ func collectAllStructDefs(info *ContractInfo) {
 			}
 		}
 	}
+}
+
+// validateDeployContractTypes checks that every label in deploy_contract_types is
+// a valid Go exported identifier, unique, and not equal to the base contract name.
+func validateDeployContractTypes(contractName string, types []string) error {
+	seen := make(map[string]struct{}, len(types))
+	for _, t := range types {
+		if t == "" {
+			return fmt.Errorf("contract %q: deploy_contract_types entries must not be empty", contractName)
+		}
+		if !isValidGoExportedIdentifier(t) {
+			return fmt.Errorf("contract %q: deploy_contract_types entry %q must be a valid Go exported identifier", contractName, t)
+		}
+		if t == contractName {
+			return fmt.Errorf("contract %q: deploy_contract_types must not contain the base contract name %q", contractName, t)
+		}
+		if _, dup := seen[t]; dup {
+			return fmt.Errorf("contract %q: duplicate deploy_contract_types entry %q", contractName, t)
+		}
+		seen[t] = struct{}{}
+	}
+
+	return nil
+}
+
+func isValidGoExportedIdentifier(s string) bool {
+	first, size := utf8.DecodeRuneInString(s)
+	if size == 0 || !unicode.IsUpper(first) {
+		return false
+	}
+	for _, r := range s[size:] {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
+			return false
+		}
+	}
+
+	return true
 }
 
 // Absolute paths and any cleaned path containing ".." or a path separator are rejected.

--- a/tools/operations-gen/internal/families/evm/evm_test.go
+++ b/tools/operations-gen/internal/families/evm/evm_test.go
@@ -1,6 +1,7 @@
 package evm_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -97,6 +98,147 @@ contracts:
 
 	require.Contains(t, string(got), `gobindings "`+wantGobindingsPackage+`"`)
 	require.NotContains(t, string(got), `gobindings "./testdata/evm/gobindings`)
+}
+
+func TestDeployContractTypesGeneratesExtraVarsAndBytecodeEntries(t *testing.T) {
+	t.Parallel()
+
+	config := `version: "1.0.0"
+chain_family: evm
+
+input:
+  gobindings_package: "github.com/smartcontractkit/chainlink-deployments-framework/tools/operations-gen/testdata/evm/gobindings"
+
+output:
+  base_path: "."
+
+contracts:
+  - contract_name: LinkToken
+    version: "1.0.0"
+    deploy_contract_types:
+      - AliasLinkToken
+      - AnotherLinkToken
+    functions:
+      - name: transfer
+        access: public
+`
+
+	var cfg core.Config
+	require.NoError(t, yaml.Unmarshal([]byte(config), &cfg), "parsing config")
+
+	tmpDir := t.TempDir()
+	cfg.Output = mustYAMLNode(t, evm.EvmOutputConfig{BasePath: tmpDir})
+
+	tmpl, err := generate.LoadTemplate("evm")
+	require.NoError(t, err)
+
+	require.NoError(t, evm.Handler{}.Generate(cfg, tmpl))
+
+	outputPath := core.ContractOutputPath(tmpDir, core.VersionToPath("1.0.0"), "link_token")
+	got, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	src := string(got)
+	require.Contains(t, src, `var AliasLinkTokenContractType cldf_deployment.ContractType = "AliasLinkToken"`)
+	require.Contains(t, src, `var AliasLinkTokenTypeAndVersion = cldf_deployment.NewTypeAndVersion(AliasLinkTokenContractType, *Version)`)
+	require.Contains(t, src, `var AnotherLinkTokenContractType cldf_deployment.ContractType = "AnotherLinkToken"`)
+	require.Contains(t, src, `var AnotherLinkTokenTypeAndVersion = cldf_deployment.NewTypeAndVersion(AnotherLinkTokenContractType, *Version)`)
+	require.Contains(t, src, `AliasLinkTokenTypeAndVersion.String()`)
+	require.Contains(t, src, `AnotherLinkTokenTypeAndVersion.String()`)
+	// Base TypeAndVersion must not be emitted when deploy_contract_types is set.
+	require.NotContains(t, src, `var TypeAndVersion = cldf_deployment.NewTypeAndVersion(ContractType, *Version)`)
+	require.NotContains(t, src, `cldf_deployment.NewTypeAndVersion(ContractType, *Version).String()`)
+}
+
+func TestDeployContractTypesValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	const baseConfig = `version: "1.0.0"
+chain_family: evm
+
+input:
+  gobindings_package: "github.com/smartcontractkit/chainlink-deployments-framework/tools/operations-gen/testdata/evm/gobindings"
+
+output:
+  base_path: "."
+
+contracts:
+  - contract_name: LinkToken
+    version: "1.0.0"
+    %s
+    functions:
+      - name: transfer
+        access: public
+`
+
+	cases := []struct {
+		name    string
+		snippet string
+		wantErr string
+	}{
+		{
+			name: "omit_deploy with deploy_contract_types",
+			snippet: `omit_deploy: true
+    deploy_contract_types:
+      - AliasLinkToken`,
+			wantErr: "deploy_contract_types cannot be set when omit_deploy is true",
+		},
+		{
+			name: "empty entry",
+			snippet: `deploy_contract_types:
+      - ""`,
+			wantErr: "deploy_contract_types entries must not be empty",
+		},
+		{
+			name: "duplicate entry",
+			snippet: `deploy_contract_types:
+      - AliasLinkToken
+      - AliasLinkToken`,
+			wantErr: `duplicate deploy_contract_types entry "AliasLinkToken"`,
+		},
+		{
+			name: "base contract name as entry",
+			snippet: `deploy_contract_types:
+      - LinkToken`,
+			wantErr: `deploy_contract_types must not contain the base contract name "LinkToken"`,
+		},
+		{
+			name:    "empty list",
+			snippet: `deploy_contract_types: []`,
+			wantErr: "deploy_contract_types must contain at least one entry",
+		},
+		{
+			name: "invalid identifier lowercase",
+			snippet: `deploy_contract_types:
+      - proposerLinkToken`,
+			wantErr: `deploy_contract_types entry "proposerLinkToken" must be a valid Go exported identifier`,
+		},
+		{
+			name: "invalid identifier with space",
+			snippet: `deploy_contract_types:
+      - "Proposer LinkToken"`,
+			wantErr: `deploy_contract_types entry "Proposer LinkToken" must be a valid Go exported identifier`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfgYAML := fmt.Sprintf(baseConfig, tc.snippet)
+			var cfg core.Config
+			require.NoError(t, yaml.Unmarshal([]byte(cfgYAML), &cfg))
+
+			cfg.Output = mustYAMLNode(t, evm.EvmOutputConfig{BasePath: t.TempDir()})
+
+			tmpl, err := generate.LoadTemplate("evm")
+			require.NoError(t, err)
+
+			err = evm.Handler{}.Generate(cfg, tmpl)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
 }
 
 func TestGenerateResolvesRelativeZkSyncBindingsPackage(t *testing.T) {

--- a/tools/operations-gen/testdata/evm/many_chain_multi_sig.golden.go
+++ b/tools/operations-gen/testdata/evm/many_chain_multi_sig.golden.go
@@ -18,7 +18,12 @@ import (
 
 var ContractType cldf_deployment.ContractType = "ManyChainMultiSig"
 var Version = semver.MustParse("1.0.0")
-var TypeAndVersion = cldf_deployment.NewTypeAndVersion(ContractType, *Version)
+var ProposerManyChainMultiSigContractType cldf_deployment.ContractType = "ProposerManyChainMultiSig"
+var ProposerManyChainMultiSigTypeAndVersion = cldf_deployment.NewTypeAndVersion(ProposerManyChainMultiSigContractType, *Version)
+var BypasserManyChainMultiSigContractType cldf_deployment.ContractType = "BypasserManyChainMultiSig"
+var BypasserManyChainMultiSigTypeAndVersion = cldf_deployment.NewTypeAndVersion(BypasserManyChainMultiSigContractType, *Version)
+var CancellerManyChainMultiSigContractType cldf_deployment.ContractType = "CancellerManyChainMultiSig"
+var CancellerManyChainMultiSigTypeAndVersion = cldf_deployment.NewTypeAndVersion(CancellerManyChainMultiSigContractType, *Version)
 
 type SetConfigArgs struct {
 	SignerAddresses []common.Address `json:"signerAddresses"`
@@ -44,7 +49,15 @@ var Deploy = contract.NewDeploy(contract.DeployParams[ConstructorArgs]{
 	Description:      "Deploys the ManyChainMultiSig contract",
 	ContractMetadata: gobindings.ManyChainMultiSigMetaData,
 	BytecodeByTypeAndVersion: map[string]contract.Bytecode{
-		cldf_deployment.NewTypeAndVersion(ContractType, *Version).String(): {
+		ProposerManyChainMultiSigTypeAndVersion.String(): {
+			EVM:      common.FromHex(gobindings.ManyChainMultiSigMetaData.Bin),
+			ZkSyncVM: zkbindings.ManyChainMultiSigZkBytecode,
+		},
+		BypasserManyChainMultiSigTypeAndVersion.String(): {
+			EVM:      common.FromHex(gobindings.ManyChainMultiSigMetaData.Bin),
+			ZkSyncVM: zkbindings.ManyChainMultiSigZkBytecode,
+		},
+		CancellerManyChainMultiSigTypeAndVersion.String(): {
 			EVM:      common.FromHex(gobindings.ManyChainMultiSigMetaData.Bin),
 			ZkSyncVM: zkbindings.ManyChainMultiSigZkBytecode,
 		},

--- a/tools/operations-gen/testdata/evm/operations_gen_mcms_config.yaml
+++ b/tools/operations-gen/testdata/evm/operations_gen_mcms_config.yaml
@@ -13,6 +13,10 @@ contracts:
     version: "1.0.0"
     package_name: many_chain_multi_sig
     zksync_bytecode: ManyChainMultiSigZkBytecode
+    deploy_contract_types:
+      - ProposerManyChainMultiSig
+      - BypasserManyChainMultiSig
+      - CancellerManyChainMultiSig
     functions:
       - name: owner
         access: public


### PR DESCRIPTION
Currently operations-gen does not support generating operation with the same contract byte code but each with different contract types (MCMS setup - proposer,canceller,bypasser).

Adds a new `deploy_contract_types` field to the EVM contract config that allows a single contract entry to register multiple ContractType labels (e.g. ProposerManyChainMultiSig, BypasserManyChainMultiSig, CancellerManyChainMultiSig) in the generated BytecodeByTypeAndVersion map.


```yaml
version: "1.0.0"
chain_family: evm
input:
  gobindings_package: "github.com/smartcontractkit/chainlink-deployments-framework/tools/operations-gen/testdata/evm/gobindings"
  zksync_bindings_package: "github.com/smartcontractkit/chainlink-deployments-framework/tools/operations-gen/testdata/evm/zksync_bindings"
output:
  base_path: "."
contracts:
  - contract_name: ManyChainMultiSig
    version: "1.0.0"
    package_name: many_chain_multi_sig
    zksync_bytecode: ManyChainMultiSigZkBytecode
    deploy_contract_types:
      - ProposerManyChainMultiSig
      - BypasserManyChainMultiSig
      - CancellerManyChainMultiSig
    functions:
      - name: owner
        access: public
```

will generate 
```go
...
var ProposerManyChainMultiSigContractType cldf_deployment.ContractType = "ProposerManyChainMultiSig"
var ProposerManyChainMultiSigTypeAndVersion = cldf_deployment.NewTypeAndVersion(ProposerManyChainMultiSigContractType, *Version)
var BypasserManyChainMultiSigContractType cldf_deployment.ContractType = "BypasserManyChainMultiSig"
var BypasserManyChainMultiSigTypeAndVersion = cldf_deployment.NewTypeAndVersion(BypasserManyChainMultiSigContractType, *Version)
var CancellerManyChainMultiSigContractType cldf_deployment.ContractType = "CancellerManyChainMultiSig"
var CancellerManyChainMultiSigTypeAndVersion = cldf_deployment.NewTypeAndVersion(CancellerManyChainMultiSigContractType, *Version)

var Deploy = contract.NewDeploy(contract.DeployParams[ConstructorArgs]{
	Name:             "many-chain-multi-sig:deploy",
	Version:          Version,
	Description:      "Deploys the ManyChainMultiSig contract",
	ContractMetadata: gobindings.ManyChainMultiSigMetaData,
	BytecodeByTypeAndVersion: map[string]contract.Bytecode{
		ProposerManyChainMultiSigTypeAndVersion.String(): {
			EVM:      common.FromHex(gobindings.ManyChainMultiSigMetaData.Bin),
			ZkSyncVM: zkbindings.ManyChainMultiSigZkBytecode,
		},
		BypasserManyChainMultiSigTypeAndVersion.String(): {
			EVM:      common.FromHex(gobindings.ManyChainMultiSigMetaData.Bin),
			ZkSyncVM: zkbindings.ManyChainMultiSigZkBytecode,
		},
		CancellerManyChainMultiSigTypeAndVersion.String(): {
			EVM:      common.FromHex(gobindings.ManyChainMultiSigMetaData.Bin),
			ZkSyncVM: zkbindings.ManyChainMultiSigZkBytecode,
		},
	},
})
...
```