### PR TITLE
Add a error based retry retry_policy

### DIFF
--- a/chain/evm/provider/rpcclient/multiclient.go
+++ b/chain/evm/provider/rpcclient/multiclient.go
@@ -48,6 +48,7 @@ type RetryConfig struct {
 	DialDelay          time.Duration
 	DialTimeout        time.Duration
 	HealthCheckTimeout time.Duration
+	ErrorPolicies      []ErrorRetryPolicy
 }
 
 // defaultRetryConfig returns default retry configuration.
@@ -402,6 +403,9 @@ func (mc *MultiClient) retryWithBackups(ctx context.Context, opName string, op f
 
 	for rpcIndex, client := range mc.clients() {
 		retryCount := 0
+		retryOpts := mc.RetryConfig.rpcRetryOptions()
+		retryOpts = append(retryOpts, retry.OnRetry(func(n uint, err error) { retryCount++ }))
+
 		err2 := retry.Do(func() error {
 			timeoutCtx, cancel := ensureTimeout(ctx, mc.RetryConfig.Timeout)
 			defer cancel()
@@ -419,8 +423,7 @@ func (mc *MultiClient) retryWithBackups(ctx context.Context, opName string, op f
 			mc.reorderRPCs(rpcIndex)
 
 			return nil
-		}, retry.Attempts(mc.RetryConfig.Attempts), retry.Delay(mc.RetryConfig.Delay),
-			retry.OnRetry(func(n uint, err error) { retryCount++ }))
+		}, retryOpts...)
 		if err2 == nil {
 			if retryCount > 0 {
 				mc.lggr.Infof("traceID %q: chain %q: op: %q: client index %d: successfully executed after %d retry", traceID.String(), mc.chainName, opName, rpcIndex, retryCount)

--- a/chain/evm/provider/rpcclient/retry_policy.go
+++ b/chain/evm/provider/rpcclient/retry_policy.go
@@ -1,0 +1,51 @@
+package rpcclient
+
+import (
+	"time"
+
+	"github.com/avast/retry-go/v4"
+)
+
+// ErrorMatcher returns true when the error should use a policy's retry delay.
+type ErrorMatcher func(error) bool
+
+// ErrorRetryPolicy configures a longer wait before retrying when Match returns true.
+type ErrorRetryPolicy struct {
+	Match ErrorMatcher
+	Delay time.Duration
+}
+
+// WithErrorRetryPolicies configures error-specific retry delays on a MultiClient.
+func WithErrorRetryPolicies(policies ...ErrorRetryPolicy) func(*MultiClient) {
+	return func(mc *MultiClient) {
+		mc.RetryConfig.ErrorPolicies = policies
+	}
+}
+
+func matchErrorPolicy(err error, policies []ErrorRetryPolicy) (ErrorRetryPolicy, bool) {
+	for _, policy := range policies {
+		if policy.Match != nil && policy.Match(err) {
+			return policy, true
+		}
+	}
+
+	return ErrorRetryPolicy{}, false
+}
+
+func (rc RetryConfig) rpcRetryOptions() []retry.Option {
+	opts := []retry.Option{
+		retry.Attempts(rc.Attempts),
+		retry.Delay(rc.Delay),
+		retry.DelayType(rc.delayForError),
+	}
+
+	return opts
+}
+
+func (rc RetryConfig) delayForError(n uint, err error, cfg *retry.Config) time.Duration {
+	if policy, ok := matchErrorPolicy(err, rc.ErrorPolicies); ok {
+		return policy.Delay
+	}
+
+	return retry.FixedDelay(n, err, cfg)
+}

--- a/chain/evm/provider/rpcclient/retry_policy.go
+++ b/chain/evm/provider/rpcclient/retry_policy.go
@@ -36,7 +36,9 @@ func (rc RetryConfig) rpcRetryOptions() []retry.Option {
 	opts := []retry.Option{
 		retry.Attempts(rc.Attempts),
 		retry.Delay(rc.Delay),
-		retry.DelayType(rc.delayForError),
+	}
+	if len(rc.ErrorPolicies) > 0 {
+		opts = append(opts, retry.DelayType(rc.delayForError))
 	}
 
 	return opts

--- a/chain/evm/provider/rpcclient/retry_policy_test.go
+++ b/chain/evm/provider/rpcclient/retry_policy_test.go
@@ -147,11 +147,9 @@ func TestMultiClient_retryWithBackups_errorPolicyDelay(t *testing.T) {
 	)
 
 	lggr := logger.Test(t)
-	client, err := ethclient.Dial("http://rpcs.cldev.sh/avalanche/fuji")
-	require.NoError(t, err)
 
 	mc := MultiClient{
-		Client:    client,
+		Client:    nil,
 		chainName: "ethereum-testnet-sepolia",
 		RetryConfig: RetryConfig{
 			Attempts: 2,

--- a/chain/evm/provider/rpcclient/retry_policy_test.go
+++ b/chain/evm/provider/rpcclient/retry_policy_test.go
@@ -168,7 +168,7 @@ func TestMultiClient_retryWithBackups_errorPolicyDelay(t *testing.T) {
 	}
 
 	start := time.Now()
-	err = mc.retryWithBackups(
+	err := mc.retryWithBackups(
 		context.Background(),
 		"test-operation",
 		func(context.Context, *ethclient.Client) error {

--- a/chain/evm/provider/rpcclient/retry_policy_test.go
+++ b/chain/evm/provider/rpcclient/retry_policy_test.go
@@ -1,0 +1,185 @@
+package rpcclient
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger"
+)
+
+func TestMatchErrorPolicy(t *testing.T) {
+	t.Parallel()
+
+	first := ErrorRetryPolicy{
+		Match: func(err error) bool { return err != nil && err.Error() == "nonce too low" },
+		Delay: time.Second,
+	}
+	second := ErrorRetryPolicy{
+		Match: func(err error) bool { return err != nil && err.Error() == "no contract code" },
+		Delay: 2 * time.Second,
+	}
+
+	tests := []struct {
+		name      string
+		policies  []ErrorRetryPolicy
+		err       error
+		wantOK    bool
+		wantDelay time.Duration
+	}{
+		{
+			name:     "returns false when no policies configured",
+			policies: nil,
+			err:      errors.New("nonce too low"),
+			wantOK:   false,
+		},
+		{
+			name:      "matches first policy",
+			policies:  []ErrorRetryPolicy{first, second},
+			err:       errors.New("nonce too low"),
+			wantOK:    true,
+			wantDelay: time.Second,
+		},
+		{
+			name:      "matches second policy when first does not match",
+			policies:  []ErrorRetryPolicy{first, second},
+			err:       errors.New("no contract code"),
+			wantOK:    true,
+			wantDelay: 2 * time.Second,
+		},
+		{
+			name: "skips nil matcher",
+			policies: []ErrorRetryPolicy{
+				{Match: nil, Delay: 5 * time.Second},
+				second,
+			},
+			err:       errors.New("no contract code"),
+			wantOK:    true,
+			wantDelay: 2 * time.Second,
+		},
+		{
+			name: "uses custom matcher",
+			policies: []ErrorRetryPolicy{
+				{
+					Match: func(err error) bool { return err != nil && err.Error() == "custom" },
+					Delay: 3 * time.Second,
+				},
+			},
+			err:       errors.New("custom"),
+			wantOK:    true,
+			wantDelay: 3 * time.Second,
+		},
+		{
+			name:     "returns false when no policy matches",
+			policies: []ErrorRetryPolicy{first, second},
+			err:      errors.New("unrelated"),
+			wantOK:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			policy, ok := matchErrorPolicy(tt.err, tt.policies)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantDelay, policy.Delay)
+			}
+		})
+	}
+}
+
+func TestRetryConfig_delayForError(t *testing.T) {
+	t.Parallel()
+
+	rc := RetryConfig{
+		Delay: 10 * time.Millisecond,
+		ErrorPolicies: []ErrorRetryPolicy{
+			{
+				Match: func(err error) bool { return err != nil && err.Error() == "nonce too low" },
+				Delay: 2 * time.Second,
+			},
+		},
+	}
+
+	t.Run("returns policy delay for matched error", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 2*time.Second, rc.delayForError(1, errors.New("nonce too low"), nil))
+	})
+
+	t.Run("returns default delay for unmatched error", func(t *testing.T) {
+		t.Parallel()
+
+		var cfg retry.Config
+		retry.Delay(10 * time.Millisecond)(&cfg)
+
+		assert.Equal(t, 10*time.Millisecond, rc.delayForError(1, errors.New("connection reset"), &cfg))
+	})
+}
+
+func TestWithErrorRetryPolicies_setsPoliciesOnMultiClient(t *testing.T) {
+	t.Parallel()
+
+	mc := &MultiClient{}
+	policies := []ErrorRetryPolicy{
+		{Match: func(error) bool { return true }, Delay: time.Second},
+		{Match: func(error) bool { return false }, Delay: 2 * time.Second},
+	}
+
+	WithErrorRetryPolicies(policies...)(mc)
+	assert.Equal(t, policies, mc.RetryConfig.ErrorPolicies)
+}
+
+func TestMultiClient_retryWithBackups_errorPolicyDelay(t *testing.T) {
+	t.Parallel()
+
+	const (
+		defaultDelay = 5 * time.Millisecond
+		policyDelay  = 100 * time.Millisecond
+	)
+
+	lggr := logger.Test(t)
+	client, err := ethclient.Dial("http://rpcs.cldev.sh/avalanche/fuji")
+	require.NoError(t, err)
+
+	mc := MultiClient{
+		Client:    client,
+		chainName: "ethereum-testnet-sepolia",
+		RetryConfig: RetryConfig{
+			Attempts: 2,
+			Delay:    defaultDelay,
+			Timeout:  3 * time.Second,
+			ErrorPolicies: []ErrorRetryPolicy{
+				{
+					Match: func(err error) bool {
+						return err != nil && strings.Contains(err.Error(), "nonce too low")
+					},
+					Delay: policyDelay,
+				},
+			},
+		},
+		lggr: lggr,
+	}
+
+	start := time.Now()
+	err = mc.retryWithBackups(
+		context.Background(),
+		"test-operation",
+		func(context.Context, *ethclient.Client) error {
+			return errors.New("nonce too low")
+		},
+	)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "nonce too low")
+	assert.GreaterOrEqual(t, elapsed, policyDelay, "expected at least one policy delay between retries")
+}

--- a/engine/cld/chains/chains.go
+++ b/engine/cld/chains/chains.go
@@ -528,8 +528,8 @@ func (l *chainLoaderEVM) Load(ctx context.Context, selector uint64) (fchain.Bloc
 				DialTimeout:        2 * time.Second,
 				HealthCheckTimeout: 15 * time.Second, // high concurrency needs more headroom than the 2s default
 				ErrorPolicies: []evmclient.ErrorRetryPolicy{
-					nonceTooLowRetryPolicy(2 * time.Second),
-					noContractCodeRetryPolicy(2 * time.Second),
+					nonceTooLowRetryPolicy(5 * time.Second),
+					noContractCodeRetryPolicy(5 * time.Second),
 				},
 			}
 		},

--- a/engine/cld/chains/chains.go
+++ b/engine/cld/chains/chains.go
@@ -527,6 +527,10 @@ func (l *chainLoaderEVM) Load(ctx context.Context, selector uint64) (fchain.Bloc
 				DialDelay:          10 * time.Millisecond,
 				DialTimeout:        2 * time.Second,
 				HealthCheckTimeout: 15 * time.Second, // high concurrency needs more headroom than the 2s default
+				ErrorPolicies: []evmclient.ErrorRetryPolicy{
+					nonceTooLowRetryPolicy(2 * time.Second),
+					noContractCodeRetryPolicy(2 * time.Second),
+				},
 			}
 		},
 	}

