### PR TITLE
feat(evm): per-chain gas config with automatic retry boosting

### DIFF
--- a/.changeset/silent-onions-leave.md
+++ b/.changeset/silent-onions-leave.md
@@ -1,0 +1,6 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat(evm): per-chain gas config with automatic retry boosting
+

--- a/chain/evm/evm_chain.go
+++ b/chain/evm/evm_chain.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zksync-sdk/zksync2-go/accounts"
 	"github.com/zksync-sdk/zksync2-go/clients"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	chaincommon "github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/common"
 	"github.com/smartcontractkit/chainlink-deployments-framework/internal/pointer"
 )
@@ -50,6 +51,9 @@ type Chain struct {
 	// SignHash allows signing of arbitrary hashes using the deployer key's signing mechanism.
 	// This function signature matches the expected format: func([]byte) ([]byte, error)
 	SignHash func([]byte) ([]byte, error)
+
+	// GasConfig holds per-chain default gas settings and optional retry boost configuration.
+	GasConfig *gas.Config
 
 	// ZK deployment specifics
 	IsZkSyncVM          bool

--- a/chain/evm/gas/apply.go
+++ b/chain/evm/gas/apply.go
@@ -1,0 +1,114 @@
+package gas
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// Client exposes the RPC methods required to apply gas price defaults.
+type Client interface {
+	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
+	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
+}
+
+// ApplyDefaults applies configured default gas limit and price settings to opts.
+// When DefaultGasPriceWei is set, the latest block header is inspected to choose EIP-1559 vs legacy.
+func ApplyDefaults(ctx context.Context, client Client, opts *bind.TransactOpts, cfg Config) error {
+	if opts == nil {
+		return errors.New("transact opts are nil")
+	}
+
+	if cfg.DefaultGasLimit > 0 {
+		opts.GasLimit = cfg.DefaultGasLimit
+	}
+
+	if cfg.DefaultGasPriceWei == 0 {
+		return nil
+	}
+
+	return applyGasPrice(ctx, client, opts, weiToBigInt(cfg.DefaultGasPriceWei), weiToBigInt(cfg.DefaultGasTipCapWei))
+}
+
+// applyGasPrice checks the latest block header to determine whether the chain supports EIP-1559.
+// When tipOverride is non-nil it is used as GasTipCap instead of SuggestGasTipCap.
+func applyGasPrice(ctx context.Context, client Client, opts *bind.TransactOpts, gasPrice, tipOverride *big.Int) error {
+	header, err := client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get latest header: %w", err)
+	}
+
+	if header.BaseFee != nil {
+		var tip *big.Int
+		if tipOverride != nil {
+			tip = tipOverride
+		} else {
+			tip, err = client.SuggestGasTipCap(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to get suggested tip cap: %w", err)
+			}
+			if gasPrice != nil && gasPrice.Cmp(tip) < 0 {
+				tip = new(big.Int).Set(gasPrice)
+			}
+		}
+		opts.GasPrice = nil
+		opts.GasTipCap = tip
+		opts.GasFeeCap = gasPrice
+	} else {
+		applyLegacyGasPrice(opts, gasPrice)
+	}
+
+	return nil
+}
+
+func applyLegacyGasPrice(opts *bind.TransactOpts, gasPrice *big.Int) {
+	opts.GasPrice = gasPrice
+	opts.GasFeeCap = nil
+	opts.GasTipCap = nil
+}
+
+// ApplyBoostOverrides returns a copy of base with gas limit and price overrides applied.
+// When gasPriceWei is non-zero on an EIP-1559 chain, gasPriceWei is used as GasFeeCap and
+// the existing GasTipCap on base is preserved when set.
+func ApplyBoostOverrides(
+	ctx context.Context,
+	client Client,
+	base *bind.TransactOpts,
+	gasLimit, gasPriceWei uint64,
+) (*bind.TransactOpts, error) {
+	if base == nil {
+		return nil, errors.New("transact opts are nil")
+	}
+	if gasLimit == 0 && gasPriceWei == 0 {
+		return base, nil
+	}
+
+	opts := *base
+	if gasLimit > 0 {
+		opts.GasLimit = gasLimit
+	}
+	if gasPriceWei == 0 {
+		return &opts, nil
+	}
+
+	gasPrice := weiToBigInt(gasPriceWei)
+	if client == nil {
+		applyLegacyGasPrice(&opts, gasPrice)
+		return &opts, nil
+	}
+
+	if err := applyGasPrice(ctx, client, &opts, gasPrice, opts.GasTipCap); err != nil {
+		return nil, err
+	}
+
+	return &opts, nil
+}
+
+// IsEIP1559Header reports whether the header indicates EIP-1559 support.
+func IsEIP1559Header(header *types.Header) bool {
+	return header != nil && header.BaseFee != nil
+}

--- a/chain/evm/gas/baseline.go
+++ b/chain/evm/gas/baseline.go
@@ -1,0 +1,48 @@
+package gas
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+)
+
+// BaselineFromTransactOpts returns the gas limit and price (legacy GasPrice or EIP-1559 GasFeeCap)
+// currently set on the deployer transactor. Used as the starting point for boost retries after
+// an attempt with zero overrides.
+func BaselineFromTransactOpts(opts *bind.TransactOpts) (limit, priceWei uint64) {
+	if opts == nil {
+		return 0, 0
+	}
+
+	limit = opts.GasLimit
+	priceWei = weiFromBigInt(opts.GasFeeCap)
+	if priceWei == 0 {
+		priceWei = weiFromBigInt(opts.GasPrice)
+	}
+
+	return limit, priceWei
+}
+
+// ResolveBoostPreviousGas returns the gas values to bump from, preferring explicit overrides
+// from the last attempt and falling back to deployer baseline when overrides were zero.
+func ResolveBoostPreviousGas(previousLimit, previousPrice, baselineLimit, baselinePrice uint64) (uint64, uint64) {
+	prevLimit := previousLimit
+	if prevLimit == 0 {
+		prevLimit = baselineLimit
+	}
+
+	prevPrice := previousPrice
+	if prevPrice == 0 {
+		prevPrice = baselinePrice
+	}
+
+	return prevLimit, prevPrice
+}
+
+func weiFromBigInt(v *big.Int) uint64 {
+	if v == nil || v.Sign() <= 0 || !v.IsUint64() {
+		return 0
+	}
+
+	return v.Uint64()
+}

