### PR TITLE
fix(operations-gen): skip constructor big.Int check when omit_deploy is set

### DIFF
--- a/.changeset/new-wasps-sit.md
+++ b/.changeset/new-wasps-sit.md
@@ -1,0 +1,5 @@
+---
+"operations-gen": patch
+---
+
+fix(operations-gen): skip constructor big.Int check when omit_deploy is set

--- a/tools/operations-gen/internal/families/evm/codegen.go
+++ b/tools/operations-gen/internal/families/evm/codegen.go
@@ -152,24 +152,31 @@ func prepareTemplateData(info *ContractInfo) templateData {
 // (struct) parameters are emitted as references into the gobindings package,
 // so their internal fields never surface as *big.Int in the generated file.
 func ChecksNeedsBigInt(info *ContractInfo) bool {
-	check := func(params []ParameterInfo) bool {
-		for _, p := range params {
-			if strings.Contains(p.GoType, "*big.Int") {
-				return true
-			}
-		}
-
-		return false
-	}
-
-	for _, fi := range info.Functions {
-		if check(fi.Parameters) || check(fi.ReturnParams) {
+	for _, name := range info.FunctionOrder {
+		fi := info.Functions[name]
+		if paramsNeedBigInt(fi.Parameters) || paramsNeedBigInt(fi.ReturnParams) {
 			return true
 		}
 	}
 
-	if info.Constructor != nil && check(info.Constructor.Parameters) {
+	for _, sd := range info.StructDefs {
+		if paramsNeedBigInt(sd.Fields) {
+			return true
+		}
+	}
+
+	if !info.OmitDeploy && info.Constructor != nil && paramsNeedBigInt(info.Constructor.Parameters) {
 		return true
+	}
+
+	return false
+}
+
+func paramsNeedBigInt(params []ParameterInfo) bool {
+	for _, p := range params {
+		if strings.Contains(p.GoType, "*big.Int") {
+			return true
+		}
 	}
 
 	return false

--- a/tools/operations-gen/internal/families/evm/codegen_test.go
+++ b/tools/operations-gen/internal/families/evm/codegen_test.go
@@ -68,6 +68,21 @@ func TestCheckNeedsBigInt(t *testing.T) {
 		require.True(t, evm.ChecksNeedsBigInt(info), "expected true for constructor uint256 param")
 	})
 
+	t.Run("constructor param ignored when omit_deploy", func(t *testing.T) {
+		t.Parallel()
+		info := &evm.ContractInfo{
+			OmitDeploy: true,
+			Constructor: &evm.FunctionInfo{
+				Parameters: []evm.ParameterInfo{{GoType: "*big.Int"}},
+			},
+			Functions: map[string]*evm.FunctionInfo{
+				"Owner": {Name: "Owner", ReturnParams: []evm.ParameterInfo{{GoType: "common.Address"}}},
+			},
+			FunctionOrder: []string{"Owner"},
+		}
+		require.False(t, evm.ChecksNeedsBigInt(info))
+	})
+
 	t.Run("no big.Int", func(t *testing.T) {
 		t.Parallel()
 		info := &evm.ContractInfo{


### PR DESCRIPTION
## Why
When generating operation using operation-gen cli from a contract where constructor parameter contains uint256 with `omit_deploy: true`, Code should ignore the type in constructor so it does not import the unneeded `math/big` package causing compile error on unused import

## Summary

- `ChecksNeedsBigInt` no longer considers constructor parameters when `omit_deploy: true`, since the deploy block (and `ConstructorArgs`) are not emitted.
- Also checks `StructDefs` for `*big.Int` usage and iterates configured functions via `FunctionOrder`.

This fixes generated ownership-only operation files (e.g. `transferOwnership` / `acceptOwnership` with `omit_deploy: true`) incorrectly importing unused `math/big` when the contract constructor has `uint256` parameters.

