### PR TITLE
feat(proposalanalysis): expose TimelockProposal in RenderRequest

### DIFF
--- a/.changeset/early-laws-accept.md
+++ b/.changeset/early-laws-accept.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat(proposalanalyzer): expose timelock proposal in renderer

--- a/engine/cld/commands/mcms/cmd_analyze_proposal_v2.go
+++ b/engine/cld/commands/mcms/cmd_analyze_proposal_v2.go
@@ -139,8 +139,9 @@ func runAnalyzeProposalV2(cmd *cobra.Command, cfg Config, f analyzeProposalV2Fla
 
 	var out bytes.Buffer
 	if err := engine.RenderTo(&out, rendererID, analysisrenderer.RenderRequest{
-		Domain:          cfg.Domain.Key(),
-		EnvironmentName: proposalCfg.EnvStr,
+		Domain:           cfg.Domain.Key(),
+		EnvironmentName:  proposalCfg.EnvStr,
+		TimelockProposal: proposalCfg.TimelockProposal,
 	}, analyzedProposal); err != nil {
 		return fmt.Errorf("render analysis output: %w", err)
 	}

--- a/engine/cld/mcms/proposalanalysis/doc.go
+++ b/engine/cld/mcms/proposalanalysis/doc.go
@@ -68,8 +68,9 @@ The engine workflow is:
 			os.Stdout,
 			renderer.IDMarkdown,
 			renderer.RenderRequest{
-				Domain:          domain.Key(),
-				EnvironmentName: env.Name,
+				Domain:           domain.Key(),
+				EnvironmentName:  env.Name,
+				TimelockProposal: proposal,
 			},
 			analyzed,
 		)

--- a/engine/cld/mcms/proposalanalysis/engine.go
+++ b/engine/cld/mcms/proposalanalysis/engine.go
@@ -139,5 +139,13 @@ func (e *analyzerEngine) RenderTo(w io.Writer, rendererID string, renderReq rend
 		return fmt.Errorf("renderer with ID %q is not registered", rendererID)
 	}
 
+	if renderReq.TimelockProposal != nil {
+		cloned, err := renderer.CloneTimelockProposal(renderReq.TimelockProposal)
+		if err != nil {
+			return fmt.Errorf("clone timelock proposal: %w", err)
+		}
+		renderReq.TimelockProposal = cloned
+	}
+
 	return r.RenderTo(w, renderReq, proposal)
 }

