### PR TITLE
feat(pipeline): correct timelock delay from on-chain minDelay during run

### DIFF
--- a/.changeset/timelock-delay-pipeline-correction.md
+++ b/.changeset/timelock-delay-pipeline-correction.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat(pipeline): correct timelock proposal delay from on-chain minDelay during durable-pipeline run

--- a/deployment/mcms_registry.go
+++ b/deployment/mcms_registry.go
@@ -31,6 +31,7 @@ type MCMSTimelockProposalInput struct {
 	// Root can't be set or executed after this time.
 	ValidUntil uint32
 	// TimelockDelay is the amount of time each operation in the proposal must wait before it can be executed.
+	// Zero means unset; durable-pipeline run resolves it to on-chain minDelay when every timelock chain is readable.
 	TimelockDelay mcmstypes.Duration
 	// TimelockAction is the action to perform on the timelock contract (schedule, bypass, or cancel).
 	TimelockAction mcmstypes.TimelockAction
@@ -58,9 +59,6 @@ func (c *MCMSTimelockProposalInput) validateAt(now time.Time) error {
 	}
 	if c.TimelockDelay.Duration < 0 {
 		return fmt.Errorf("%w: timelock delay must not be negative", ErrInvalidMCMSTimelockProposalInput)
-	}
-	if c.TimelockAction == mcmstypes.TimelockActionSchedule && c.TimelockDelay.Duration <= 0 {
-		return fmt.Errorf("%w: timelock delay must be positive for schedule action", ErrInvalidMCMSTimelockProposalInput)
 	}
 	if c.ValidUntil == 0 {
 		return fmt.Errorf("%w: valid until must be set", ErrInvalidMCMSTimelockProposalInput)

--- a/deployment/mcms_registry_test.go
+++ b/deployment/mcms_registry_test.go
@@ -65,14 +65,12 @@ func TestMCMSTimelockProposalInput_Validate(t *testing.T) {
 			errMsg:  "invalid timelock action",
 		},
 		{
-			name: "schedule requires positive delay",
+			name: "valid schedule with zero delay",
 			input: MCMSTimelockProposalInput{
 				TimelockAction: mcms_types.TimelockActionSchedule,
 				ValidUntil:     testValidUntilUnix,
 				TimelockDelay:  mcms_types.NewDuration(0),
 			},
-			wantErr: ErrInvalidMCMSTimelockProposalInput,
-			errMsg:  "timelock delay must be positive for schedule action",
 		},
 		{
 			name: "negative timelock delay",

--- a/engine/cld/commands/pipeline/deps.go
+++ b/engine/cld/commands/pipeline/deps.go
@@ -3,9 +3,14 @@ package pipeline
 import (
 	"context"
 
+	"github.com/smartcontractkit/mcms"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	fdeployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/domain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/timelockdelay"
+	"github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger"
 )
 
 // EnvironmentLoaderFunc loads a deployment environment.
@@ -16,10 +21,20 @@ type EnvironmentLoaderFunc func(
 	opts ...environment.LoadEnvironmentOption,
 ) (fdeployment.Environment, error)
 
+// TimelockDelayCorrectorFunc corrects schedule proposal delays against on-chain minDelay.
+type TimelockDelayCorrectorFunc func(
+	ctx context.Context,
+	lggr logger.Logger,
+	blockChains chain.BlockChains,
+	proposals []mcms.TimelockProposal,
+) error
+
 // Deps holds optional dependencies that can be overridden for testing.
 type Deps struct {
 	// EnvironmentLoader loads a deployment environment. Default: environment.Load
 	EnvironmentLoader EnvironmentLoaderFunc
+	// TimelockDelayCorrector corrects timelock proposal delays. Default: timelockdelay.CorrectTimelockDelays
+	TimelockDelayCorrector TimelockDelayCorrectorFunc
 }
 
 // DefaultEnvironmentLoader is used when Deps.EnvironmentLoader is nil.
@@ -30,5 +45,8 @@ var DefaultEnvironmentLoader = environment.Load
 func (d *Deps) applyDefaults() {
 	if d.EnvironmentLoader == nil {
 		d.EnvironmentLoader = DefaultEnvironmentLoader
+	}
+	if d.TimelockDelayCorrector == nil {
+		d.TimelockDelayCorrector = timelockdelay.CorrectTimelockDelays
 	}
 }

--- a/engine/cld/commands/pipeline/run.go
+++ b/engine/cld/commands/pipeline/run.go
@@ -198,6 +198,12 @@ func runRun(cmd *cobra.Command, cfg *Config, f runFlags) error {
 		return saveErr
 	}
 
+	if len(out.MCMSTimelockProposals) > 0 {
+		if delayErr := deps.TimelockDelayCorrector(cmd.Context(), cfg.Logger, env.BlockChains, out.MCMSTimelockProposals); delayErr != nil {
+			return fmt.Errorf("failed to correct timelock proposal delay: %w", delayErr)
+		}
+	}
+
 	err = saveChangesetProposalMetadata(registry, actualChangesetName, out)
 	if err != nil {
 		return fmt.Errorf("failed to save changeset proposal metadata: %w", err)

--- a/engine/cld/commands/pipeline/run_test.go
+++ b/engine/cld/commands/pipeline/run_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/samber/lo"
@@ -16,11 +17,13 @@ import (
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	fresolvers "github.com/smartcontractkit/chainlink-deployments-framework/changeset/resolvers"
 	fdeployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/changeset"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/domain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/mcms/timelockdelay"
 	"github.com/smartcontractkit/chainlink-deployments-framework/experimental/analyzer"
 	"github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger"
 )
@@ -89,7 +92,7 @@ func (m *mockProposalContext) GetEVMRegistry() analyzer.EVMABIRegistry {
 }
 
 // loadProposal is a helper function to load the generated proposal from disk for assertions.
-func loadProposal(t *testing.T, proposalsDir string) (*mcms.TimelockProposal, string) {
+func loadProposal(t *testing.T, proposalsDir string) *mcms.TimelockProposal {
 	t.Helper()
 
 	files, err := filepath.Glob(filepath.Join(proposalsDir, "*.json"))
@@ -99,7 +102,7 @@ func loadProposal(t *testing.T, proposalsDir string) (*mcms.TimelockProposal, st
 	proposal, err := mcms.LoadProposal(mcmstypes.KindTimelockProposal, files[0])
 	require.NoError(t, err)
 
-	return proposal.(*mcms.TimelockProposal), files[0]
+	return proposal.(*mcms.TimelockProposal)
 }
 
 //nolint:paralleltest
@@ -647,7 +650,7 @@ changesets:
 	err = cmd.Execute()
 	require.NoError(t, err)
 
-	proposal, _ := loadProposal(t, proposalsDir)
+	proposal := loadProposal(t, proposalsDir)
 	require.Equal(t, "v1", proposal.Version)
 	require.NotNil(t, proposal.Metadata)
 	require.Equal(t, map[string]any{
@@ -679,6 +682,139 @@ changesets:
 			},
 		}},
 	}}, proposal.Operations)
+}
+
+//nolint:paralleltest
+func TestRunCmd_TimelockDelayCorrection(t *testing.T) {
+	generateStableUUIDs(t)
+
+	const (
+		env           = "testnet"
+		changesetName = "0001_test_changeset"
+		yamlFileName  = "test-input.yaml"
+	)
+	yamlContent := `environment: testnet
+domain: test
+changesets:
+  - 0001_test_changeset:
+      payload:
+        chain: optimism_sepolia
+        value: 123456789012345678901234`
+	minDelay := mcmstypes.NewDuration(3 * time.Hour)
+
+	tests := []struct {
+		name       string
+		corrector  TimelockDelayCorrectorFunc
+		wantErr    error
+		wantErrMsg string
+		checkSaved func(t *testing.T, proposalsDir string)
+	}{
+		{
+			name: "corrects unset delay before save",
+			corrector: func(
+				ctx context.Context,
+				lggr logger.Logger,
+				_ chain.BlockChains,
+				proposals []mcms.TimelockProposal,
+			) error {
+				return timelockdelay.CorrectTimelockDelaysWithLookup(ctx, lggr, proposals, func(
+					_ context.Context,
+					_ *mcms.TimelockProposal,
+					_ uint64,
+					_ string,
+				) (mcmstypes.Duration, error) {
+					return minDelay, nil
+				})
+			},
+			checkSaved: func(t *testing.T, proposalsDir string) {
+				t.Helper()
+				savedProposal := loadProposal(t, proposalsDir)
+				require.Equal(t, minDelay, savedProposal.Delay)
+			},
+		},
+		{
+			name:       "fails when unset delay cannot be verified",
+			wantErr:    timelockdelay.ErrUnsetTimelockDelayUnverified,
+			wantErrMsg: "failed to correct timelock proposal delay",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			workspaceRoot := t.TempDir()
+			domainsRoot := filepath.Join(workspaceRoot, "domains")
+			testDomain := domain.NewDomain(domainsRoot, "test")
+			envRoot := filepath.Join(domainsRoot, testDomain.String(), env)
+			inputsDir := filepath.Join(envRoot, "durable_pipelines", "inputs")
+			require.NoError(t, os.MkdirAll(inputsDir, 0o755))
+			proposalsDir := filepath.Join(envRoot, "proposals")
+
+			require.NoError(t, os.WriteFile(filepath.Join(inputsDir, yamlFileName), []byte(yamlContent), 0o600))
+
+			originalWd, err := os.Getwd()
+			require.NoError(t, err)
+			require.NoError(t, os.Chdir(workspaceRoot))
+			t.Cleanup(func() { require.NoError(t, os.Chdir(originalWd)) })
+
+			proposal := *testProposal
+			proposal.Delay = mcmstypes.NewDuration(0)
+
+			changesetStub := &stubProposalChangeset{TimelockProposal: proposal}
+			loadChangesets := func(envName string) (*changeset.ChangesetsRegistry, error) {
+				rp := &registryProviderStub{
+					BaseRegistryProvider: changeset.NewBaseRegistryProvider(),
+					AddAction: func(reg *changeset.ChangesetsRegistry) {
+						reg.Add(changesetName, changeset.Configure(changesetStub).WithEnvInput())
+					},
+				}
+				if initErr := rp.Init(); initErr != nil {
+					return nil, initErr
+				}
+
+				return rp.Registry(), nil
+			}
+
+			cfg := &Config{
+				Logger:                logger.Test(t),
+				Domain:                testDomain,
+				LoadChangesets:        loadChangesets,
+				ConfigResolverManager: fresolvers.NewConfigResolverManager(),
+				Deps: Deps{
+					EnvironmentLoader: func(ctx context.Context, dom domain.Domain, envKey string, opts ...environment.LoadEnvironmentOption) (fdeployment.Environment, error) {
+						return fdeployment.Environment{}, nil
+					},
+					TimelockDelayCorrector: tt.corrector,
+				},
+			}
+
+			cmd, err := NewCommand(cfg)
+			require.NoError(t, err)
+
+			t.Setenv("DURABLE_PIPELINE_INPUT", `{"payload":{"chain":"optimism_sepolia","value":123456789012345678901234}}`)
+
+			cmd.SetArgs([]string{
+				"run",
+				"--environment", env,
+				"--changeset", changesetName,
+				"--input-file", yamlFileName,
+				"--dry-run",
+			})
+
+			err = cmd.Execute()
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tt.wantErr)
+				require.ErrorContains(t, err, tt.wantErrMsg)
+
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.checkSaved != nil {
+				tt.checkSaved(t, proposalsDir)
+			}
+		})
+	}
 }
 
 //nolint:paralleltest
