### PR TITLE
don't require changeset selector with 1 option

### DIFF
--- a/.changeset/optional-durable-pipeline-changeset-selector.md
+++ b/.changeset/optional-durable-pipeline-changeset-selector.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+Make `-c` / `-x` optional for `durable-pipeline run` when the input YAML contains exactly one changeset.

--- a/engine/cld/commands/pipeline/run.go
+++ b/engine/cld/commands/pipeline/run.go
@@ -45,6 +45,12 @@ var (
   		--changeset 0001_test_changeset \
   		--input-file inputs.yaml
 
+		# Run the only changeset in a single-changeset input file (no -c or -x required)
+		chainlink-deployments durable-pipeline run \
+  		--environment testnet \
+  		--input-file inputs.yaml \
+  		--dry-run
+
 		# Run changeset by index position with array format input file.
 		chainlink-deployments durable-pipeline run \
   		--environment testnet \
@@ -88,31 +94,50 @@ func newRunCmd(cfg *Config) *cobra.Command {
 
 	_ = cmd.MarkFlagRequired("input-file")
 	cmd.MarkFlagsMutuallyExclusive("changeset", "changeset-index")
-	cmd.MarkFlagsOneRequired("changeset", "changeset-index")
 
 	return cmd
+}
+
+func resolveChangesetForRun(
+	cmd *cobra.Command,
+	cfg *Config,
+	f runFlags,
+) (actualChangesetName string, indexForLog *int, err error) {
+	switch {
+	case f.changeset != "":
+		if err := input.PrepareInputForRunByName(f.inputFile, f.changeset, cfg.Domain, f.environment); err != nil {
+			return "", nil, fmt.Errorf("failed to parse input file: %w", err)
+		}
+
+		return f.changeset, nil, nil
+	case cmd.Flags().Changed("changeset-index"):
+		name, err := input.PrepareInputForRunByIndex(f.inputFile, f.changesetIndex, cfg.Domain, f.environment)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to get changeset at index %d: %w", f.changesetIndex, err)
+		}
+		idx := f.changesetIndex
+
+		return name, &idx, nil
+	default:
+		name, err := input.PrepareInputForRunAuto(f.inputFile, cfg.Domain, f.environment)
+		if err != nil {
+			return "", nil, err
+		}
+
+		return name, nil, nil
+	}
 }
 
 func runRun(cmd *cobra.Command, cfg *Config, f runFlags) error {
 	envdir := cfg.Domain.EnvDir(f.environment)
 	artdir := envdir.ArtifactsDir()
 
-	var actualChangesetName string
-
-	if f.changeset != "" {
-		actualChangesetName = f.changeset
-		if err := input.PrepareInputForRunByName(f.inputFile, f.changeset, cfg.Domain, f.environment); err != nil {
-			return fmt.Errorf("failed to parse input file: %w", err)
-		}
-	} else {
-		var err error
-		actualChangesetName, err = input.PrepareInputForRunByIndex(f.inputFile, f.changesetIndex, cfg.Domain, f.environment)
-		if err != nil {
-			return fmt.Errorf("failed to get changeset at index %d: %w", f.changesetIndex, err)
-		}
+	actualChangesetName, indexForLog, err := resolveChangesetForRun(cmd, cfg, f)
+	if err != nil {
+		return err
 	}
 
-	if err := artdir.SetDurablePipelines(strconv.FormatInt(time.Now().UnixNano(), 10)); err != nil {
+	if err = artdir.SetDurablePipelines(strconv.FormatInt(time.Now().UnixNano(), 10)); err != nil {
 		return err
 	}
 
@@ -154,8 +179,8 @@ func runRun(cmd *cobra.Command, cfg *Config, f runFlags) error {
 	}
 
 	indexStr := ""
-	if f.changeset == "" {
-		indexStr = fmt.Sprintf(" (at index %d)", f.changesetIndex)
+	if indexForLog != nil {
+		indexStr = fmt.Sprintf(" (at index %d)", *indexForLog)
 	}
 	cfg.Logger.Infof("Applying %s durable pipeline for changeset %s%s for environment: %s\n",
 		cfg.Domain, actualChangesetName, indexStr, f.environment,

--- a/engine/cld/commands/pipeline/run.go
+++ b/engine/cld/commands/pipeline/run.go
@@ -121,7 +121,7 @@ func resolveChangesetForRun(
 	default:
 		name, err := input.PrepareInputForRunAuto(f.inputFile, cfg.Domain, f.environment)
 		if err != nil {
-			return "", nil, err
+			return "", nil, fmt.Errorf("failed to parse input file: %w", err)
 		}
 
 		return name, nil, nil

--- a/engine/cld/commands/pipeline/run_test.go
+++ b/engine/cld/commands/pipeline/run_test.go
@@ -800,6 +800,7 @@ changesets:
 
 	err = cmd.Execute()
 	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to parse input file:")
 	require.ErrorContains(t, err, "contains 2 changesets")
 	require.ErrorContains(t, err, "--changeset (-c) or --changeset-index (-x)")
 }

--- a/engine/cld/commands/pipeline/run_test.go
+++ b/engine/cld/commands/pipeline/run_test.go
@@ -681,6 +681,129 @@ changesets:
 	}}, proposal.Operations)
 }
 
+//nolint:paralleltest
+func TestRunCmd_SingleChangesetWithoutSelector(t *testing.T) {
+	env := "testnet"
+	changesetName := "0001_test_changeset"
+	testDomain := domain.NewDomain(t.TempDir(), "test")
+
+	workspaceRoot := t.TempDir()
+	inputsDir := filepath.Join(workspaceRoot, "domains", testDomain.String(), env, "durable_pipelines", "inputs")
+	require.NoError(t, os.MkdirAll(inputsDir, 0o755))
+
+	yamlContent := `environment: testnet
+domain: test
+changesets:
+  - 0001_test_changeset:
+      payload:
+        chain: optimism_sepolia
+        value: 100`
+	yamlFileName := "single-changeset.yaml"
+	require.NoError(t, os.WriteFile(filepath.Join(inputsDir, yamlFileName), []byte(yamlContent), 0o600))
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workspaceRoot))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(originalWd)) })
+
+	changesetStub := &stubChangeset{}
+	loadChangesets := func(envName string) (*changeset.ChangesetsRegistry, error) {
+		rp := &registryProviderStub{
+			BaseRegistryProvider: changeset.NewBaseRegistryProvider(),
+			AddAction: func(reg *changeset.ChangesetsRegistry) {
+				reg.Add(changesetName, changeset.Configure(changesetStub).With(1))
+			},
+		}
+		if initErr := rp.Init(); initErr != nil {
+			return nil, initErr
+		}
+
+		return rp.Registry(), nil
+	}
+
+	cfg := &Config{
+		Logger:                logger.Test(t),
+		Domain:                testDomain,
+		LoadChangesets:        loadChangesets,
+		ConfigResolverManager: fresolvers.NewConfigResolverManager(),
+		Deps: Deps{
+			EnvironmentLoader: func(ctx context.Context, dom domain.Domain, envKey string, opts ...environment.LoadEnvironmentOption) (fdeployment.Environment, error) {
+				return fdeployment.Environment{}, nil
+			},
+		},
+	}
+
+	cmd, err := NewCommand(cfg)
+	require.NoError(t, err)
+
+	cmd.SetArgs([]string{
+		"run",
+		"--environment", env,
+		"--input-file", yamlFileName,
+		"--dry-run",
+	})
+
+	err = cmd.Execute()
+	require.NoError(t, err)
+	require.True(t, changesetStub.ApplyCalled)
+}
+
+//nolint:paralleltest
+func TestRunCmd_MultipleChangesetsRequireSelector(t *testing.T) {
+	env := "testnet"
+	testDomain := domain.NewDomain(t.TempDir(), "test")
+
+	workspaceRoot := t.TempDir()
+	inputsDir := filepath.Join(workspaceRoot, "domains", testDomain.String(), env, "durable_pipelines", "inputs")
+	require.NoError(t, os.MkdirAll(inputsDir, 0o755))
+
+	yamlContent := `environment: testnet
+domain: test
+changesets:
+  - 0001_test_changeset:
+      payload:
+        chain: optimism_sepolia
+  - 0002_other_changeset:
+      payload:
+        chain: base_sepolia`
+	yamlFileName := "multi-changeset.yaml"
+	require.NoError(t, os.WriteFile(filepath.Join(inputsDir, yamlFileName), []byte(yamlContent), 0o600))
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workspaceRoot))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(originalWd)) })
+
+	cfg := &Config{
+		Logger: logger.Test(t),
+		Domain: testDomain,
+		LoadChangesets: func(string) (*changeset.ChangesetsRegistry, error) {
+			return changeset.NewBaseRegistryProvider().Registry(), nil
+		},
+		ConfigResolverManager: fresolvers.NewConfigResolverManager(),
+		Deps: Deps{
+			EnvironmentLoader: func(ctx context.Context, dom domain.Domain, envKey string, opts ...environment.LoadEnvironmentOption) (fdeployment.Environment, error) {
+				return fdeployment.Environment{}, nil
+			},
+		},
+	}
+
+	cmd, err := NewCommand(cfg)
+	require.NoError(t, err)
+
+	cmd.SetArgs([]string{
+		"run",
+		"--environment", env,
+		"--input-file", yamlFileName,
+		"--dry-run",
+	})
+
+	err = cmd.Execute()
+	require.Error(t, err)
+	require.ErrorContains(t, err, "contains 2 changesets")
+	require.ErrorContains(t, err, "--changeset (-c) or --changeset-index (-x)")
+}
+
 // ----- shared test data -----
 
 var testProposal = lo.Must(mcms.NewTimelockProposalBuilder().

--- a/engine/cld/pipeline/input/yaml.go
+++ b/engine/cld/pipeline/input/yaml.go
@@ -82,6 +82,10 @@ func PrepareInputForRunAuto(inputFileName string, dom domain.Domain, envKey stri
 		return "", err
 	}
 
+	if _, isArray := dpYAML.Changesets.([]any); !isArray {
+		return "", fmt.Errorf("input file %s: invalid 'changesets' format, expected array format", inputFileName)
+	}
+
 	changesets, err := GetAllChangesetsInOrder(dpYAML.Changesets)
 	if err != nil {
 		return "", fmt.Errorf("input file %s: %w", inputFileName, err)

--- a/engine/cld/pipeline/input/yaml.go
+++ b/engine/cld/pipeline/input/yaml.go
@@ -74,6 +74,37 @@ func PrepareInputForRunByIndex(inputFileName string, index int, dom domain.Domai
 	return selected.Name, nil
 }
 
+// PrepareInputForRunAuto selects the changeset when the input file contains exactly one entry.
+// When multiple changesets are present, the caller must pass --changeset or --changeset-index.
+func PrepareInputForRunAuto(inputFileName string, dom domain.Domain, envKey string) (string, error) {
+	dpYAML, err := ParseDurablePipelineYAML(inputFileName, dom, envKey)
+	if err != nil {
+		return "", err
+	}
+
+	changesets, err := GetAllChangesetsInOrder(dpYAML.Changesets)
+	if err != nil {
+		return "", fmt.Errorf("input file %s: %w", inputFileName, err)
+	}
+
+	switch len(changesets) {
+	case 0:
+		return "", fmt.Errorf("input file %s: no changesets found", inputFileName)
+	case 1:
+		selected := changesets[0]
+		if err := SetChangesetEnvironmentVariable(selected.Name, selected.Data); err != nil {
+			return "", fmt.Errorf("input file %s: %w", inputFileName, err)
+		}
+
+		return selected.Name, nil
+	default:
+		return "", fmt.Errorf(
+			"input file %s contains %d changesets; specify --changeset (-c) or --changeset-index (-x)",
+			inputFileName, len(changesets),
+		)
+	}
+}
+
 // ChangesetItem represents a single changeset in order.
 type ChangesetItem struct {
 	Name string

--- a/engine/cld/pipeline/input/yaml_test.go
+++ b/engine/cld/pipeline/input/yaml_test.go
@@ -580,9 +580,8 @@ domain: mydomain
 	}
 }
 
+//nolint:paralleltest // mutates process cwd and environment variables.
 func TestPrepareInputForRunAuto(t *testing.T) {
-	t.Parallel()
-
 	workspaceRoot := t.TempDir()
 	dom := domain.NewDomain(workspaceRoot, "test")
 	envKey := "testnet"
@@ -627,4 +626,15 @@ changesets:
 	_, err = PrepareInputForRunAuto("multi.yaml", dom, envKey)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "contains 2 changesets")
+
+	writeInput("object-format.yaml", `environment: testnet
+domain: test
+changesets:
+  only_changeset:
+    payload:
+      value: 1
+`)
+	_, err = PrepareInputForRunAuto("object-format.yaml", dom, envKey)
+	require.Error(t, err)
+	require.Equal(t, "input file object-format.yaml: invalid 'changesets' format, expected array format", err.Error())
 }