--- a/chain/evm/gas/boost.go
+++ b/chain/evm/gas/boost.go
@@ -1,0 +1,53 @@
+package gas
+
+import "context"
+
+// ExecuteWithBoost retries fn on gas-related errors, bumping gas limit and price between attempts.
+// The first attempt uses zero overrides so the chain deployer's default settings apply.
+// baselineLimit and baselinePriceWei should reflect DeployerKey gas after ApplyDefaults; they
+// ensure the first retry increases from those values instead of reset boost.initial_* defaults.
+// When cfg is nil or isZkSyncVM is true, fn is invoked once without gas adjustment.
+func ExecuteWithBoost[T any](
+	ctx context.Context,
+	isZkSyncVM bool,
+	cfg *BoostConfig,
+	baselineLimit, baselinePriceWei uint64,
+	fn func(gasLimit, gasPriceWei uint64) (T, error),
+) (T, error) {
+	var zero T
+	if cfg == nil || isZkSyncVM {
+		return fn(0, 0)
+	}
+
+	boostCfg := *cfg
+	maxAttempts := boostCfg.maxAttempts()
+
+	var (
+		result      T
+		err         error
+		gasLimit    uint64
+		gasPriceWei uint64
+	)
+
+	for attempt := range maxAttempts {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return zero, ctxErr
+		}
+
+		result, err = fn(gasLimit, gasPriceWei)
+		if err == nil {
+			return result, nil
+		}
+		if !IsRetryable(err) {
+			return zero, err
+		}
+		if attempt+1 >= maxAttempts {
+			break
+		}
+
+		prevLimit, prevPrice := ResolveBoostPreviousGas(gasLimit, gasPriceWei, baselineLimit, baselinePriceWei)
+		gasLimit, gasPriceWei = NextBoostedGas(boostCfg, attempt, prevLimit, prevPrice)
+	}
+
+	return zero, err
+}

--- a/chain/evm/gas/config.go
+++ b/chain/evm/gas/config.go
@@ -1,0 +1,101 @@
+package gas
+
+import (
+	"math/big"
+)
+
+const (
+	defaultInitialGasLimit   = uint64(5_000_000)
+	defaultGasLimitIncrement = uint64(500_000)
+	defaultInitialGasPrice   = uint64(20_000_000_000)
+	defaultGasPriceIncrement = uint64(10_000_000_000)
+	defaultMaxAttempts       = uint(10)
+)
+
+// Config holds per-chain default gas settings and optional retry boost configuration.
+type Config struct {
+	DefaultGasLimit     uint64       `yaml:"default_gas_limit,omitempty" json:"defaultGasLimit,omitempty"`
+	DefaultGasPriceWei  uint64       `yaml:"default_gas_price_wei,omitempty" json:"defaultGasPriceWei,omitempty"`
+	DefaultGasTipCapWei uint64       `yaml:"default_gas_tip_cap_wei,omitempty" json:"defaultGasTipCapWei,omitempty"`
+	Boost               *BoostConfig `yaml:"boost,omitempty" json:"boost,omitempty"`
+}
+
+// BoostConfig defines gas limit and price increments applied on transaction retries.
+// Increment fields use pointers so zero is a valid configured value (no increment).
+type BoostConfig struct {
+	InitialGasLimit   uint64  `yaml:"initial_gas_limit,omitempty" json:"initialGasLimit,omitempty"`
+	GasLimitIncrement *uint64 `yaml:"gas_limit_increment,omitempty" json:"gasLimitIncrement,omitempty"`
+	InitialGasPrice   uint64  `yaml:"initial_gas_price_wei,omitempty" json:"initialGasPrice,omitempty"`
+	GasPriceIncrement *uint64 `yaml:"gas_price_increment,omitempty" json:"gasPriceIncrement,omitempty"`
+	MaxAttempts       uint    `yaml:"max_attempts,omitempty" json:"maxAttempts,omitempty"`
+}
+
+func (cfg BoostConfig) gasLimitIncrement() uint64 {
+	if cfg.GasLimitIncrement == nil {
+		return defaultGasLimitIncrement
+	}
+
+	return *cfg.GasLimitIncrement
+}
+
+func (cfg BoostConfig) gasPriceIncrement() uint64 {
+	if cfg.GasPriceIncrement == nil {
+		return defaultGasPriceIncrement
+	}
+
+	return *cfg.GasPriceIncrement
+}
+
+func (cfg BoostConfig) maxAttempts() uint {
+	if cfg.MaxAttempts > 0 {
+		return cfg.MaxAttempts
+	}
+
+	return defaultMaxAttempts
+}
+
+func resolveInitialGasLimit(cfg BoostConfig) uint64 {
+	if cfg.InitialGasLimit > 0 {
+		return cfg.InitialGasLimit
+	}
+
+	return defaultInitialGasLimit
+}
+
+func resolveInitialGasPrice(cfg BoostConfig) uint64 {
+	if cfg.InitialGasPrice > 0 {
+		return cfg.InitialGasPrice
+	}
+
+	return defaultInitialGasPrice
+}
+
+// NextBoostedGas returns the gas limit and legacy gas price for the given retry attempt.
+func NextBoostedGas(cfg BoostConfig, attempt uint, previousLimit, previousPrice uint64) (gasLimit uint64, gasPrice uint64) {
+	initialGasLimit := resolveInitialGasLimit(cfg)
+	gasLimitIncrement := cfg.gasLimitIncrement()
+	initialGasPrice := resolveInitialGasPrice(cfg)
+	gasPriceIncrement := cfg.gasPriceIncrement()
+
+	if previousLimit > 0 {
+		gasLimit = previousLimit + gasLimitIncrement
+	} else {
+		gasLimit = initialGasLimit + uint64(attempt)*gasLimitIncrement
+	}
+
+	if previousPrice > 0 {
+		gasPrice = previousPrice + gasPriceIncrement
+	} else {
+		gasPrice = initialGasPrice + uint64(attempt)*gasPriceIncrement
+	}
+
+	return gasLimit, gasPrice
+}
+
+func weiToBigInt(wei uint64) *big.Int {
+	if wei == 0 {
+		return nil
+	}
+
+	return new(big.Int).SetUint64(wei)
+}