@@ -812,6 +948,7 @@ var testProposal = lo.Must(mcms.NewTimelockProposalBuilder().
 	SetValidUntil(2082758399).
 	SetDescription("test timelock proposal").
 	SetOverridePreviousRoot(true).
+	SetDelay(mcmstypes.NewDuration(time.Hour)).
 	SetAction(mcmstypes.TimelockActionSchedule).
 	AddTimelockAddress(mcmstypes.ChainSelector(chainsel.GETH_TESTNET.Selector), "0xTimelockAddress").
 	AddChainMetadata(mcmstypes.ChainSelector(chainsel.GETH_TESTNET.Selector), mcmstypes.ChainMetadata{MCMAddress: "0xMCMAddress"}).

--- a/engine/cld/mcms/timelockdelay/correct.go
+++ b/engine/cld/mcms/timelockdelay/correct.go
@@ -1,0 +1,126 @@
+package timelockdelay
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/smartcontractkit/mcms"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger"
+)
+
+// MinDelayLookup reads on-chain minDelay for one timelock chain entry.
+type MinDelayLookup func(
+	ctx context.Context,
+	proposal *mcms.TimelockProposal,
+	chainSelector uint64,
+	timelockAddress string,
+) (mcmstypes.Duration, error)
+
+// CorrectTimelockDelays updates schedule proposal delays using on-chain minDelay from blockChains.
+// Unset or too-low delays are bumped to the max on-chain minDelay across timelock chains when
+// minDelay can be read for every timelock chain. An unset delay fails the call if any chain
+// cannot be read or on-chain minDelay is zero. An explicitly set delay is left unchanged when
+// on-chain minDelay cannot be verified.
+func CorrectTimelockDelays(
+	ctx context.Context,
+	lggr logger.Logger,
+	blockChains chain.BlockChains,
+	proposals []mcms.TimelockProposal,
+) error {
+	lookup := func(
+		ctx context.Context,
+		proposal *mcms.TimelockProposal,
+		chainSelector uint64,
+		timelockAddress string,
+	) (mcmstypes.Duration, error) {
+		return readTimelockMinDelay(ctx, blockChains, proposal, chainSelector, timelockAddress)
+	}
+
+	return CorrectTimelockDelaysWithLookup(ctx, lggr, proposals, lookup)
+}
+
+// CorrectTimelockDelaysWithLookup is like CorrectTimelockDelays but accepts a custom lookup (for tests).
+func CorrectTimelockDelaysWithLookup(
+	ctx context.Context,
+	lggr logger.Logger,
+	proposals []mcms.TimelockProposal,
+	lookup MinDelayLookup,
+) error {
+	for i := range proposals {
+		if err := correctProposalDelay(ctx, lggr, lookup, &proposals[i]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func correctProposalDelay(
+	ctx context.Context,
+	lggr logger.Logger,
+	lookup MinDelayLookup,
+	proposal *mcms.TimelockProposal,
+) error {
+	if proposal == nil || proposal.Action != mcmstypes.TimelockActionSchedule {
+		return nil
+	}
+
+	unsetDelay := proposal.Delay.Duration <= 0
+
+	if len(proposal.TimelockAddresses) == 0 {
+		if unsetDelay {
+			return fmt.Errorf("%w: no timelock addresses in proposal", ErrUnsetTimelockDelayUnverified)
+		}
+		lggr.Warnw("skipping timelock delay correction: no timelock addresses in proposal",
+			"action", proposal.Action,
+		)
+
+		return nil
+	}
+
+	chainDelays, verifyErrors := readChainMinDelaysWithLookup(ctx, lookup, proposal)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	verifyErrMsg := strings.Join(verifyErrors, "; ")
+
+	if len(verifyErrors) > 0 {
+		lggr.Warnw("unable to verify on-chain minDelay for timelock delay correction",
+			"errors", verifyErrMsg,
+		)
+		if unsetDelay {
+			return fmt.Errorf("%w: %s", ErrUnsetTimelockDelayUnverified, verifyErrMsg)
+		}
+
+		return nil
+	}
+
+	maxMinDelay := MaxMinDelay(chainDelays)
+	if maxMinDelay.Duration <= 0 {
+		if unsetDelay {
+			lggr.Warnw("on-chain minDelay is zero on all timelock chains; cannot resolve unset proposal delay")
+			return fmt.Errorf("%w: on-chain minDelay is zero on all timelock chains", ErrUnsetTimelockDelayUnverified)
+		}
+
+		return nil
+	}
+
+	originalDelay := proposal.Delay
+	if originalDelay.Duration > 0 && originalDelay.Duration >= maxMinDelay.Duration {
+		return nil
+	}
+
+	proposal.Delay = maxMinDelay
+
+	lggr.Infow("corrected timelock proposal delay to on-chain minDelay",
+		"originalDelay", originalDelay.String(),
+		"correctedDelay", maxMinDelay.String(),
+	)
+
+	return nil
+}

--- a/engine/cld/mcms/timelockdelay/correct_test.go
+++ b/engine/cld/mcms/timelockdelay/correct_test.go
@@ -1,0 +1,336 @@
+package timelockdelay
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/smartcontractkit/mcms"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger"
+)
+
+func TestMaxMinDelay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input []ChainDelay
+		want  mcmstypes.Duration
+	}{
+		{
+			name: "nil input",
+		},
+		{
+			name: "returns largest delay",
+			input: []ChainDelay{
+				{Selector: 1, MinDelay: mcmstypes.NewDuration(30 * time.Minute)},
+				{Selector: 2, MinDelay: mcmstypes.NewDuration(time.Hour)},
+			},
+			want: mcmstypes.NewDuration(time.Hour),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, MaxMinDelay(tt.input))
+		})
+	}
+}
+
+func TestDurationFromSeconds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		seconds uint64
+		want    mcmstypes.Duration
+		wantErr string
+	}{
+		{
+			name:    "converts seconds",
+			seconds: 3600,
+			want:    mcmstypes.NewDuration(time.Hour),
+		},
+		{
+			name:    "rejects overflow",
+			seconds: ^uint64(0),
+			wantErr: "exceeds representable duration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := durationFromSeconds(tt.seconds)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCorrectTimelockDelaysWithLookup(t *testing.T) {
+	t.Parallel()
+
+	minDelay := mcmstypes.NewDuration(3 * time.Hour)
+	singleChainLookup := func(
+		_ context.Context,
+		_ *mcms.TimelockProposal,
+		chainSelector uint64,
+		_ string,
+	) (mcmstypes.Duration, error) {
+		if chainSelector != 1 {
+			return mcmstypes.Duration{}, errors.New("unexpected chain")
+		}
+
+		return minDelay, nil
+	}
+	multiChainLookup := func(
+		_ context.Context,
+		_ *mcms.TimelockProposal,
+		chainSelector uint64,
+		_ string,
+	) (mcmstypes.Duration, error) {
+		switch chainSelector {
+		case 1:
+			return mcmstypes.NewDuration(time.Hour), nil
+		case 2:
+			return minDelay, nil
+		default:
+			return mcmstypes.Duration{}, errors.New("unexpected chain")
+		}
+	}
+	failingLookup := func(
+		_ context.Context,
+		_ *mcms.TimelockProposal,
+		_ uint64,
+		_ string,
+	) (mcmstypes.Duration, error) {
+		return mcmstypes.Duration{}, errors.New("rpc unavailable")
+	}
+	partialLookup := func(
+		_ context.Context,
+		_ *mcms.TimelockProposal,
+		chainSelector uint64,
+		_ string,
+	) (mcmstypes.Duration, error) {
+		if chainSelector == 1 {
+			return mcmstypes.NewDuration(time.Hour), nil
+		}
+
+		return mcmstypes.Duration{}, errors.New("rpc unavailable")
+	}
+	zeroLookup := func(
+		_ context.Context,
+		_ *mcms.TimelockProposal,
+		_ uint64,
+		_ string,
+	) (mcmstypes.Duration, error) {
+		return mcmstypes.NewDuration(0), nil
+	}
+
+	tests := []struct {
+		name      string
+		proposal  func() mcms.TimelockProposal
+		lookup    MinDelayLookup
+		contextFn func(t *testing.T) context.Context
+		wantErr   error
+		wantDelay mcmstypes.Duration
+	}{
+		{
+			name:      "fills unset delay",
+			proposal:  func() mcms.TimelockProposal { return scheduleProposal(mcmstypes.NewDuration(0)) },
+			lookup:    singleChainLookup,
+			wantDelay: minDelay,
+		},
+		{
+			name:      "uses max minDelay across chains",
+			proposal:  func() mcms.TimelockProposal { return scheduleMultiChainProposal(mcmstypes.NewDuration(0)) },
+			lookup:    multiChainLookup,
+			wantDelay: minDelay,
+		},
+		{
+			name:      "bumps delay below minDelay",
+			proposal:  func() mcms.TimelockProposal { return scheduleProposal(mcmstypes.NewDuration(time.Hour)) },
+			lookup:    singleChainLookup,
+			wantDelay: minDelay,
+		},
+		{
+			name:      "leaves sufficient delay unchanged",
+			proposal:  func() mcms.TimelockProposal { return scheduleProposal(mcmstypes.NewDuration(4 * time.Hour)) },
+			lookup:    singleChainLookup,
+			wantDelay: mcmstypes.NewDuration(4 * time.Hour),
+		},
+		{
+			name: "skips bypass proposals",
+			proposal: func() mcms.TimelockProposal {
+				proposal := scheduleProposal(mcmstypes.NewDuration(0))
+				proposal.Action = mcmstypes.TimelockActionBypass
+
+				return proposal
+			},
+			lookup:    singleChainLookup,
+			wantDelay: mcmstypes.NewDuration(0),
+		},
+		{
+			name:      "rpc failure with unset delay returns error",
+			proposal:  func() mcms.TimelockProposal { return scheduleProposal(mcmstypes.NewDuration(0)) },
+			lookup:    failingLookup,
+			wantErr:   ErrUnsetTimelockDelayUnverified,
+			wantDelay: mcmstypes.NewDuration(0),
+		},
+		{
+			name:      "rpc failure with explicit delay leaves proposal unchanged",
+			proposal:  func() mcms.TimelockProposal { return scheduleProposal(mcmstypes.NewDuration(time.Hour)) },
+			lookup:    failingLookup,
+			wantDelay: mcmstypes.NewDuration(time.Hour),
+		},
+		{
+			name:      "partial rpc failure with unset delay returns error",
+			proposal:  func() mcms.TimelockProposal { return scheduleMultiChainProposal(mcmstypes.NewDuration(0)) },
+			lookup:    partialLookup,
+			wantErr:   ErrUnsetTimelockDelayUnverified,
+			wantDelay: mcmstypes.NewDuration(0),
+		},
+		{
+			name:      "zero on-chain minDelay with unset delay returns error",
+			proposal:  func() mcms.TimelockProposal { return scheduleProposal(mcmstypes.NewDuration(0)) },
+			lookup:    zeroLookup,
+			wantErr:   ErrUnsetTimelockDelayUnverified,
+			wantDelay: mcmstypes.NewDuration(0),
+		},
+		{
+			name:      "context cancellation with explicit delay returns error",
+			proposal:  func() mcms.TimelockProposal { return scheduleProposal(mcmstypes.NewDuration(time.Hour)) },
+			lookup:    singleChainLookup,
+			contextFn: cancelledTestContext,
+			wantErr:   context.Canceled,
+			wantDelay: mcmstypes.NewDuration(time.Hour),
+		},
+		{
+			name:      "context cancellation with unset delay returns error",
+			proposal:  func() mcms.TimelockProposal { return scheduleProposal(mcmstypes.NewDuration(0)) },
+			lookup:    singleChainLookup,
+			contextFn: cancelledTestContext,
+			wantErr:   context.Canceled,
+			wantDelay: mcmstypes.NewDuration(0),
+		},
+		{
+			name: "no timelock addresses with unset delay returns error",
+			proposal: func() mcms.TimelockProposal {
+				proposal := scheduleProposal(mcmstypes.NewDuration(0))
+				proposal.TimelockAddresses = nil
+
+				return proposal
+			},
+			lookup:  singleChainLookup,
+			wantErr: ErrUnsetTimelockDelayUnverified,
+		},
+		{
+			name: "no timelock addresses with explicit delay leaves proposal unchanged",
+			proposal: func() mcms.TimelockProposal {
+				proposal := scheduleProposal(mcmstypes.NewDuration(time.Hour))
+				proposal.TimelockAddresses = nil
+
+				return proposal
+			},
+			lookup:    singleChainLookup,
+			wantDelay: mcmstypes.NewDuration(time.Hour),
+		},
+		{
+			name:      "zero on-chain minDelay with explicit delay leaves proposal unchanged",
+			proposal:  func() mcms.TimelockProposal { return scheduleProposal(mcmstypes.NewDuration(time.Hour)) },
+			lookup:    zeroLookup,
+			wantDelay: mcmstypes.NewDuration(time.Hour),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testContext(t)
+			if tt.contextFn != nil {
+				ctx = tt.contextFn(t)
+			}
+
+			proposals := []mcms.TimelockProposal{tt.proposal()}
+			err := CorrectTimelockDelaysWithLookup(ctx, logger.Test(t), proposals, tt.lookup)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.wantDelay, proposals[0].Delay)
+		})
+	}
+}
+
+func TestCorrectTimelockDelays(t *testing.T) {
+	t.Parallel()
+
+	proposal := scheduleProposal(mcmstypes.NewDuration(0))
+	proposals := []mcms.TimelockProposal{proposal}
+
+	err := CorrectTimelockDelays(t.Context(), logger.Test(t), chain.NewBlockChains(nil), proposals)
+	require.ErrorIs(t, err, ErrUnsetTimelockDelayUnverified)
+	require.Equal(t, mcmstypes.NewDuration(0), proposals[0].Delay)
+}
+
+func scheduleProposal(delay mcmstypes.Duration) mcms.TimelockProposal {
+	return mcms.TimelockProposal{
+		BaseProposal: mcms.BaseProposal{
+			ChainMetadata: map[mcmstypes.ChainSelector]mcmstypes.ChainMetadata{
+				1: {MCMAddress: "0xMCMS"},
+			},
+		},
+		Action: mcmstypes.TimelockActionSchedule,
+		Delay:  delay,
+		TimelockAddresses: map[mcmstypes.ChainSelector]string{
+			1: "0xTimelock",
+		},
+		Operations: []mcmstypes.BatchOperation{{
+			ChainSelector: 1,
+			Transactions:  []mcmstypes.Transaction{{To: "0xTo"}},
+		}},
+	}
+}
+
+func scheduleMultiChainProposal(delay mcmstypes.Duration) mcms.TimelockProposal {
+	return mcms.TimelockProposal{
+		BaseProposal: mcms.BaseProposal{
+			ChainMetadata: map[mcmstypes.ChainSelector]mcmstypes.ChainMetadata{
+				1: {MCMAddress: "0xMCMS1"},
+				2: {MCMAddress: "0xMCMS2"},
+			},
+		},
+		Action: mcmstypes.TimelockActionSchedule,
+		Delay:  delay,
+		TimelockAddresses: map[mcmstypes.ChainSelector]string{
+			1: "0xTimelock1",
+			2: "0xTimelock2",
+		},
+		Operations: []mcmstypes.BatchOperation{
+			{
+				ChainSelector: 1,
+				Transactions:  []mcmstypes.Transaction{{To: "0xTo1"}},
+			},
+			{
+				ChainSelector: 2,
+				Transactions:  []mcmstypes.Transaction{{To: "0xTo2"}},
+			},
+		},
+	}
+}