--- a/engine/cld/pipeline/input/yaml_test.go
+++ b/engine/cld/pipeline/input/yaml_test.go
@@ -579,3 +579,52 @@ domain: mydomain
 		})
 	}
 }
+
+func TestPrepareInputForRunAuto(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	dom := domain.NewDomain(workspaceRoot, "test")
+	envKey := "testnet"
+	inputsDir := filepath.Join(workspaceRoot, "domains", dom.String(), envKey, "durable_pipelines", "inputs")
+	require.NoError(t, os.MkdirAll(inputsDir, 0o755))
+
+	writeInput := func(name, content string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(inputsDir, name), []byte(content), 0o600))
+	}
+
+	writeInput("single.yaml", `environment: testnet
+domain: test
+changesets:
+  - only_changeset:
+      payload:
+        value: 1
+`)
+	writeInput("multi.yaml", `environment: testnet
+domain: test
+changesets:
+  - first_changeset:
+      payload:
+        value: 1
+  - second_changeset:
+      payload:
+        value: 2
+`)
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workspaceRoot))
+	t.Cleanup(func() { _ = os.Chdir(originalWd) })
+
+	t.Cleanup(func() { _ = os.Unsetenv("DURABLE_PIPELINE_INPUT") })
+
+	name, err := PrepareInputForRunAuto("single.yaml", dom, envKey)
+	require.NoError(t, err)
+	require.Equal(t, "only_changeset", name)
+	require.Contains(t, os.Getenv("DURABLE_PIPELINE_INPUT"), `"value":1`)
+
+	_, err = PrepareInputForRunAuto("multi.yaml", dom, envKey)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "contains 2 changesets")
+}


### PR DESCRIPTION
Make the `-c or -x` optional when only one valid option exists anyway.