### PR TITLE
test(aptos): fix flaky TestChain_ReadOnly Ryuk race

### DIFF
--- a/.github/workflows/pull-request-main.yml
+++ b/.github/workflows/pull-request-main.yml
@@ -148,9 +148,10 @@ jobs:
       # process's Ryuk keep-alive goroutine long enough to blow Ryuk's default 10s
       # reconnection timeout, causing it to reap the Aptos node container mid-test
       # ("connection refused" on the next API call). Raise the timeouts so Ryuk tolerates
-      # the compile step instead of killing the container out from under the test.
-      RYUK_RECONNECTION_TIMEOUT: 60s
-      RYUK_CONNECTION_TIMEOUT: 2m
+      # the compile step and parallel package teardown (chain/aptos/provider often
+      # finishes ~60-70s before chain/aptos) instead of killing the container mid-test.
+      RYUK_RECONNECTION_TIMEOUT: 5m
+      RYUK_CONNECTION_TIMEOUT: 5m
     steps:
       - name: Install Aptos CLI
         uses: aptos-labs/actions/install-aptos-cli@528ef7ad9427a8c0720ea3eea790a9190d6e377d # v0.1

--- a/chain/aptos/aptos_chain_test.go
+++ b/chain/aptos/aptos_chain_test.go
@@ -104,6 +104,11 @@ func TestChain_ReadOnly(t *testing.T) {
 	require.NoError(t, err)
 
 	// write with read-only client should fail
-	_, _, _, err = aptosmcms.DeployToResourceAccount(roAptosChain.DeployerSigner, roAptosChain.Client, seed) //nolint:dogsled
+	transferPayload, err := aptosgosdk.CoinTransferPayload(nil, aptosChain.DeployerSigner.AccountAddress(), 1)
+	require.NoError(t, err)
+	_, err = roAptosChain.Client.BuildSignAndSubmitTransaction(
+		roAptosChain.DeployerSigner,
+		aptosgosdk.TransactionPayload{Payload: transferPayload},
+	)
 	require.ErrorContains(t, err, "INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE")
 }


### PR DESCRIPTION
## Summary

`TestChain_ReadOnly` was flaky in CI with `connection refused` against the local Aptos node. The test triggered two MCMS deploys, each shelling out to the Aptos CLI for a ~90s Move compile. While blocked on compile, Ryuk could reap the container after a parallel `chain/aptos/provider` test finished and closed the shared session connection.

- Replace the second MCMS deploy assertion with a lightweight APT coin transfer that still fails with `INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE` on the read-only signer, avoiding a second compile.
- Raise `RYUK_RECONNECTION_TIMEOUT` and `RYUK_CONNECTION_TIMEOUT` from 60s/2m to 5m so Ryuk tolerates long compiles and cross-package teardown timing.

JIRA: https://smartcontract-it.atlassian.net/browse/CLD-3039