### PR TITLE
fix: mark report field as deprecated

### DIFF
--- a/.changeset/tidy-coats-fly.md
+++ b/.changeset/tidy-coats-fly.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix(changesetoutput): mark Reports field as deprecated

--- a/changeset/sequenceutils/changeset.go
+++ b/changeset/sequenceutils/changeset.go
@@ -199,7 +199,7 @@ func NewOnChainChangesetFromSequence[IN any, DEP any, CFG any](
 		}
 		report, err := operations.ExecuteSequence(e.OperationsBundle, params.Sequence, deps, input)
 		if err != nil {
-			return deployment.ChangesetOutput{Reports: report.ExecutionReports},
+			return deployment.ChangesetOutput{},
 				fmt.Errorf("failed to execute sequence with ID %s: %w", params.Sequence.ID(), err)
 		}
 
@@ -218,17 +218,13 @@ func buildOnChainChangesetOutput[IN any](
 ) (deployment.ChangesetOutput, error) {
 	ds := datastore.NewMemoryDataStore()
 	if metaErr := ds.WriteMetadata(report.Output.Metadata); metaErr != nil {
-		return deployment.ChangesetOutput{Reports: report.ExecutionReports},
+		return deployment.ChangesetOutput{},
 			fmt.Errorf("failed to write metadata to datastore: %w", metaErr)
 	}
 
-	partialOutput := deployment.ChangesetOutput{
-		Reports:   report.ExecutionReports,
-		DataStore: ds,
-	}
+	partialOutput := deployment.ChangesetOutput{DataStore: ds}
 
-	builder := deployment.NewOutputBuilder(e, ds).
-		WithOperationsReports(report.ExecutionReports)
+	builder := deployment.NewOutputBuilder(e, ds)
 
 	if cfg.mcmsRegistry != nil {
 		builder = builder.WithMCMSReaderRegistry(cfg.mcmsRegistry)

--- a/changeset/sequenceutils/changeset_test.go
+++ b/changeset/sequenceutils/changeset_test.go
@@ -207,8 +207,6 @@ func TestNewOnChainChangesetFromSequence_applySuccess(t *testing.T) {
 
 	out, err := cs.Apply(env, WithMCMS[testCfg]{Cfg: cfg})
 	require.NoError(t, err)
-	require.NotEmpty(t, out.Reports)
-
 	refs, fetchErr := out.DataStore.Addresses().Fetch()
 	require.NoError(t, fetchErr)
 	require.Len(t, refs, 1)
@@ -232,7 +230,6 @@ func TestNewOnChainChangesetFromSequence_applyWithBatchOpsAndMCMS(t *testing.T) 
 
 	out, err := cs.Apply(env, WithMCMS[testCfg]{Cfg: cfg, MCMS: &mcmsInput})
 	require.NoError(t, err)
-	require.NotEmpty(t, out.Reports)
 	require.NotNil(t, out.DataStore)
 	require.Len(t, out.MCMSTimelockProposals, 1)
 
@@ -287,7 +284,6 @@ func TestNewOnChainChangesetFromSequence_applyBatchOpsWithoutMCMS_preservesMetad
 	out, err := cs.Apply(env, WithMCMS[testCfg]{Cfg: cfg})
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrBatchOpsWithoutMCMSInput)
-	require.NotEmpty(t, out.Reports)
 	require.NotNil(t, out.DataStore)
 
 	refs, fetchErr := out.DataStore.Addresses().Fetch()
@@ -312,7 +308,6 @@ func TestNewOnChainChangesetFromSequence_applyEmptyBatchOpsWithoutMCMS(t *testin
 
 	out, err := cs.Apply(env, WithMCMS[testCfg]{Cfg: cfg})
 	require.NoError(t, err)
-	require.NotEmpty(t, out.Reports)
 	require.Empty(t, out.MCMSTimelockProposals)
 }
 
@@ -347,7 +342,6 @@ func TestNewOnChainChangesetFromSequence_applyMCMSBuildFailure(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, readerErr)
 	require.ErrorContains(t, err, "get timelock ref for chain")
-	require.NotEmpty(t, out.Reports)
 	require.NotNil(t, out.DataStore)
 
 	refs, fetchErr := out.DataStore.Addresses().Fetch()
@@ -370,7 +364,6 @@ func TestNewOnChainChangesetFromSequence_applySequenceError(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, seqErr.Error())
 	require.ErrorContains(t, err, "failed to execute sequence")
-	require.NotEmpty(t, out.Reports)
 	require.Nil(t, out.DataStore)
 }
 
@@ -394,7 +387,6 @@ func TestNewOnChainChangesetFromSequence_applyWriteMetadataError(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, datastore.ErrAddressRefVersionRequired)
 	require.ErrorContains(t, err, "failed to write metadata to datastore")
-	require.NotEmpty(t, out.Reports)
 	require.Nil(t, out.DataStore)
 }
 