--- a/engine/cld/chains/evm_retry_policies.go
+++ b/engine/cld/chains/evm_retry_policies.go
@@ -1,0 +1,39 @@
+package chains
+
+import (
+	"strings"
+	"time"
+
+	evmclient "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider/rpcclient"
+)
+
+// isNonceTooLowError reports whether err indicates a nonce-too-low condition.
+func isNonceTooLowError(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "nonce too low")
+}
+
+// isNoContractCodeError reports whether err indicates contract code is not yet available.
+func isNoContractCodeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+
+	return strings.Contains(msg, "no code at") ||
+		strings.Contains(msg, "no contract code") ||
+		strings.Contains(msg, "empty string")
+}
+
+func nonceTooLowRetryPolicy(delay time.Duration) evmclient.ErrorRetryPolicy {
+	return evmclient.ErrorRetryPolicy{
+		Match: isNonceTooLowError,
+		Delay: delay,
+	}
+}
+
+func noContractCodeRetryPolicy(delay time.Duration) evmclient.ErrorRetryPolicy {
+	return evmclient.ErrorRetryPolicy{
+		Match: isNoContractCodeError,
+		Delay: delay,
+	}
+}

--- a/engine/cld/chains/evm_retry_policies.go
+++ b/engine/cld/chains/evm_retry_policies.go
@@ -14,14 +14,7 @@ func isNonceTooLowError(err error) bool {
 
 // isNoContractCodeError reports whether err indicates contract code is not yet available.
 func isNoContractCodeError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := strings.ToLower(err.Error())
-
-	return strings.Contains(msg, "no code at") ||
-		strings.Contains(msg, "no contract code") ||
-		strings.Contains(msg, "empty string")
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "no contract code")
 }
 
 func nonceTooLowRetryPolicy(delay time.Duration) evmclient.ErrorRetryPolicy {

--- a/engine/cld/chains/evm_retry_policies_test.go
+++ b/engine/cld/chains/evm_retry_policies_test.go
@@ -65,18 +65,8 @@ func TestIsNoContractCodeError(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "matches no code at message",
-			err:  errors.New("no code at given address"),
-			want: true,
-		},
-		{
 			name: "matches no contract code message",
-			err:  errors.New("no contract code at address"),
-			want: true,
-		},
-		{
-			name: "matches empty string message",
-			err:  errors.New("attempting to unmarshal an empty string"),
+			err:  errors.New("no contract code at given address"),
 			want: true,
 		},
 		{

--- a/engine/cld/chains/evm_retry_policies_test.go
+++ b/engine/cld/chains/evm_retry_policies_test.go
@@ -1,0 +1,100 @@
+package chains
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNonceTooLowError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "returns false for nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "matches nonce too low message",
+			err:  errors.New("nonce too low: address 0xabc, tx: 1 state: 2"),
+			want: true,
+		},
+		{
+			name: "matches case-insensitively",
+			err:  errors.New("Error Nonce Too Low"),
+			want: true,
+		},
+		{
+			name: "matches wrapped error",
+			err:  fmt.Errorf("send failed: %w", errors.New("nonce too low")),
+			want: true,
+		},
+		{
+			name: "does not match unrelated error",
+			err:  errors.New("replacement transaction underpriced"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isNonceTooLowError(tt.err))
+		})
+	}
+}
+
+func TestIsNoContractCodeError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "returns false for nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "matches no code at message",
+			err:  errors.New("no code at given address"),
+			want: true,
+		},
+		{
+			name: "matches no contract code message",
+			err:  errors.New("no contract code at address"),
+			want: true,
+		},
+		{
+			name: "matches empty string message",
+			err:  errors.New("attempting to unmarshal an empty string"),
+			want: true,
+		},
+		{
+			name: "matches wrapped error",
+			err:  fmt.Errorf("call failed: %w", errors.New("no contract code")),
+			want: true,
+		},
+		{
+			name: "does not match unrelated error",
+			err:  errors.New("execution reverted"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isNoContractCodeError(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
Add a error based retry retry policy

1. No policy should presever the current behaviour
2. Delay can be specified by matching an error
3. Add nonce too low and no code at error in the default evm chain loader