### PR TITLE
feat: ed25519 changeset

### DIFF
--- a/.changeset/young-rocks-tap.md
+++ b/.changeset/young-rocks-tap.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+Add Ed25519 AWS KMS signing support.


### PR DESCRIPTION
This pull request introduces a patch to the `chainlink-deployments-framework` package, adding support for Ed25519 AWS KMS signing.