### PR TITLE
Add MCMS to Aptos chain

### DIFF
--- a/.changeset/public-words-obey.md
+++ b/.changeset/public-words-obey.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+Add MCMS to Aptos chain

--- a/chain/aptos/aptos_chain.go
+++ b/chain/aptos/aptos_chain.go
@@ -18,6 +18,10 @@ type Chain struct {
 	URL            string
 
 	Confirm func(txHash string, opts ...any) error
+
+	// MCMSAddress is the CCIP MCMS contract on this chain. Zero when unset.
+	// Populated by Aptos deployment/lane changesets from the datastore.
+	MCMSAddress aptoslib.AccountAddress
 }
 
 // Author note: Have to implement the blockhain interface methods explicitly below


### PR DESCRIPTION
Add MCMS address to the chain so it can be injected in some adapters from the Datastore