--- a/chain/evm/gas/errors.go
+++ b/chain/evm/gas/errors.go
@@ -1,0 +1,48 @@
+package gas
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+// IsRetryable reports whether err indicates a gas-related failure that may succeed with higher gas.
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, vm.ErrOutOfGas) ||
+		errors.Is(err, vm.ErrCodeStoreOutOfGas) ||
+		errors.Is(err, core.ErrIntrinsicGas) ||
+		errors.Is(err, core.ErrFeeCapTooLow) ||
+		errors.Is(err, core.ErrGasLimitReached) ||
+		errors.Is(err, txpool.ErrUnderpriced) ||
+		errors.Is(err, txpool.ErrReplaceUnderpriced) ||
+		errors.Is(err, txpool.ErrTxGasPriceTooLow) ||
+		errors.Is(err, txpool.ErrGasLimit) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+	for _, pattern := range retryableErrorPatterns {
+		if strings.Contains(msg, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+var retryableErrorPatterns = []string{
+	"out of gas",
+	"gas required exceeds allowance",
+	"intrinsic gas too low",
+	"underpriced",
+	"replacement transaction underpriced",
+	"max fee per gas less than block base fee",
+	"exceeds block gas limit",
+}

--- a/chain/evm/gas/gas_test.go
+++ b/chain/evm/gas/gas_test.go
@@ -1,0 +1,281 @@
+package gas_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
+)
+
+func TestNextBoostedGas(t *testing.T) {
+	t.Parallel()
+
+	limit, price := gas.NextBoostedGas(gas.BoostConfig{}, 0, 0, 0)
+	require.Equal(t, uint64(5_000_000), limit)
+	require.Equal(t, uint64(20_000_000_000), price)
+
+	limit, price = gas.NextBoostedGas(gas.BoostConfig{}, 2, 0, 0)
+	require.Equal(t, uint64(6_000_000), limit)
+	require.Equal(t, uint64(40_000_000_000), price)
+
+	inc := uint64(100_000)
+	limit, price = gas.NextBoostedGas(gas.BoostConfig{
+		InitialGasLimit:   1_000_000,
+		GasLimitIncrement: &inc,
+		InitialGasPrice:   5_000_000_000,
+		GasPriceIncrement: ptrUint64(1_000_000_000),
+	}, 3, 0, 0)
+	require.Equal(t, uint64(1_300_000), limit)
+	require.Equal(t, uint64(8_000_000_000), price)
+
+	limit, price = gas.NextBoostedGas(gas.BoostConfig{}, 5, 4_000_000, 30_000_000_000)
+	require.Equal(t, uint64(4_500_000), limit)
+	require.Equal(t, uint64(40_000_000_000), price)
+}
+
+func TestIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, gas.IsRetryable(nil))
+	require.False(t, gas.IsRetryable(errors.New("invalid constructor args")))
+	require.True(t, gas.IsRetryable(errors.New("out of gas: gas required exceeds allowance")))
+	require.True(t, gas.IsRetryable(errors.New("transaction underpriced")))
+	require.True(t, gas.IsRetryable(vm.ErrOutOfGas))
+	require.True(t, gas.IsRetryable(fmt.Errorf("send failed: %w", txpool.ErrUnderpriced)))
+	require.True(t, gas.IsRetryable(fmt.Errorf("deploy failed: %w", core.ErrFeeCapTooLow)))
+}
+
+func TestApplyDefaults_LegacyChain(t *testing.T) {
+	t.Parallel()
+	mockClient := evm.NewMockOnchainClient(t)
+	mockClient.EXPECT().HeaderByNumber(mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{BaseFee: nil}, nil)
+
+	opts := &bind.TransactOpts{}
+	err := gas.ApplyDefaults(t.Context(), mockClient, opts, gas.Config{
+		DefaultGasPriceWei: 50_000_000_000,
+		DefaultGasLimit:    5_000_000,
+	})
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(50_000_000_000), opts.GasPrice)
+	require.Equal(t, uint64(5_000_000), opts.GasLimit)
+	require.Nil(t, opts.GasTipCap)
+	require.Nil(t, opts.GasFeeCap)
+}
+
+func TestApplyDefaults_EIP1559Chain(t *testing.T) {
+	t.Parallel()
+	mockClient := evm.NewMockOnchainClient(t)
+	mockClient.EXPECT().HeaderByNumber(mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{BaseFee: big.NewInt(100)}, nil)
+	mockClient.EXPECT().SuggestGasTipCap(mock.Anything).
+		Return(big.NewInt(1_000_000_000), nil)
+
+	opts := &bind.TransactOpts{}
+	err := gas.ApplyDefaults(t.Context(), mockClient, opts, gas.Config{
+		DefaultGasPriceWei: 50_000_000_000,
+		DefaultGasLimit:    5_000_000,
+	})
+	require.NoError(t, err)
+	require.Nil(t, opts.GasPrice)
+	require.Equal(t, big.NewInt(1_000_000_000), opts.GasTipCap)
+	require.Equal(t, big.NewInt(50_000_000_000), opts.GasFeeCap)
+	require.Equal(t, uint64(5_000_000), opts.GasLimit)
+}
+
+func TestApplyDefaults_GasLimitOnly(t *testing.T) {
+	t.Parallel()
+	mockClient := evm.NewMockOnchainClient(t)
+
+	opts := &bind.TransactOpts{}
+	err := gas.ApplyDefaults(t.Context(), mockClient, opts, gas.Config{
+		DefaultGasLimit: 10_000_000,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(10_000_000), opts.GasLimit)
+	require.Nil(t, opts.GasPrice)
+}
+
+func TestApplyDefaults_EIP1559WithTipOverride(t *testing.T) {
+	t.Parallel()
+	mockClient := evm.NewMockOnchainClient(t)
+	mockClient.EXPECT().HeaderByNumber(mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{BaseFee: big.NewInt(100)}, nil)
+
+	opts := &bind.TransactOpts{}
+	err := gas.ApplyDefaults(t.Context(), mockClient, opts, gas.Config{
+		DefaultGasPriceWei:  100_000_000_000,
+		DefaultGasTipCapWei: 40_000_000_000,
+	})
+	require.NoError(t, err)
+	require.Nil(t, opts.GasPrice)
+	require.Equal(t, big.NewInt(40_000_000_000), opts.GasTipCap)
+	require.Equal(t, big.NewInt(100_000_000_000), opts.GasFeeCap)
+}
+
+func TestExecuteWithBoost(t *testing.T) {
+	t.Parallel()
+
+	failures := 2
+	var gasLimits []uint64
+	cfg := gas.BoostConfig{
+		InitialGasLimit:   1_000_000,
+		GasLimitIncrement: ptrUint64(100_000),
+	}
+
+	result, err := gas.ExecuteWithBoost(t.Context(), false, &cfg, 0, 0,
+		func(gasLimit, _ uint64) (uint64, error) {
+			gasLimits = append(gasLimits, gasLimit)
+			if failures > 0 {
+				failures--
+				return 0, errors.New("out of gas")
+			}
+
+			return gasLimit, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1_100_000), result)
+	require.Equal(t, []uint64{0, 1_000_000, 1_100_000}, gasLimits)
+}
+
+func TestExecuteWithBoostSkipsZkSync(t *testing.T) {
+	t.Parallel()
+
+	var gasLimits []uint64
+	_, err := gas.ExecuteWithBoost(t.Context(), true, &gas.BoostConfig{}, 0, 0,
+		func(gasLimit, _ uint64) (struct{}, error) {
+			gasLimits = append(gasLimits, gasLimit)
+			return struct{}{}, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{0}, gasLimits)
+}
+
+func TestBaselineFromTransactOpts(t *testing.T) {
+	t.Parallel()
+
+	limit, price := gas.BaselineFromTransactOpts(nil)
+	require.Equal(t, uint64(0), limit)
+	require.Equal(t, uint64(0), price)
+
+	limit, price = gas.BaselineFromTransactOpts(&bind.TransactOpts{
+		GasLimit: 7_500_000,
+		GasPrice: big.NewInt(210_000_000_000),
+	})
+	require.Equal(t, uint64(7_500_000), limit)
+	require.Equal(t, uint64(210_000_000_000), price)
+
+	limit, price = gas.BaselineFromTransactOpts(&bind.TransactOpts{
+		GasLimit:  5_000_000,
+		GasFeeCap: big.NewInt(100_000_000_000),
+		GasTipCap: big.NewInt(40_000_000_000),
+	})
+	require.Equal(t, uint64(5_000_000), limit)
+	require.Equal(t, uint64(100_000_000_000), price)
+}
+
+func TestResolveBoostPreviousGas(t *testing.T) {
+	t.Parallel()
+
+	limit, price := gas.ResolveBoostPreviousGas(0, 0, 7_500_000, 210_000_000_000)
+	require.Equal(t, uint64(7_500_000), limit)
+	require.Equal(t, uint64(210_000_000_000), price)
+
+	limit, price = gas.ResolveBoostPreviousGas(8_000_000, 220_000_000_000, 7_500_000, 210_000_000_000)
+	require.Equal(t, uint64(8_000_000), limit)
+	require.Equal(t, uint64(220_000_000_000), price)
+}
+
+func TestExecuteWithBoostFromBaseline(t *testing.T) {
+	t.Parallel()
+
+	var gasLimits []uint64
+	cfg := gas.BoostConfig{
+		GasLimitIncrement: ptrUint64(500_000),
+		GasPriceIncrement: ptrUint64(10_000_000_000),
+	}
+
+	result, err := gas.ExecuteWithBoost(t.Context(), false, &cfg, 7_500_000, 210_000_000_000,
+		func(gasLimit, _ uint64) (uint64, error) {
+			gasLimits = append(gasLimits, gasLimit)
+			if len(gasLimits) == 1 {
+				return 0, errors.New("out of gas")
+			}
+
+			return gasLimit, nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(8_000_000), result)
+	require.Equal(t, []uint64{0, 8_000_000}, gasLimits)
+}
+
+func TestApplyBoostOverrides_PreservesEIP1559Tip(t *testing.T) {
+	t.Parallel()
+
+	mockClient := evm.NewMockOnchainClient(t)
+	mockClient.EXPECT().HeaderByNumber(mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{BaseFee: big.NewInt(100)}, nil)
+
+	base := &bind.TransactOpts{
+		GasLimit:  5_000_000,
+		GasFeeCap: big.NewInt(100_000_000_000),
+		GasTipCap: big.NewInt(40_000_000_000),
+	}
+
+	opts, err := gas.ApplyBoostOverrides(t.Context(), mockClient, base, 0, 110_000_000_000)
+	require.NoError(t, err)
+	require.Equal(t, big.NewInt(40_000_000_000), opts.GasTipCap)
+	require.Equal(t, big.NewInt(110_000_000_000), opts.GasFeeCap)
+	require.Nil(t, opts.GasPrice)
+}
+
+func TestApplyBoostOverrides_NilClient(t *testing.T) {
+	t.Parallel()
+
+	base := &bind.TransactOpts{
+		GasLimit:  21_000,
+		GasFeeCap: big.NewInt(100),
+		GasTipCap: big.NewInt(2),
+	}
+
+	opts, err := gas.ApplyBoostOverrides(t.Context(), nil, base, 750_000, 25_000_000_000)
+	require.NoError(t, err)
+	require.Equal(t, uint64(750_000), opts.GasLimit)
+	require.Equal(t, uint64(25_000_000_000), opts.GasPrice.Uint64())
+	require.Nil(t, opts.GasFeeCap)
+	require.Nil(t, opts.GasTipCap)
+}
+
+func TestExecuteWithBoostRespectsContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	cfg := gas.BoostConfig{InitialGasLimit: 1_000_000}
+	_, err := gas.ExecuteWithBoost(ctx, false, &cfg, 0, 0,
+		func(_, _ uint64) (struct{}, error) {
+			return struct{}{}, errors.New("out of gas")
+		},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func ptrUint64(v uint64) *uint64 {
+	return &v
+}

--- a/chain/evm/operations2/contract/deploy.go
+++ b/chain/evm/operations2/contract/deploy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zksync-sdk/zksync2-go/clients"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
@@ -139,13 +140,52 @@ func NewDeploy[ARGS any](params DeployParams[ARGS]) *operations.Operation[Deploy
 					args...,
 				)
 			} else {
-				addr, tx, _, deployErr = deployEVMContract(
-					transactOptsWithGasOverrides(chain.DeployerKey, input.GasLimit, input.GasPrice),
-					*parsedABI,
-					bytecode.EVM,
-					chain.Client,
-					args...,
-				)
+				runDeploy := func(gasLimit, gasPrice uint64) (common.Address, *types.Transaction, error) {
+					opts, optsErr := transactOptsWithGasOverrides(b.GetContext(), chain, chain.DeployerKey, gasLimit, gasPrice)
+					if optsErr != nil {
+						return common.Address{}, nil, optsErr
+					}
+					a, t, _, derr := deployEVMContract(
+						opts,
+						*parsedABI,
+						bytecode.EVM,
+						chain.Client,
+						args...,
+					)
+
+					return a, t, derr
+				}
+
+				if shouldAutoGasBoost(chain, input.GasLimit, input.GasPrice) {
+					baselineLimit, baselinePriceWei := gas.BaselineFromTransactOpts(chain.DeployerKey)
+					type deployResult struct {
+						addr common.Address
+						tx   *types.Transaction
+					}
+					result, boostErr := gas.ExecuteWithBoost(
+						b.GetContext(),
+						chain.IsZkSyncVM,
+						chain.GasConfig.Boost,
+						baselineLimit,
+						baselinePriceWei,
+						func(gasLimit, gasPrice uint64) (deployResult, error) {
+							a, t, derr := runDeploy(gasLimit, gasPrice)
+							if derr != nil {
+								return deployResult{}, derr
+							}
+
+							return deployResult{addr: a, tx: t}, nil
+						},
+					)
+					if boostErr != nil {
+						deployErr = boostErr
+					} else {
+						addr = result.addr
+						tx = result.tx
+					}
+				} else {
+					addr, tx, deployErr = runDeploy(input.GasLimit, input.GasPrice)
+				}
 			}
 			if !chain.IsZkSyncVM {
 				if deployErr == nil && tx == nil {

--- a/chain/evm/operations2/contract/gas_boost.go
+++ b/chain/evm/operations2/contract/gas_boost.go
@@ -1,35 +1,19 @@
 package contract
 
 import (
-	"errors"
-	"math/big"
-	"strings"
+	"context"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/txpool"
-	"github.com/ethereum/go-ethereum/core/vm"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-)
-
-const (
-	defaultInitialGasLimit   = uint64(5_000_000)
-	defaultGasLimitIncrement = uint64(500_000)
-	defaultInitialGasPrice   = uint64(20_000_000_000)
-	defaultGasPriceIncrement = uint64(10_000_000_000)
 )
 
 // GasBoostConfig defines gas limit and price increments applied on deploy retries.
 // Increment fields use pointers so zero is a valid configured value (no increment).
 // A nil increment pointer uses the package default increment.
-type GasBoostConfig struct {
-	InitialGasLimit   uint64  `json:"initialGasLimit"`
-	GasLimitIncrement *uint64 `json:"gasLimitIncrement,omitempty"`
-	InitialGasPrice   uint64  `json:"initialGasPrice"`
-	GasPriceIncrement *uint64 `json:"gasPriceIncrement,omitempty"`
-}
+type GasBoostConfig = gas.BoostConfig
 
 // GasOverridable is implemented by operation inputs that carry optional gas overrides.
 type GasOverridable[IN any] interface {
@@ -74,12 +58,14 @@ func RetryWithGasBoost[IN GasOverridable[IN]](cfg *GasBoostConfig) operations.Ex
 	c := *cfg
 
 	return operations.WithRetryInput(func(attempt uint, err error, in IN, deps evm.Chain) IN {
-		if deps.IsZkSyncVM || !isGasRetryableError(err) {
+		if deps.IsZkSyncVM || !gas.IsRetryable(err) {
 			return in
 		}
 
 		gasLimit, gasPrice := in.GasBoostValues()
-		gasLimit, gasPrice = nextBoostedGas(c, attempt, gasLimit, gasPrice)
+		baselineLimit, baselinePrice := gas.BaselineFromTransactOpts(deps.DeployerKey)
+		prevLimit, prevPrice := gas.ResolveBoostPreviousGas(gasLimit, gasPrice, baselineLimit, baselinePrice)
+		gasLimit, gasPrice = gas.NextBoostedGas(c, attempt, prevLimit, prevPrice)
 
 		return in.WithGasBoost(gasLimit, gasPrice)
 	})
@@ -98,114 +84,25 @@ func RetryWriteWithGasBoost[ARGS any](cfg *GasBoostConfig) operations.ExecuteOpt
 	return RetryWithGasBoost[FunctionInput[ARGS]](cfg)
 }
 
-func (cfg GasBoostConfig) gasLimitIncrement() uint64 {
-	if cfg.GasLimitIncrement == nil {
-		return defaultGasLimitIncrement
-	}
-
-	return *cfg.GasLimitIncrement
-}
-
-func (cfg GasBoostConfig) gasPriceIncrement() uint64 {
-	if cfg.GasPriceIncrement == nil {
-		return defaultGasPriceIncrement
-	}
-
-	return *cfg.GasPriceIncrement
-}
-
-func resolveInitialGasLimit(cfg GasBoostConfig) uint64 {
-	if cfg.InitialGasLimit > 0 {
-		return cfg.InitialGasLimit
-	}
-
-	return defaultInitialGasLimit
-}
-
-func resolveInitialGasPrice(cfg GasBoostConfig) uint64 {
-	if cfg.InitialGasPrice > 0 {
-		return cfg.InitialGasPrice
-	}
-
-	return defaultInitialGasPrice
-}
-
-func nextBoostedGas(cfg GasBoostConfig, attempt uint, previousLimit, previousPrice uint64) (gasLimit uint64, gasPrice uint64) {
-	initialGasLimit := resolveInitialGasLimit(cfg)
-	gasLimitIncrement := cfg.gasLimitIncrement()
-	initialGasPrice := resolveInitialGasPrice(cfg)
-	gasPriceIncrement := cfg.gasPriceIncrement()
-
-	if previousLimit > 0 {
-		gasLimit = previousLimit + gasLimitIncrement
-	} else {
-		gasLimit = initialGasLimit + uint64(attempt)*gasLimitIncrement
-	}
-
-	if previousPrice > 0 {
-		gasPrice = previousPrice + gasPriceIncrement
-	} else {
-		gasPrice = initialGasPrice + uint64(attempt)*gasPriceIncrement
-	}
-
-	return gasLimit, gasPrice
-}
-
-func isGasRetryableError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	if errors.Is(err, vm.ErrOutOfGas) ||
-		errors.Is(err, vm.ErrCodeStoreOutOfGas) ||
-		errors.Is(err, core.ErrIntrinsicGas) ||
-		errors.Is(err, core.ErrFeeCapTooLow) ||
-		errors.Is(err, core.ErrGasLimitReached) ||
-		errors.Is(err, txpool.ErrUnderpriced) ||
-		errors.Is(err, txpool.ErrReplaceUnderpriced) ||
-		errors.Is(err, txpool.ErrTxGasPriceTooLow) ||
-		errors.Is(err, txpool.ErrGasLimit) {
-		return true
-	}
-
-	msg := strings.ToLower(err.Error())
-	for _, pattern := range gasRetryableErrorPatterns {
-		if strings.Contains(msg, pattern) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// gasRetryableErrorPatterns covers RPC and wrapped errors that no longer carry geth sentinels.
-var gasRetryableErrorPatterns = []string{
-	"out of gas",
-	"gas required exceeds allowance",
-	"intrinsic gas too low",
-	"underpriced",
-	"replacement transaction underpriced",
-	"max fee per gas less than block base fee",
-	"exceeds block gas limit",
-}
-
-func transactOptsWithGasOverrides(base *bind.TransactOpts, gasLimit, gasPrice uint64) *bind.TransactOpts {
-	if base == nil {
-		return nil
-	}
+func transactOptsWithGasOverrides(
+	ctx context.Context,
+	chain evm.Chain,
+	base *bind.TransactOpts,
+	gasLimit, gasPrice uint64,
+) (*bind.TransactOpts, error) {
 	if gasLimit == 0 && gasPrice == 0 {
-		return base
+		return base, nil
 	}
 
-	opts := *base
-	if gasLimit > 0 {
-		opts.GasLimit = gasLimit
-	}
-	if gasPrice > 0 {
-		opts.GasPrice = new(big.Int).SetUint64(gasPrice)
-		opts.GasFeeCap = nil
-		opts.GasTipCap = nil
-	}
+	return gas.ApplyBoostOverrides(ctx, chain.Client, base, gasLimit, gasPrice)
+}
 
-	return &opts
+func shouldAutoGasBoost(chain evm.Chain, gasLimit, gasPrice uint64) bool {
+	// A non-nil Boost pointer (including boost: {} in YAML) enables the inner retry loop.
+	// Use RetryDeployWithGasBoost for an additional outer operations-level retry; when both
+	// are active, outer retries set input gas overrides and disable this auto path.
+	return chain.GasConfig != nil &&
+		chain.GasConfig.Boost != nil &&
+		gasLimit == 0 &&
+		gasPrice == 0
 }

--- a/chain/evm/operations2/contract/gas_boost_test.go
+++ b/chain/evm/operations2/contract/gas_boost_test.go
@@ -10,10 +10,13 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations/optest"
 )
@@ -21,15 +24,15 @@ import (
 func TestNextBoostedGas(t *testing.T) {
 	t.Parallel()
 
-	limit, price := nextBoostedGas(GasBoostConfig{}, 0, 0, 0)
+	limit, price := gas.NextBoostedGas(gas.BoostConfig{}, 0, 0, 0)
 	require.Equal(t, uint64(5_000_000), limit)
 	require.Equal(t, uint64(20_000_000_000), price)
 
-	limit, price = nextBoostedGas(GasBoostConfig{}, 2, 0, 0)
+	limit, price = gas.NextBoostedGas(gas.BoostConfig{}, 2, 0, 0)
 	require.Equal(t, uint64(6_000_000), limit)
 	require.Equal(t, uint64(40_000_000_000), price)
 
-	limit, price = nextBoostedGas(GasBoostConfig{
+	limit, price = gas.NextBoostedGas(gas.BoostConfig{
 		InitialGasLimit:   1_000_000,
 		GasLimitIncrement: ptrUint64(100_000),
 		InitialGasPrice:   5_000_000_000,
@@ -38,12 +41,12 @@ func TestNextBoostedGas(t *testing.T) {
 	require.Equal(t, uint64(1_300_000), limit)
 	require.Equal(t, uint64(8_000_000_000), price)
 
-	limit, price = nextBoostedGas(GasBoostConfig{}, 5, 4_000_000, 30_000_000_000)
+	limit, price = gas.NextBoostedGas(gas.BoostConfig{}, 5, 4_000_000, 30_000_000_000)
 	require.Equal(t, uint64(4_500_000), limit)
 	require.Equal(t, uint64(40_000_000_000), price)
 
 	zeroInc := uint64(0)
-	limit, price = nextBoostedGas(GasBoostConfig{
+	limit, price = gas.NextBoostedGas(gas.BoostConfig{
 		GasLimitIncrement: &zeroInc,
 		GasPriceIncrement: &zeroInc,
 	}, 1, 2_000_000, 10_000_000_000)
@@ -54,17 +57,13 @@ func TestNextBoostedGas(t *testing.T) {
 func TestIsGasRetryableError(t *testing.T) {
 	t.Parallel()
 
-	require.False(t, isGasRetryableError(nil))
-	require.False(t, isGasRetryableError(errors.New("invalid constructor args")))
-
-	// String fallback for RPC / simulation messages.
-	require.True(t, isGasRetryableError(errors.New("out of gas: gas required exceeds allowance")))
-	require.True(t, isGasRetryableError(errors.New("transaction underpriced")))
-
-	// geth sentinels via errors.Is.
-	require.True(t, isGasRetryableError(vm.ErrOutOfGas))
-	require.True(t, isGasRetryableError(fmt.Errorf("send failed: %w", txpool.ErrUnderpriced)))
-	require.True(t, isGasRetryableError(fmt.Errorf("deploy failed: %w", core.ErrFeeCapTooLow)))
+	require.False(t, gas.IsRetryable(nil))
+	require.False(t, gas.IsRetryable(errors.New("invalid constructor args")))
+	require.True(t, gas.IsRetryable(errors.New("out of gas: gas required exceeds allowance")))
+	require.True(t, gas.IsRetryable(errors.New("transaction underpriced")))
+	require.True(t, gas.IsRetryable(vm.ErrOutOfGas))
+	require.True(t, gas.IsRetryable(fmt.Errorf("send failed: %w", txpool.ErrUnderpriced)))
+	require.True(t, gas.IsRetryable(fmt.Errorf("deploy failed: %w", core.ErrFeeCapTooLow)))
 }
 
 func TestTransactOptsWithGasOverrides(t *testing.T) {
@@ -76,22 +75,35 @@ func TestTransactOptsWithGasOverrides(t *testing.T) {
 		GasFeeCap: big.NewInt(100),
 		GasTipCap: big.NewInt(2),
 	}
+	mockClient := evm.NewMockOnchainClient(t)
+	chain := evm.Chain{Client: mockClient}
 
-	require.Nil(t, transactOptsWithGasOverrides(nil, 1, 1))
-	require.Same(t, base, transactOptsWithGasOverrides(base, 0, 0))
+	opts, err := transactOptsWithGasOverrides(t.Context(), chain, nil, 1, 1)
+	require.Error(t, err)
+	require.Nil(t, opts)
 
-	limitOnly := transactOptsWithGasOverrides(base, 500_000, 0)
+	same, err := transactOptsWithGasOverrides(t.Context(), chain, base, 0, 0)
+	require.NoError(t, err)
+	require.Same(t, base, same)
+
+	limitOnly, err := transactOptsWithGasOverrides(t.Context(), chain, base, 500_000, 0)
+	require.NoError(t, err)
 	require.Equal(t, uint64(500_000), limitOnly.GasLimit)
 	require.Equal(t, big.NewInt(1), limitOnly.GasPrice)
 	require.Equal(t, big.NewInt(100), limitOnly.GasFeeCap)
 
-	priceOnly := transactOptsWithGasOverrides(base, 0, 30_000_000_000)
-	require.Equal(t, uint64(21_000), priceOnly.GasLimit)
-	require.Equal(t, uint64(30_000_000_000), priceOnly.GasPrice.Uint64())
-	require.Nil(t, priceOnly.GasFeeCap)
-	require.Nil(t, priceOnly.GasTipCap)
+	mockClient.EXPECT().HeaderByNumber(mock.Anything, (*big.Int)(nil)).
+		Return(&types.Header{BaseFee: nil}, nil).Twice()
 
-	withGas := transactOptsWithGasOverrides(base, 500_000, 30_000_000_000)
+	legacyOnly, err := transactOptsWithGasOverrides(t.Context(), chain, base, 0, 30_000_000_000)
+	require.NoError(t, err)
+	require.Equal(t, uint64(21_000), legacyOnly.GasLimit)
+	require.Equal(t, uint64(30_000_000_000), legacyOnly.GasPrice.Uint64())
+	require.Nil(t, legacyOnly.GasFeeCap)
+	require.Nil(t, legacyOnly.GasTipCap)
+
+	withGas, err := transactOptsWithGasOverrides(t.Context(), chain, base, 500_000, 30_000_000_000)
+	require.NoError(t, err)
 	require.Equal(t, uint64(500_000), withGas.GasLimit)
 	require.Equal(t, uint64(30_000_000_000), withGas.GasPrice.Uint64())
 	require.Nil(t, withGas.GasFeeCap)
@@ -365,4 +377,57 @@ func TestRetryWriteWithGasBoostSkipsZkSync(t *testing.T) {
 	for _, limit := range gasLimits {
 		require.Equal(t, uint64(0), limit)
 	}
+}
+
+func TestShouldAutoGasBoost(t *testing.T) {
+	t.Parallel()
+
+	boost := &gas.BoostConfig{}
+	chainWithBoost := evm.Chain{
+		GasConfig: &gas.Config{Boost: boost},
+	}
+
+	require.True(t, shouldAutoGasBoost(chainWithBoost, 0, 0))
+	require.False(t, shouldAutoGasBoost(chainWithBoost, 1, 0))
+	require.False(t, shouldAutoGasBoost(chainWithBoost, 0, 1))
+	require.False(t, shouldAutoGasBoost(evm.Chain{}, 0, 0))
+	require.False(t, shouldAutoGasBoost(evm.Chain{GasConfig: &gas.Config{}}, 0, 0))
+}
+
+func TestRetryDeployWithGasBoostFromDeployerBaseline(t *testing.T) {
+	t.Parallel()
+
+	var gasLimits []uint64
+	op := operations.NewOperation(
+		"gas-boost-baseline",
+		semver.MustParse("1.0.0"),
+		"test",
+		func(_ operations.Bundle, _ evm.Chain, input DeployInput[struct{}]) (uint64, error) {
+			gasLimits = append(gasLimits, input.GasLimit)
+			if len(gasLimits) == 1 {
+				return 0, errors.New("out of gas")
+			}
+
+			return input.GasLimit, nil
+		},
+	)
+
+	cfg := &GasBoostConfig{GasLimitIncrement: ptrUint64(500_000)}
+	bundle := optest.NewBundle(t)
+	res, err := operations.ExecuteOperation(
+		bundle,
+		op,
+		evm.Chain{
+			Selector: 1,
+			DeployerKey: &bind.TransactOpts{
+				GasLimit: 7_500_000,
+				GasPrice: big.NewInt(210_000_000_000),
+			},
+		},
+		DeployInput[struct{}]{},
+		RetryDeployWithGasBoost[struct{}](cfg),
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint64(8_000_000), res.Output)
+	require.Equal(t, []uint64{0, 8_000_000}, gasLimits)
 }

--- a/chain/evm/operations2/contract/write.go
+++ b/chain/evm/operations2/contract/write.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/workflow/generated/workflow_registry_wrapper_v2"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
@@ -96,10 +97,41 @@ func NewWrite[ARGS any, C interface{ Address() common.Address }](params WritePar
 			}
 			opts := deployment.SimTransactOpts()
 			if allowed {
-				opts = transactOptsWithGasOverrides(chain.DeployerKey, input.GasLimit, input.GasPrice)
+				opts, err = transactOptsWithGasOverrides(b.GetContext(), chain, chain.DeployerKey, input.GasLimit, input.GasPrice)
+				if err != nil {
+					return WriteOutput{}, fmt.Errorf("failed to apply gas overrides for %s on %s: %w", params.Name, chain, err)
+				}
 			}
 			var execInfo *ExecInfo
-			tx, callErr := params.CallContract(params.Contract, opts, input.Args)
+			var tx *eth_types.Transaction
+			var callErr error
+
+			runWrite := func(gasLimit, gasPrice uint64) (*eth_types.Transaction, error) {
+				writeOpts, optsErr := transactOptsWithGasOverrides(b.GetContext(), chain, chain.DeployerKey, gasLimit, gasPrice)
+				if optsErr != nil {
+					return nil, optsErr
+				}
+
+				return params.CallContract(params.Contract, writeOpts, input.Args)
+			}
+
+			if allowed && shouldAutoGasBoost(chain, input.GasLimit, input.GasPrice) {
+				baselineLimit, baselinePriceWei := gas.BaselineFromTransactOpts(chain.DeployerKey)
+				tx, callErr = gas.ExecuteWithBoost(
+					b.GetContext(),
+					chain.IsZkSyncVM,
+					chain.GasConfig.Boost,
+					baselineLimit,
+					baselinePriceWei,
+					func(gasLimit, gasPrice uint64) (*eth_types.Transaction, error) {
+						return runWrite(gasLimit, gasPrice)
+					},
+				)
+			} else if allowed {
+				tx, callErr = runWrite(input.GasLimit, input.GasPrice)
+			} else {
+				tx, callErr = params.CallContract(params.Contract, opts, input.Args)
+			}
 			if callErr == nil && tx == nil {
 				return WriteOutput{}, fmt.Errorf("contract call returned nil transaction for %s against %s on %s", params.Name, params.Contract.Address(), chain)
 			}

--- a/chain/evm/provider/rpc_provider.go
+++ b/chain/evm/provider/rpc_provider.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider/rpcclient"
 )
 
@@ -40,6 +41,8 @@ type RPCChainProviderConfig struct {
 	// Optional: Logger is the logger to use for the RPCChainProvider. If not provided, a default
 	// logger will be used.
 	Logger logger.Logger
+	// Optional: GasConfig configures default gas limit/price and retry boost behavior for the chain.
+	GasConfig *gas.Config
 }
 
 // validate checks if the RPCChainProviderConfig is valid.
@@ -134,6 +137,12 @@ func (p *RPCChainProvider) Initialize(ctx context.Context) (chain.BlockChain, er
 		return nil, fmt.Errorf("failed to create multi-client: %w", err)
 	}
 
+	if p.config.GasConfig != nil {
+		if applyErr := gas.ApplyDefaults(ctx, client, deployerKey, *p.config.GasConfig); applyErr != nil {
+			return nil, fmt.Errorf("failed to apply gas defaults for chain %d: %w", p.selector, applyErr)
+		}
+	}
+
 	// Setup the confirm function
 	confirmFunc, err := p.config.ConfirmFunctor.Generate(
 		ctx, p.selector, client, deployerKey.From,
@@ -149,6 +158,7 @@ func (p *RPCChainProvider) Initialize(ctx context.Context) (chain.BlockChain, er
 		Users:       users,
 		Confirm:     confirmFunc,
 		SignHash:    p.config.DeployerTransactorGen.SignHash,
+		GasConfig:   p.config.GasConfig,
 	}
 
 	return *p.chain, nil

--- a/chain/evm/provider/rpcclient/multiclient.go
+++ b/chain/evm/provider/rpcclient/multiclient.go
@@ -142,6 +142,8 @@ func NewMultiClient(
 }
 
 // SendTransaction is a wrapper around the ethclient.SendTransaction method that retries on failure.
+// Gas bumping is not performed here because the transaction is already signed; use chain/evm/gas
+// at transaction build time to adjust gas limit and price before signing.
 func (mc *MultiClient) SendTransaction(ctx context.Context, tx *types.Transaction) error {
 	return mc.retryWithBackups(ctx, "SendTransaction", func(ct context.Context, client *ethclient.Client) error {
 		return client.SendTransaction(ct, tx)

--- a/chain/evm/provider/zksync_rpc_provider.go
+++ b/chain/evm/provider/zksync_rpc_provider.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider/rpcclient"
 )
 
@@ -45,6 +46,8 @@ type ZkSyncRPCChainProviderConfig struct {
 	// Optional: Logger is the logger to use for the RPCChainProvider. If not provided, a default
 	// logger will be used.
 	Logger logger.Logger
+	// Optional: GasConfig configures default gas limit/price for the chain.
+	GasConfig *gas.Config
 }
 
 // validate checks if the config is valid.
@@ -134,6 +137,13 @@ func (p *ZkSyncRPCChainProvider) Initialize(ctx context.Context) (chain.BlockCha
 		return nil, fmt.Errorf("failed to create multi-client: %w", err)
 	}
 
+	if p.config.GasConfig != nil {
+		// Applies EVM-style defaults to DeployerKey; ZkSync deployments use DeployerKeyZkSyncVM instead.
+		if applyErr := gas.ApplyDefaults(ctx, client, deployerKey, *p.config.GasConfig); applyErr != nil {
+			return nil, fmt.Errorf("failed to apply gas defaults for chain %d: %w", p.selector, applyErr)
+		}
+	}
+
 	// Setup the confirm function
 	confirmFunc, err := p.config.ConfirmFunctor.Generate(
 		ctx, p.selector, client, deployerKey.From,
@@ -160,6 +170,7 @@ func (p *ZkSyncRPCChainProvider) Initialize(ctx context.Context) (chain.BlockCha
 		DeployerKey:         deployerKey,
 		Confirm:             confirmFunc,
 		SignHash:            p.config.DeployerTransactorGen.SignHash,
+		GasConfig:           p.config.GasConfig,
 		IsZkSyncVM:          true,
 		ClientZkSyncVM:      clientZk,
 		DeployerKeyZkSyncVM: deployerKeyZkSyncVM,

--- a/engine/cld/chains/chains.go
+++ b/engine/cld/chains/chains.go
@@ -20,6 +20,7 @@ import (
 	cantonauthcode "github.com/smartcontractkit/chainlink-deployments-framework/chain/canton/provider/authentication/authorizationcode"
 	cantonclientcreds "github.com/smartcontractkit/chainlink-deployments-framework/chain/canton/provider/authentication/clientcredentials"
 	fevm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	evmgas "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	evmprov "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider"
 	evmclient "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider/rpcclient"
 	solanaprov "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana/provider"
@@ -535,6 +536,8 @@ func (l *chainLoaderEVM) Load(ctx context.Context, selector uint64) (fchain.Bloc
 		},
 	}
 
+	gasConfig := evmGasConfigFromNetwork(network)
+
 	var c fchain.BlockChain
 
 	// Use the zkSync RPC if the chain should be treated as a zkSync VM chain. Per-chain network config may
@@ -554,6 +557,7 @@ func (l *chainLoaderEVM) Load(ctx context.Context, selector uint64) (fchain.Bloc
 				ConfirmFunctor:        confirmFunctor,
 				ClientOpts:            clientOpts,
 				Logger:                l.lggr,
+				GasConfig:             gasConfig,
 			},
 		).Initialize(ctx)
 	} else {
@@ -564,6 +568,7 @@ func (l *chainLoaderEVM) Load(ctx context.Context, selector uint64) (fchain.Bloc
 				ConfirmFunctor:        confirmFunctor,
 				ClientOpts:            clientOpts,
 				Logger:                l.lggr,
+				GasConfig:             gasConfig,
 			},
 		).Initialize(ctx)
 	}
@@ -589,6 +594,19 @@ func (l *chainLoaderEVM) resolveIsZkSyncVM(network cfgnet.Network, selector uint
 	}
 
 	return l.isZkSyncVM(selector)
+}
+
+func evmGasConfigFromNetwork(network cfgnet.Network) *evmgas.Config {
+	if network.Metadata == nil {
+		return nil
+	}
+
+	md, err := cfgnet.DecodeMetadata[cfgnet.EVMMetadata](network.Metadata)
+	if err != nil || md.GasConfig == nil {
+		return nil
+	}
+
+	return md.GasConfig
 }
 
 // isZkSyncVM checks if the given chain selector corresponds to a zkSyncchain.

--- a/engine/cld/chains/chains_test.go
+++ b/engine/cld/chains/chains_test.go
@@ -1568,3 +1568,29 @@ func Test_chainLoaderEVM_resolveIsZkSyncVM(t *testing.T) {
 		})
 	}
 }
+
+func Test_evmGasConfigFromNetwork(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, evmGasConfigFromNetwork(cfgnet.Network{}))
+
+	network := cfgnet.Network{
+		Metadata: map[string]any{
+			"gas_config": map[string]any{
+				"default_gas_limit":     uint64(7_500_000),
+				"default_gas_price_wei": uint64(210_000_000_000),
+				"boost":                 map[string]any{},
+			},
+		},
+	}
+
+	cfg := evmGasConfigFromNetwork(network)
+	require.NotNil(t, cfg)
+	require.Equal(t, uint64(7_500_000), cfg.DefaultGasLimit)
+	require.Equal(t, uint64(210_000_000_000), cfg.DefaultGasPriceWei)
+	require.NotNil(t, cfg.Boost)
+
+	require.Nil(t, evmGasConfigFromNetwork(cfgnet.Network{
+		Metadata: map[string]any{"is_zksync": true},
+	}))
+}

--- a/engine/cld/config/network/metadata.go
+++ b/engine/cld/config/network/metadata.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 )
 
 // EVMMetadata is a struct that holds metadata specific to EVM networks.
@@ -13,7 +15,8 @@ type EVMMetadata struct {
 	// IsZkSync overrides the default VM classification for this chain. When set, it
 	// takes precedence over the hardcoded isZkSyncVM allowlist in the EVM chain loader.
 	// Set false to force the standard EVM deploy path on zkStack chains
-	IsZkSync *bool `yaml:"is_zksync,omitempty"`
+	IsZkSync  *bool       `yaml:"is_zksync,omitempty"`
+	GasConfig *gas.Config `yaml:"gas_config,omitempty"`
 }
 
 // StellarMetadata holds metadata specific to Stellar networks.


### PR DESCRIPTION
## Summary

Adds framework-level EVM gas configuration so domains can set per-chain defaults and automatic gas bumping via network YAML, instead of wrapping pipelines with[ ad-hoc gas overrides](https://github.com/smartcontractkit/chainlink-deployments/blob/6908cdff2162ee9ca0e83482e554b609109dee1f/domains/ccip/testnet/durable_pipelines.go#L805-L813).

- New `chain/evm/gas` package: `ApplyDefaults`, `ExecuteWithBoost`, EIP-1559 vs legacy handling, retryable gas error detection
- `gas_config` on `EVMMetadata` wired through chain loading into `evm.Chain.GasConfig`
- operations2 deploy/write auto-enable gas boost when `gas_config.boost` is present
- Boost retries bump from deployer baseline (post-`ApplyDefaults`), preserving EIP-1559 tip caps on retries

## YAML configuration

Add under a network entry's `metadata` block in `.config/networks/*.yaml`:

```yaml
metadata:
  gas_config:
    # Applied to DeployerKey at chain init (first tx attempt uses these)
    default_gas_limit: 7500000
    default_gas_price_wei: 210000000000   # legacy GasPrice or EIP-1559 max fee (wei)
    default_gas_tip_cap_wei: 40000000000    # optional; EIP-1559 priority fee (wei)

    # Enables automatic retry with gas bumps in operations2 deploy/write.
    # On retry, limit/price increase from the defaults above (+ increments below).
    # initial_* fields are optional fallbacks when no deployer baseline is set.
    boost:
      gas_limit_increment: 500000         # +500k per retry (default)
      gas_price_increment: 10000000000      # +10 gwei per retry (default)
      max_attempts: 10                      # optional; default 10
```

**Legacy chain example (WEMIX-style):**

```yaml
metadata:
  gas_config:
    default_gas_limit: 7500000
    default_gas_price_wei: 210000000000  # 210 gwei
    boost:
      gas_limit_increment: 500000
      gas_price_increment: 10000000000
```

First attempt: 7.5M limit @ 210 gwei. If it fails with a gas error, first retry: 8M @ 220 gwei, then 8.5M @ 230 gwei, etc.

**EIP-1559 chain example (Ronin-style):**

```yaml
metadata:
  gas_config:
    default_gas_price_wei: 100000000000   # max fee cap (100 gwei)
    default_gas_tip_cap_wei: 40000000000    # tip (40 gwei); preserved on boost retries
    boost:
      gas_limit_increment: 500000
      gas_price_increment: 10000000000
```

When `boost` is present, operations2 deploy/write retry on gas-related errors and increase limit/price before re-signing. ZkSync VM chains skip auto-boost (deploy uses `DeployerKeyZkSyncVM`).