### PR TITLE
test(ci): raise Ryuk timeouts for Aptos chain tests

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -142,6 +142,15 @@ jobs:
       id-token: write
       contents: read
       actions: read
+    env:
+      # Tests shells out to the Aptos CLI to compile a Move package, which is
+      # CPU-bound and can run for 90-100s. On the 2-vCPU runner this starves the test
+      # process's Ryuk keep-alive goroutine long enough to blow Ryuk's default 10s
+      # reconnection timeout, causing it to reap the Aptos node container mid-test
+      # ("connection refused" on the next API call). Raise the timeouts so Ryuk tolerates
+      # the compile step instead of killing the container out from under the test.
+      RYUK_RECONNECTION_TIMEOUT: 60s
+      RYUK_CONNECTION_TIMEOUT: 2m
     steps:
       - name: Install Aptos CLI
         uses: aptos-labs/actions/install-aptos-cli@528ef7ad9427a8c0720ea3eea790a9190d6e377d # v0.1


### PR DESCRIPTION
## Summary
- `TestChain_ReadOnly` (chain/aptos) has been [failing consistently](https://github.com/smartcontractkit/chainlink-deployments-framework/actions/runs/28489506336/job/84442968741?pr=1082#step:3:633) in CI with `dial tcp 127.0.0.1:<port>: connect: connection refused` (reproduced across multiple CI runs at the same line, same timing).
- Root cause: the test shells out to the Aptos CLI to compile a Move package via `os/exec`, a CPU-bound step taking ~90-100s. On the 2-vCPU `ubuntu-latest` runner, this starves the test process long enough to blow Testcontainers' Ryuk reaper's default 10s reconnection timeout. Ryuk then reaps (kills) the Aptos node container mid-test, so every subsequent API call fails with connection refused.
- This explains why the failure never reproduces locally (more CPU cores means the compile step never starves the Ryuk keep-alive goroutine) but is deterministic in CI.
- Fix: raise `RYUK_RECONNECTION_TIMEOUT` (60s) and `RYUK_CONNECTION_TIMEOUT` (2m) as job-level env vars for `ci-test-provider-aptos`, giving Ryuk enough slack to tolerate the compile step instead of killing the container out from under the test.

## Test plan
- [x] Confirm `ci-test-provider-aptos` job passes on this PR's CI run
- [x] Re-run a couple of times to confirm the fix isn't just luck (the failure was 2/2 reproducible before this change)