--- a/deployment/changeset.go
+++ b/deployment/changeset.go
@@ -118,6 +118,8 @@ type ChangesetOutput struct {
 	DataStore   datastore.MutableDataStore
 	// Reports are populated by the Operations API with the
 	// results of the operations executed in the changeset.
+	// Deprecated: This field is no longer being used.
+	// Retained for backwards compatibility. This field is no longer used by the framework and may not be populated or propagated.
 	Reports []operations.Report[any, any]
 }
 

--- a/deployment/output_builder.go
+++ b/deployment/output_builder.go
@@ -8,8 +8,6 @@ import (
 	"github.com/smartcontractkit/mcms"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 
-	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 )
 
@@ -42,12 +40,6 @@ func NewOutputBuilder(e Environment, newDS datastore.MutableDataStore) *OutputBu
 			DataStore: newDS,
 		},
 	}
-}
-
-// WithOperationsReports sets the reports on the ChangesetOutput.
-func (b *OutputBuilder) WithOperationsReports(reports []operations.Report[any, any]) *OutputBuilder {
-	b.changesetOutput.Reports = reports
-	return b
 }
 
 // WithMCMSReaderRegistry overrides the MCMS reader registry used during Build (default: GetMCMSReaderRegistry).
@@ -89,7 +81,7 @@ func (b *OutputBuilder) WithTimelockProposal(
 }
 
 // Build constructs the final ChangesetOutput, including one MCMS timelock proposal per non-empty spec.
-// On error, returns the accumulated ChangesetOutput (data store, reports, and any proposals built so far)
+// On error, returns the accumulated ChangesetOutput (data store and any proposals built so far)
 // together with an error. The error index refers to the position in the appended proposal spec list (including
 // specs skipped because they have no batch operations after processing).
 func (b *OutputBuilder) Build() (ChangesetOutput, error) {

--- a/deployment/output_builder_test.go
+++ b/deployment/output_builder_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
 const ethMainnetSelector = 5009297550715157269
@@ -34,15 +33,6 @@ func TestNewOutputBuilder_fromMutableDataStore(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, refs, 1)
 	require.Equal(t, "0xabc", refs[0].Address)
-}
-
-func TestWithOperationsReports(t *testing.T) {
-	t.Parallel()
-	b := newTestOutputBuilder(t)
-	reports := []operations.Report[any, any]{{}}
-	out, err := b.WithOperationsReports(reports).Build()
-	require.NoError(t, err)
-	require.Len(t, out.Reports, 1)
 }
 
 func TestBuild_noTimelockProposals(t *testing.T) {
@@ -315,10 +305,7 @@ func TestBuild_returnsPartialOutputOnProposalFailure(t *testing.T) {
 		Version:       semver.MustParse("1.0.0"),
 		Address:       "0xabc",
 	}))
-	reports := []operations.Report[any, any]{{}}
-
 	b := NewOutputBuilder(Environment{}, ds).
-		WithOperationsReports(reports).
 		WithMCMSReaderRegistry(testMCMSRegistry(t))
 	b.WithTimelockProposal(validMCMSProposalInput(), []mcms_types.BatchOperation{sampleBatchOp()})
 	b.WithTimelockProposal(MCMSTimelockProposalInput{
@@ -334,7 +321,6 @@ func TestBuild_returnsPartialOutputOnProposalFailure(t *testing.T) {
 	refs, fetchErr := out.DataStore.Addresses().Fetch()
 	require.NoError(t, fetchErr)
 	require.Len(t, refs, 1)
-	require.Equal(t, reports, out.Reports)
 	require.Len(t, out.MCMSTimelockProposals, 1)
 }
 


### PR DESCRIPTION
The Reports field in ChangesetOutput was never used, the values set are discarded, we should retire it.

I had plans previously for the introduction of this field but it never came to any fruition, and after some improvements awhile back on how operations report work, i dont think we need this field anymore