### PR TITLE
fix: scaffolding

### DIFF
--- a/.changeset/wacky-dolls-tap.md
+++ b/.changeset/wacky-dolls-tap.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+Fix domain scaffolding: the generated `cmd/main.go` hardcoded the `chainlink-deployments` repo in its self import while `go.mod` derived the module path from `{{.repo}}`.

--- a/engine/cld/scaffold/templates/cmd_main.go.tmpl
+++ b/engine/cld/scaffold/templates/cmd_main.go.tmpl
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/smartcontractkit/chainlink-deployments/domains/{{.package}}/cmd/internal/cli"
+	"github.com/smartcontractkit/{{.repo}}/domains/{{.package}}/cmd/internal/cli"
 )
 
 func main() {


### PR DESCRIPTION
This pull request fixes an issue with domain scaffolding in the deployment framework. Previously, the generated `cmd/main.go` file incorrectly hardcoded the `chainlink-deployments` repository in its import path.