### PR TITLE
Overrideable isZkSync via network metadata 

### DIFF
--- a/.changeset/modern-ads-post.md
+++ b/.changeset/modern-ads-post.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+Overrideable isZkSync via network metadata

--- a/engine/cld/chains/chains.go
+++ b/engine/cld/chains/chains.go
@@ -537,9 +537,8 @@ func (l *chainLoaderEVM) Load(ctx context.Context, selector uint64) (fchain.Bloc
 
 	var c fchain.BlockChain
 
-	// Use the zkSync RPC if the chain is a zkSync chain. Per-chain network config may
-	// override the hardcoded classification via EVMMetadata.IsZkSyncVM; otherwise the
-	// hardcoded allowlist is used.
+	// Use the zkSync RPC if the chain should be treated as a zkSync VM chain. Per-chain network config may
+	// override the hardcoded classification via EVMMetadata.IsZkSync; otherwise the hardcoded allowlist is used.
 	if l.resolveIsZkSyncVM(network, selector) {
 		var signerGen evmprov.ZkSyncSignerGenerator
 		signerGen, err = l.zkSyncSignerGenerator(l.cfg)

--- a/engine/cld/chains/chains.go
+++ b/engine/cld/chains/chains.go
@@ -576,10 +576,17 @@ func (l *chainLoaderEVM) Load(ctx context.Context, selector uint64) (fchain.Bloc
 }
 
 // resolveIsZkSyncVM determines whether a chain should use zkSync VM handling. A
-// per-chain EVMMetadata.IsZkSyncVM override in the network config takes precedence
+// per-chain EVMMetadata.IsZkSync override in the network config takes precedence;
+// when unset it falls back to the hardcoded isZkSyncVM allowlist.
 func (l *chainLoaderEVM) resolveIsZkSyncVM(network cfgnet.Network, selector uint64) bool {
-	if md, err := cfgnet.DecodeMetadata[cfgnet.EVMMetadata](network.Metadata); err == nil && md.IsZkSync != nil {
-		return *md.IsZkSync
+	if network.Metadata != nil {
+		switch md, err := cfgnet.DecodeMetadata[cfgnet.EVMMetadata](network.Metadata); {
+		case err != nil:
+			l.lggr.Warnw("Failed to decode EVM network metadata; falling back to hardcoded zkSync classification",
+				"selector", selector, "error", err)
+		case md.IsZkSync != nil:
+			return *md.IsZkSync
+		}
 	}
 
 	return l.isZkSyncVM(selector)

--- a/engine/cld/chains/chains.go
+++ b/engine/cld/chains/chains.go
@@ -537,11 +537,10 @@ func (l *chainLoaderEVM) Load(ctx context.Context, selector uint64) (fchain.Bloc
 
 	var c fchain.BlockChain
 
-	// Use the zkSync RPC if the chain is a zkSync chain.
-	//
-	// This is a temporary solution until we have a more generic way to identify zkSync chains in the
-	// network config.
-	if l.isZkSyncVM(selector) {
+	// Use the zkSync RPC if the chain is a zkSync chain. Per-chain network config may
+	// override the hardcoded classification via EVMMetadata.IsZkSyncVM; otherwise the
+	// hardcoded allowlist is used.
+	if l.resolveIsZkSyncVM(network, selector) {
 		var signerGen evmprov.ZkSyncSignerGenerator
 		signerGen, err = l.zkSyncSignerGenerator(l.cfg)
 		if err != nil {
@@ -574,6 +573,16 @@ func (l *chainLoaderEVM) Load(ctx context.Context, selector uint64) (fchain.Bloc
 	}
 
 	return c, nil
+}
+
+// resolveIsZkSyncVM determines whether a chain should use zkSync VM handling. A
+// per-chain EVMMetadata.IsZkSyncVM override in the network config takes precedence
+func (l *chainLoaderEVM) resolveIsZkSyncVM(network cfgnet.Network, selector uint64) bool {
+	if md, err := cfgnet.DecodeMetadata[cfgnet.EVMMetadata](network.Metadata); err == nil && md.IsZkSync != nil {
+		return *md.IsZkSync
+	}
+
+	return l.isZkSyncVM(selector)
 }
 
 // isZkSyncVM checks if the given chain selector corresponds to a zkSyncchain.

--- a/engine/cld/chains/chains_test.go
+++ b/engine/cld/chains/chains_test.go
@@ -1550,9 +1550,15 @@ func Test_chainLoaderEVM_resolveIsZkSyncVM(t *testing.T) {
 			metadata: map[string]any{"anvil_config": map[string]any{"image": "x", "port": 1}},
 			want:     true,
 		},
+		{
+			name:     "malformed metadata warns and falls back to hardcoded",
+			selector: zkSel,
+			metadata: map[string]any{"is_zksync": "not-a-bool"},
+			want:     true,
+		},
 	}
 
-	l := &chainLoaderEVM{}
+	l := &chainLoaderEVM{lggr: logger.Test(t)}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/engine/cld/chains/chains_test.go
+++ b/engine/cld/chains/chains_test.go
@@ -1503,3 +1503,62 @@ func newFakeRPCServer(t *testing.T) *httptest.Server {
 
 	return srv
 }
+
+// Test_chainLoaderEVM_resolveIsZkSyncVM verifies that a per-chain
+// EVMMetadata.IsZkSync override in the network config takes precedence over the
+// hardcoded isZkSyncVM allowlist, and that the loader falls back to the allowlist
+// when no override is present.
+func Test_chainLoaderEVM_resolveIsZkSyncVM(t *testing.T) {
+	t.Parallel()
+
+	zkSel := chainsel.ETHEREUM_TESTNET_SEPOLIA_ZKSYNC_1.Selector // hardcoded zkSync
+	evmSel := chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector         // hardcoded non-zkSync
+
+	tests := []struct {
+		name     string
+		selector uint64
+		metadata any
+		want     bool
+	}{
+		{
+			name:     "no metadata: zkSync selector falls back to hardcoded true",
+			selector: zkSel,
+			metadata: nil,
+			want:     true,
+		},
+		{
+			name:     "no metadata: non-zkSync selector is set to false",
+			selector: evmSel,
+			metadata: nil,
+			want:     false,
+		},
+		{
+			name:     "override is_zksync=false on hardcoded zkSync selector wins",
+			selector: zkSel,
+			metadata: map[string]any{"is_zksync": false},
+			want:     false,
+		},
+		{
+			name:     "override is_zksync=true on non-zkSync selector wins",
+			selector: evmSel,
+			metadata: map[string]any{"is_zksync": true},
+			want:     true,
+		},
+		{
+			name:     "metadata present without is_zksync falls back to hardcoded",
+			selector: zkSel,
+			metadata: map[string]any{"anvil_config": map[string]any{"image": "x", "port": 1}},
+			want:     true,
+		},
+	}
+
+	l := &chainLoaderEVM{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			network := cfgnet.Network{ChainSelector: tt.selector, Metadata: tt.metadata}
+			assert.Equal(t, tt.want, l.resolveIsZkSyncVM(network, tt.selector))
+		})
+	}
+}

--- a/engine/cld/config/network/metadata.go
+++ b/engine/cld/config/network/metadata.go
@@ -10,6 +10,10 @@ import (
 // EVMMetadata is a struct that holds metadata specific to EVM networks.
 type EVMMetadata struct {
 	AnvilConfig *AnvilConfig `yaml:"anvil_config,omitempty"`
+	// IsZkSync overrides the default VM classification for this chain. When set, it
+	// takes precedence over the hardcoded isZkSyncVM allowlist in the EVM chain loader.
+	// Set false to force the standard EVM deploy path on zkStack chains
+	IsZkSync *bool `yaml:"is_zksync,omitempty"`
 }
 
 // StellarMetadata holds metadata specific to Stellar networks.


### PR DESCRIPTION
- zkSync Stack supports EVM compiled contract deployments from v27
- We need create2 & ccv domains in cld to deploy EVM complied contracts bytecode for zkSync chains
- While also maintain the zkSolc compiled contracts requirement for existing domains such as CCIP