--- a/engine/cld/mcms/timelockdelay/errors.go
+++ b/engine/cld/mcms/timelockdelay/errors.go
@@ -1,0 +1,7 @@
+package timelockdelay
+
+import "errors"
+
+// ErrUnsetTimelockDelayUnverified indicates a schedule proposal has no delay set and
+// on-chain minDelay could not be read for every timelock chain.
+var ErrUnsetTimelockDelayUnverified = errors.New("timelock delay unset and unable to resolve from on-chain minDelay")

--- a/engine/cld/mcms/timelockdelay/helpers_test.go
+++ b/engine/cld/mcms/timelockdelay/helpers_test.go
@@ -1,0 +1,21 @@
+package timelockdelay
+
+import (
+	"context"
+	"testing"
+)
+
+func testContext(t *testing.T) context.Context {
+	t.Helper()
+
+	return t.Context()
+}
+
+func cancelledTestContext(t *testing.T) context.Context {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	return ctx
+}

--- a/engine/cld/mcms/timelockdelay/read.go
+++ b/engine/cld/mcms/timelockdelay/read.go
@@ -1,0 +1,184 @@
+package timelockdelay
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/smartcontractkit/mcms"
+	mcmschainwrappers "github.com/smartcontractkit/mcms/chainwrappers"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldfmcmsadapters "github.com/smartcontractkit/chainlink-deployments-framework/chain/mcms/adapters"
+)
+
+// ChainDelay captures on-chain minDelay for one timelock chain.
+type ChainDelay struct {
+	Selector uint64
+	MinDelay mcmstypes.Duration
+}
+
+type timelockChainEntry struct {
+	selector uint64
+	address  string
+}
+
+// ReadChainMinDelays reads on-chain minDelay for each timelock address in the proposal.
+// Returns per-chain delays and verify error messages for chains that could not be read.
+func ReadChainMinDelays(
+	ctx context.Context,
+	blockChains chain.BlockChains,
+	proposal *mcms.TimelockProposal,
+) ([]ChainDelay, []string) {
+	lookup := func(
+		ctx context.Context,
+		proposal *mcms.TimelockProposal,
+		chainSelector uint64,
+		timelockAddress string,
+	) (mcmstypes.Duration, error) {
+		return readTimelockMinDelay(ctx, blockChains, proposal, chainSelector, timelockAddress)
+	}
+
+	return readChainMinDelaysWithLookup(ctx, lookup, proposal)
+}
+
+func readChainMinDelaysWithLookup(
+	ctx context.Context,
+	lookup MinDelayLookup,
+	proposal *mcms.TimelockProposal,
+) ([]ChainDelay, []string) {
+	entries := sortedTimelockEntries(proposal)
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	type chainResult struct {
+		delay  ChainDelay
+		errMsg string
+	}
+
+	results := make([]chainResult, len(entries))
+
+	var wg sync.WaitGroup
+	wg.Add(len(entries))
+	for i, entry := range entries {
+		go func(i int, entry timelockChainEntry) {
+			defer wg.Done()
+
+			if err := ctx.Err(); err != nil {
+				results[i].errMsg = fmt.Sprintf("chain %d (%s): %v", entry.selector, entry.address, err)
+
+				return
+			}
+
+			minDelay, err := lookup(ctx, proposal, entry.selector, entry.address)
+			if err != nil {
+				results[i].errMsg = fmt.Sprintf("chain %d (%s): %v", entry.selector, entry.address, err)
+
+				return
+			}
+			results[i].delay = ChainDelay{Selector: entry.selector, MinDelay: minDelay}
+		}(i, entry)
+	}
+	wg.Wait()
+
+	chainDelays := make([]ChainDelay, 0, len(entries))
+	verifyErrors := make([]string, 0)
+	for _, result := range results {
+		if result.errMsg != "" {
+			verifyErrors = append(verifyErrors, result.errMsg)
+
+			continue
+		}
+		chainDelays = append(chainDelays, result.delay)
+	}
+
+	return chainDelays, verifyErrors
+}
+
+// MaxMinDelay returns the largest minDelay across chains.
+func MaxMinDelay(chainDelays []ChainDelay) mcmstypes.Duration {
+	var maxMinDelay mcmstypes.Duration
+	for _, entry := range chainDelays {
+		if entry.MinDelay.Duration > maxMinDelay.Duration {
+			maxMinDelay = entry.MinDelay
+		}
+	}
+
+	return maxMinDelay
+}
+
+func sortedTimelockEntries(proposal *mcms.TimelockProposal) []timelockChainEntry {
+	if proposal == nil || len(proposal.TimelockAddresses) == 0 {
+		return nil
+	}
+
+	selectors := make([]uint64, 0, len(proposal.TimelockAddresses))
+	for selector := range proposal.TimelockAddresses {
+		selectors = append(selectors, uint64(selector))
+	}
+	sort.Slice(selectors, func(i, j int) bool { return selectors[i] < selectors[j] })
+
+	entries := make([]timelockChainEntry, len(selectors))
+	for i, selector := range selectors {
+		entries[i] = timelockChainEntry{
+			selector: selector,
+			address:  proposal.TimelockAddresses[mcmstypes.ChainSelector(selector)],
+		}
+	}
+
+	return entries
+}
+
+func readTimelockMinDelay(
+	ctx context.Context,
+	blockChains chain.BlockChains,
+	proposal *mcms.TimelockProposal,
+	chainSelector uint64,
+	timelockAddress string,
+) (mcmstypes.Duration, error) {
+	chainAccessor := cldfmcmsadapters.Wrap(blockChains)
+	metadata := chainMetadataForInspector(proposal, chainSelector)
+
+	inspector, err := mcmschainwrappers.BuildTimelockInspector(
+		&chainAccessor,
+		mcmstypes.ChainSelector(chainSelector),
+		metadata,
+	)
+	if err != nil {
+		return mcmstypes.Duration{}, err
+	}
+
+	minDelaySec, err := inspector.GetMinDelay(ctx, timelockAddress)
+	if err != nil {
+		return mcmstypes.Duration{}, err
+	}
+
+	return durationFromSeconds(minDelaySec)
+}
+
+func chainMetadataForInspector(proposal *mcms.TimelockProposal, chainSelector uint64) mcmstypes.ChainMetadata {
+	if proposal == nil || len(proposal.ChainMetadata) == 0 {
+		return mcmstypes.ChainMetadata{}
+	}
+
+	metadata, ok := proposal.ChainMetadata[mcmstypes.ChainSelector(chainSelector)]
+	if !ok {
+		return mcmstypes.ChainMetadata{}
+	}
+
+	return metadata
+}
+
+func durationFromSeconds(seconds uint64) (mcmstypes.Duration, error) {
+	maxSeconds := uint64(math.MaxInt64 / int64(time.Second))
+	if seconds > maxSeconds {
+		return mcmstypes.Duration{}, fmt.Errorf("min delay %d seconds exceeds representable duration", seconds)
+	}
+
+	return mcmstypes.NewDuration(time.Duration(seconds) * time.Second), nil
+}