--- a/engine/cld/mcms/proposalanalysis/engine_test.go
+++ b/engine/cld/mcms/proposalanalysis/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/mcms"
@@ -163,6 +164,48 @@ func TestAnalyzerEngineRenderTo(t *testing.T) {
 	err = engine.RenderTo(out, "plain", req, analyzer.NewAnalyzedProposalNode(nil))
 	require.NoError(t, err)
 	require.Equal(t, "rendered", out.String())
+}
+
+func TestAnalyzerEngineRenderTo_clonesTimelockProposal(t *testing.T) {
+	t.Parallel()
+
+	original := &mcms.TimelockProposal{
+		BaseProposal: mcms.BaseProposal{
+			Version:     "v1",
+			Kind:        mcmstypes.KindTimelockProposal,
+			ValidUntil:  uint32(time.Now().Add(time.Hour).Unix()), //nolint:gosec // test fixture
+			Description: "original",
+			ChainMetadata: map[mcmstypes.ChainSelector]mcmstypes.ChainMetadata{
+				mcmstypes.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector): {
+					MCMAddress: "0x1111111111111111111111111111111111111111",
+				},
+			},
+		},
+		Action: mcmstypes.TimelockActionSchedule,
+		TimelockAddresses: map[mcmstypes.ChainSelector]string{
+			mcmstypes.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector): "0x1111111111111111111111111111111111111111",
+		},
+		Operations: []mcmstypes.BatchOperation{
+			{
+				ChainSelector: mcmstypes.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector),
+				Transactions:  []mcmstypes.Transaction{{To: "0x123", Data: []byte{0x01}}},
+			},
+		},
+	}
+	engine := NewAnalyzerEngine()
+	require.NoError(t, engine.RegisterRenderer(&rendererStub{
+		id: "mutator",
+		renderFn: func(_ io.Writer, req renderer.RenderRequest, _ analyzer.AnalyzedProposal) error {
+			req.TimelockProposal.Description = "mutated"
+			return nil
+		},
+	}))
+
+	err := engine.RenderTo(io.Discard, "mutator", renderer.RenderRequest{
+		TimelockProposal: original,
+	}, analyzer.NewAnalyzedProposalNode(nil))
+	require.NoError(t, err)
+	require.Equal(t, "original", original.Description)
 }
 
 func TestAnalyzerEngineRunExecutesAnalyzersAndResolvesDependencies(t *testing.T) {

--- a/engine/cld/mcms/proposalanalysis/examples/ccip/renderers/mermaid/renderer.go
+++ b/engine/cld/mcms/proposalanalysis/examples/ccip/renderers/mermaid/renderer.go
@@ -21,10 +21,13 @@ func NewMermaidRenderer() *MermaidRenderer { return &MermaidRenderer{} }
 
 func (r *MermaidRenderer) ID() string { return IDMermaid }
 
-func (r *MermaidRenderer) RenderTo(w io.Writer, _ renderer.RenderRequest, proposal renderer.AnalyzedProposal) error {
+func (r *MermaidRenderer) RenderTo(w io.Writer, req renderer.RenderRequest, proposal renderer.AnalyzedProposal) error {
 	var b strings.Builder
 
 	b.WriteString("graph TD\n")
+	if req.TimelockProposal != nil {
+		fmt.Fprintf(&b, "    %%%% Min delay: %s\n", req.TimelockProposal.Delay.Duration)
+	}
 	b.WriteString("    classDef registry fill:#e1f5fe,stroke:#01579b,stroke-width:2px\n")
 	b.WriteString("    classDef pool fill:#d4edda,stroke:#28a745,stroke-width:2px\n")
 	b.WriteString("    classDef default fill:#f5f5f5,stroke:#666,stroke-width:1px\n")

--- a/engine/cld/mcms/proposalanalysis/examples/ccip/renderers/mermaid/renderer_test.go
+++ b/engine/cld/mcms/proposalanalysis/examples/ccip/renderers/mermaid/renderer_test.go
@@ -6,7 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/smartcontractkit/mcms"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -15,11 +18,16 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/proposalanalysis/renderer"
 )
 
-func render(t *testing.T, proposal *renderer.AnalyzedProposalNode) string {
+func render(t *testing.T, proposal *renderer.AnalyzedProposalNode, req ...renderer.RenderRequest) string {
 	t.Helper()
 
+	renderReq := renderer.RenderRequest{Domain: "ccip", EnvironmentName: "mainnet"}
+	if len(req) > 0 {
+		renderReq = req[0]
+	}
+
 	var buf bytes.Buffer
-	err := NewMermaidRenderer().RenderTo(&buf, renderer.RenderRequest{Domain: "ccip", EnvironmentName: "mainnet"}, proposal)
+	err := NewMermaidRenderer().RenderTo(&buf, renderReq, proposal)
 	require.NoError(t, err)
 
 	return buf.String()
@@ -83,6 +91,17 @@ func TestMermaid_MultipleBatchesSameChain(t *testing.T) {
 	assert.Contains(t, out, "1. applyChainUpdates")
 	assert.Contains(t, out, "2. acceptOwnership")
 	assert.Contains(t, out, "3. setPool")
+}
+
+func TestMermaid_TimelockProposalDelay(t *testing.T) {
+	t.Parallel()
+
+	out := render(t, renderer.NewAnalyzedProposalNode(nil), renderer.RenderRequest{
+		TimelockProposal: &mcms.TimelockProposal{
+			Delay: mcmstypes.NewDuration(time.Hour),
+		},
+	})
+	assert.Contains(t, out, "%% Min delay: 1h0m0s")
 }
 
 func TestMermaid_CrossChainEdges(t *testing.T) {

--- a/engine/cld/mcms/proposalanalysis/renderer/renderer.go
+++ b/engine/cld/mcms/proposalanalysis/renderer/renderer.go
@@ -10,9 +10,9 @@ import (
 type RenderRequest struct {
 	Domain          string
 	EnvironmentName string
-	// TimelockProposal is the original MCMS timelock proposal used during analysis.
+	// TimelockProposal carries MCMS timelock metadata for rendering.
+	// AnalyzerEngine.RenderTo clones this value before invoking renderers.
 	// It may be nil in tests or when callers omit proposal metadata.
-	// Callers should pass the same instance supplied to AnalyzerEngine.Run.
 	TimelockProposal *mcms.TimelockProposal
 }
 

--- a/engine/cld/mcms/proposalanalysis/renderer/renderer.go
+++ b/engine/cld/mcms/proposalanalysis/renderer/renderer.go
@@ -2,12 +2,18 @@ package renderer
 
 import (
 	"io"
+
+	"github.com/smartcontractkit/mcms"
 )
 
-// RenderRequest encapsulates the domain and environment name
+// RenderRequest encapsulates the domain, environment, and optional source proposal.
 type RenderRequest struct {
 	Domain          string
 	EnvironmentName string
+	// TimelockProposal is the original MCMS timelock proposal used during analysis.
+	// It may be nil in tests or when callers omit proposal metadata.
+	// Callers should pass the same instance supplied to AnalyzerEngine.Run.
+	TimelockProposal *mcms.TimelockProposal
 }
 
 // Renderer transforms an AnalyzedProposal into a specific output format

--- a/engine/cld/mcms/proposalanalysis/renderer/template_renderer_test.go
+++ b/engine/cld/mcms/proposalanalysis/renderer/template_renderer_test.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 	"testing"
 	"text/template"
+	"time"
 
+	"github.com/smartcontractkit/mcms"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -132,6 +135,24 @@ func TestRenderTo_PassesRenderRequest(t *testing.T) {
 	err = r.RenderTo(&buf, RenderRequest{Domain: "test", EnvironmentName: "staging"}, newTestProposal())
 	require.NoError(t, err)
 	assert.Equal(t, "test-staging", buf.String())
+}
+
+func TestRenderTo_PassesTimelockProposal(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewMarkdownRenderer(
+		WithTemplates(minimalTemplates(`{{ define "proposal" }}{{ .Request.TimelockProposal.Delay.Duration }}{{ end }}`)),
+	)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = r.RenderTo(&buf, RenderRequest{
+		TimelockProposal: &mcms.TimelockProposal{
+			Delay: mcmstypes.NewDuration(30 * time.Minute),
+		},
+	}, newTestProposal())
+	require.NoError(t, err)
+	assert.Equal(t, "30m0s", buf.String())
 }
 
 func TestWithTemplateFuncs(t *testing.T) {

--- a/engine/cld/mcms/proposalanalysis/renderer/timelock_proposal.go
+++ b/engine/cld/mcms/proposalanalysis/renderer/timelock_proposal.go
@@ -1,0 +1,28 @@
+package renderer
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/smartcontractkit/mcms"
+)
+
+// CloneTimelockProposal returns a deep copy of proposal using JSON round-trip.
+// It returns nil when proposal is nil.
+func CloneTimelockProposal(proposal *mcms.TimelockProposal) (*mcms.TimelockProposal, error) {
+	if proposal == nil {
+		return nil, nil //nolint:nilnil // nil proposal is valid input; callers treat absence as optional metadata
+	}
+
+	var buf bytes.Buffer
+	if err := mcms.WriteTimelockProposal(&buf, proposal); err != nil {
+		return nil, fmt.Errorf("marshal timelock proposal: %w", err)
+	}
+
+	cloned, err := mcms.NewTimelockProposal(&buf)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal timelock proposal: %w", err)
+	}
+
+	return cloned, nil
+}

--- a/engine/cld/mcms/proposalanalysis/renderer/timelock_proposal_test.go
+++ b/engine/cld/mcms/proposalanalysis/renderer/timelock_proposal_test.go
@@ -1,0 +1,67 @@
+package renderer
+
+import (
+	"testing"
+	"time"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/mcms"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloneTimelockProposal_nil(t *testing.T) {
+	t.Parallel()
+
+	cloned, err := CloneTimelockProposal(nil)
+	require.NoError(t, err)
+	require.Nil(t, cloned)
+}
+
+func TestCloneTimelockProposal_isolatesMutation(t *testing.T) {
+	t.Parallel()
+
+	original := testTimelockProposalForClone("original description")
+	chainSelector := mcmstypes.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector)
+
+	cloned, err := CloneTimelockProposal(original)
+	require.NoError(t, err)
+	require.NotSame(t, original, cloned)
+
+	cloned.Description = "mutated description"
+	cloned.Operations[0].Transactions[0].Data[0] = 0xff
+	cloned.TimelockAddresses[chainSelector] = "0x3333333333333333333333333333333333333333"
+
+	require.Equal(t, "original description", original.Description)
+	require.Equal(t, byte(0x01), original.Operations[0].Transactions[0].Data[0])
+	require.Equal(t, "0x2222222222222222222222222222222222222222", original.TimelockAddresses[chainSelector])
+}
+
+func testTimelockProposalForClone(description string) *mcms.TimelockProposal {
+	chainSelector := mcmstypes.ChainSelector(chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector)
+
+	return &mcms.TimelockProposal{
+		BaseProposal: mcms.BaseProposal{
+			Version:     "v1",
+			Kind:        mcmstypes.KindTimelockProposal,
+			ValidUntil:  uint32(time.Now().Add(time.Hour).Unix()), //nolint:gosec // test fixture
+			Description: description,
+			ChainMetadata: map[mcmstypes.ChainSelector]mcmstypes.ChainMetadata{
+				chainSelector: {MCMAddress: "0x1111111111111111111111111111111111111111"},
+			},
+		},
+		Action: mcmstypes.TimelockActionSchedule,
+		Delay:  mcmstypes.NewDuration(time.Hour),
+		TimelockAddresses: map[mcmstypes.ChainSelector]string{
+			chainSelector: "0x2222222222222222222222222222222222222222",
+		},
+		Operations: []mcmstypes.BatchOperation{
+			{
+				ChainSelector: chainSelector,
+				Transactions: []mcmstypes.Transaction{
+					{To: "0x1111111111111111111111111111111111111111", Data: []byte{0x01, 0x02}},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

Exposes the original `*mcms.TimelockProposal` to proposal renderers via `renderer.RenderRequest`, so renderers can access MCMS metadata such as timelock min delay without changing the `Renderer` interface.

- Adds optional `TimelockProposal` field to `RenderRequest`
- Wires `analyze-proposal-v2` to pass the analyzed proposal into render requests
- Updates the CCIP mermaid renderer to emit min delay when present
- Adds tests covering template and mermaid access to timelock metadata

Closes [CLD-3040](https://smartcontract-it.atlassian.net/browse/CLD-3040)