--- a/engine/cld/mcms/timelockdelay/read_test.go
+++ b/engine/cld/mcms/timelockdelay/read_test.go
@@ -1,0 +1,173 @@
+package timelockdelay
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/smartcontractkit/mcms"
+	mcmstypes "github.com/smartcontractkit/mcms/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+)
+
+func TestReadChainMinDelays(t *testing.T) {
+	t.Parallel()
+
+	minDelay := mcmstypes.NewDuration(2 * time.Hour)
+	singleChainLookup := func(
+		_ context.Context,
+		_ *mcms.TimelockProposal,
+		chainSelector uint64,
+		_ string,
+	) (mcmstypes.Duration, error) {
+		if chainSelector != 1 {
+			return mcmstypes.Duration{}, errors.New("unexpected chain")
+		}
+
+		return minDelay, nil
+	}
+
+	tests := []struct {
+		name            string
+		contextFn       func(t *testing.T) context.Context
+		read            func(ctx context.Context, proposal *mcms.TimelockProposal) ([]ChainDelay, []string)
+		wantDelays      []ChainDelay
+		wantVerifyCount int
+		verifyContains  string
+	}{
+		{
+			name:      "returns verify errors when chain is unavailable",
+			contextFn: testContext,
+			read: func(ctx context.Context, proposal *mcms.TimelockProposal) ([]ChainDelay, []string) {
+				return ReadChainMinDelays(ctx, chain.NewBlockChains(nil), proposal)
+			},
+			wantVerifyCount: 1,
+			verifyContains:  "chain 1",
+		},
+		{
+			name:      "reads delays via lookup",
+			contextFn: testContext,
+			read: func(ctx context.Context, proposal *mcms.TimelockProposal) ([]ChainDelay, []string) {
+				return readChainMinDelaysWithLookup(ctx, singleChainLookup, proposal)
+			},
+			wantDelays: []ChainDelay{{Selector: 1, MinDelay: minDelay}},
+		},
+		{
+			name:      "returns context error when context is cancelled",
+			contextFn: cancelledTestContext,
+			read: func(ctx context.Context, proposal *mcms.TimelockProposal) ([]ChainDelay, []string) {
+				return readChainMinDelaysWithLookup(ctx, singleChainLookup, proposal)
+			},
+			wantVerifyCount: 1,
+			verifyContains:  context.Canceled.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := tt.contextFn(t)
+
+			proposal := scheduleProposal(mcmstypes.NewDuration(0))
+			delays, verifyErrors := tt.read(ctx, &proposal)
+
+			if tt.wantDelays != nil {
+				require.Equal(t, tt.wantDelays, delays)
+			} else {
+				require.Empty(t, delays)
+			}
+			require.Len(t, verifyErrors, tt.wantVerifyCount)
+			if tt.verifyContains != "" {
+				require.Contains(t, verifyErrors[0], tt.verifyContains)
+			}
+		})
+	}
+}
+
+func TestSortedTimelockEntries(t *testing.T) {
+	t.Parallel()
+
+	multiChainProposal := scheduleMultiChainProposal(mcmstypes.NewDuration(0))
+
+	tests := []struct {
+		name     string
+		proposal *mcms.TimelockProposal
+		wantLen  int
+		want     []timelockChainEntry
+	}{
+		{
+			name:     "nil proposal",
+			proposal: nil,
+		},
+		{
+			name:     "empty timelock addresses",
+			proposal: &mcms.TimelockProposal{},
+		},
+		{
+			name:     "sorts selectors",
+			proposal: &multiChainProposal,
+			wantLen:  2,
+			want: []timelockChainEntry{
+				{selector: 1, address: "0xTimelock1"},
+				{selector: 2, address: "0xTimelock2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			entries := sortedTimelockEntries(tt.proposal)
+			require.Len(t, entries, tt.wantLen)
+			require.Equal(t, tt.want, entries)
+		})
+	}
+}
+
+func TestChainMetadataForInspector(t *testing.T) {
+	t.Parallel()
+
+	proposal := scheduleProposal(mcmstypes.NewDuration(0))
+
+	tests := []struct {
+		name          string
+		proposal      *mcms.TimelockProposal
+		chainSelector uint64
+		want          mcmstypes.ChainMetadata
+	}{
+		{
+			name:          "nil proposal",
+			proposal:      nil,
+			chainSelector: 1,
+		},
+		{
+			name:          "empty chain metadata",
+			proposal:      &mcms.TimelockProposal{},
+			chainSelector: 1,
+		},
+		{
+			name:          "known selector",
+			proposal:      &proposal,
+			chainSelector: 1,
+			want:          mcmstypes.ChainMetadata{MCMAddress: "0xMCMS"},
+		},
+		{
+			name:          "unknown selector",
+			proposal:      &proposal,
+			chainSelector: 99,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, chainMetadataForInspector(tt.proposal, tt.chainSelector))
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/smartcontractkit/freeport v0.1.3-0.20250828155247-add56fa28aad
 	github.com/smartcontractkit/go-daml v0.0.0-20260615231356-88c6ee9b5774
 	github.com/smartcontractkit/libocr v0.0.0-20260304194147-a03701e2c02e
-	github.com/smartcontractkit/mcms v0.50.1
+	github.com/smartcontractkit/mcms v0.51.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -719,8 +719,8 @@ github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 h1:12i
 github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7/go.mod h1:FX7/bVdoep147QQhsOPkYsPEXhGZjeYx6lBSaSXtZOA=
 github.com/smartcontractkit/libocr v0.0.0-20260304194147-a03701e2c02e h1:poXTj5cFVM6XfC4HICIDYkDVc/A6OYB0eeID0wU2JQE=
 github.com/smartcontractkit/libocr v0.0.0-20260304194147-a03701e2c02e/go.mod h1:PLdNK6GlqfxIWXzziPkU7dCAVlVFeYkyyW7AQY0R+4Q=
-github.com/smartcontractkit/mcms v0.50.1 h1:WtzIO/eH14MaLEL0khh+Ifadlo8RQjRBYD4aNb9HXSQ=
-github.com/smartcontractkit/mcms v0.50.1/go.mod h1:L8XXsBRCDWjFKsMNvZdgDsaptDtoGkuK1ciP0Ui4OR8=
+github.com/smartcontractkit/mcms v0.51.0 h1:RA1qe2ltzgAiYlQu5WvfPX7sqCf21g/9qCgBOW2Hmqs=
+github.com/smartcontractkit/mcms v0.51.0/go.mod h1:L8XXsBRCDWjFKsMNvZdgDsaptDtoGkuK1ciP0Ui4OR8=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=


### PR DESCRIPTION
## Summary

Correct schedule proposal timelock delays during durable-pipeline `run`, immediately after changeset Apply and before proposals are persisted.

- Add `engine/cld/mcms/timelockdelay` to read on-chain `minDelay` per timelock chain (parallel RPC reads) and bump unset/too-low delays to the max across chains
- Relax `MCMSTimelockProposalInput.Validate()` to allow zero delay for schedule actions; durable-pipeline resolves it when every timelock chain is readable
- Fail the pipeline when delay is unset and on-chain verification fails; warn and continue when the author set an explicit delay but RPC verification fails

Closes [CLD-3058](https://smartcontract-it.atlassian.net/browse/CLD-3058).

## Timelock delay correction behaviour

Applies only to **schedule** proposals (`TimelockActionSchedule`). Non-schedule actions are skipped.

| Proposal delay | On-chain verification | Pipeline | Resulting delay |
|---|---|---|---|
| Unset (≤0) | All chains OK, `max(minDelay) > 0` | Continue | Set to `max(minDelay)` across timelock chains |
| Unset (≤0) | Any RPC/read failure | **Fail** (`ErrUnsetTimelockDelayUnverified`) | Unchanged |
| Unset (≤0) | All OK but `max(minDelay) = 0` | **Fail** (`ErrUnsetTimelockDelayUnverified`) | Unchanged |
| Unset (≤0) | No timelock addresses in proposal | **Fail** (`ErrUnsetTimelockDelayUnverified`) | Unchanged |
| Explicit, below `max(minDelay)` | All chains OK, `max(minDelay) > 0` | Continue | Set to `max(minDelay)` |
| Explicit, ≥ `max(minDelay)` | All chains OK | Continue | Unchanged |
| Explicit (any value) | Any RPC/read failure | Continue (warn) | Unchanged |
| Explicit (any value) | No timelock addresses | Continue (warn) | Unchanged |
| Explicit (any value) | All OK but `max(minDelay) = 0` | Continue | Unchanged |

**Rationale:** An unset delay cannot be safely inferred without on-chain verification, so any verification failure is a hard error. An explicit delay was author-chosen; if RPC fails we warn and leave it unchanged rather than block the pipeline.
