### PR TITLE
feat(evm): per-chain gas defaults via network YAML

### DIFF
--- a/.changeset/evm-gas-config-defaults.md
+++ b/.changeset/evm-gas-config-defaults.md
@@ -1,0 +1,7 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat(evm): per-chain gas defaults via network YAML
+
+Adds `gas_config` to EVM network metadata so domains can set default gas limit and price on the chain deployer at load time. Replaces hardcoded framework chain tables and consumer-side gas override workarounds.

--- a/.changeset/evm-gas-config-defaults.md
+++ b/.changeset/evm-gas-config-defaults.md
@@ -4,4 +4,4 @@
 
 feat(evm): per-chain gas defaults via network YAML
 
-Adds `gas_config` to EVM network metadata so domains can set default gas limit and price on the chain deployer at load time. Replaces hardcoded framework chain tables and consumer-side gas override workarounds.
+Adds `gas_config` to EVM network metadata so domains can set default gas limit and price on the chain deployer at load time, and optionally cap deployer gas and `eth_estimateGas` via `max_tx_gas_limit`.

--- a/chain/evm/evm_chain.go
+++ b/chain/evm/evm_chain.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zksync-sdk/zksync2-go/accounts"
 	"github.com/zksync-sdk/zksync2-go/clients"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	chaincommon "github.com/smartcontractkit/chainlink-deployments-framework/chain/internal/common"
 	"github.com/smartcontractkit/chainlink-deployments-framework/internal/pointer"
 )
@@ -50,6 +51,11 @@ type Chain struct {
 	// SignHash allows signing of arbitrary hashes using the deployer key's signing mechanism.
 	// This function signature matches the expected format: func([]byte) ([]byte, error)
 	SignHash func([]byte) ([]byte, error)
+
+	// GasConfig holds per-chain default gas settings applied to DeployerKey at chain load.
+	// See chain/evm/gas.Config for YAML schema. On zkSync VM chains, deploys use
+	// DeployerKeyZkSyncVM and are not covered by these defaults.
+	GasConfig *gas.Config
 
 	// ZK deployment specifics
 	IsZkSyncVM          bool

--- a/chain/evm/gas/apply.go
+++ b/chain/evm/gas/apply.go
@@ -18,13 +18,14 @@ type Client interface {
 
 // ApplyDefaults applies configured default gas limit and price settings to opts.
 // When DefaultGasPriceWei is set, the latest block header is inspected to choose EIP-1559 vs legacy.
+// DefaultGasLimit is capped by MaxTxGasLimit when both are set.
 func ApplyDefaults(ctx context.Context, client Client, opts *bind.TransactOpts, cfg Config) error {
 	if opts == nil {
 		return errors.New("transact opts are nil")
 	}
 
 	if cfg.DefaultGasLimit > 0 {
-		opts.GasLimit = cfg.DefaultGasLimit
+		opts.GasLimit = CapGasLimit(cfg.DefaultGasLimit, cfg.MaxTxGasLimit)
 	}
 
 	if cfg.DefaultGasPriceWei == 0 {

--- a/chain/evm/gas/apply.go
+++ b/chain/evm/gas/apply.go
@@ -1,0 +1,95 @@
+package gas
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// Client exposes the RPC methods required to apply gas price defaults.
+type Client interface {
+	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
+	SuggestGasTipCap(ctx context.Context) (*big.Int, error)
+}
+
+// ApplyDefaults applies configured default gas limit and price settings to opts.
+// When DefaultGasPriceWei is set, the latest block header is inspected to choose EIP-1559 vs legacy.
+func ApplyDefaults(ctx context.Context, client Client, opts *bind.TransactOpts, cfg Config) error {
+	if opts == nil {
+		return errors.New("transact opts are nil")
+	}
+
+	if cfg.DefaultGasLimit > 0 {
+		opts.GasLimit = cfg.DefaultGasLimit
+	}
+
+	if cfg.DefaultGasPriceWei == 0 {
+		return nil
+	}
+
+	if client == nil {
+		return errors.New("gas client is required when default_gas_price_wei is set")
+	}
+
+	return applyGasPrice(ctx, client, opts, weiToBigInt(cfg.DefaultGasPriceWei), weiToBigInt(cfg.DefaultGasTipCapWei))
+}
+
+func applyGasPrice(ctx context.Context, client Client, opts *bind.TransactOpts, gasPrice, tipOverride *big.Int) error {
+	header, err := client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to get latest header: %w", err)
+	}
+	if header == nil {
+		return errors.New("latest block header is nil")
+	}
+
+	if IsEIP1559Header(header) {
+		if gasPrice == nil {
+			return errors.New("gas fee cap is nil")
+		}
+
+		var tip *big.Int
+		if tipOverride != nil {
+			tip = tipOverride
+		} else {
+			tip, err = client.SuggestGasTipCap(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to get suggested tip cap: %w", err)
+			}
+		}
+		if tip == nil {
+			return errors.New("gas tip cap is nil")
+		}
+
+		maxTip := new(big.Int).Sub(gasPrice, header.BaseFee)
+		if maxTip.Sign() < 0 {
+			return fmt.Errorf("default_gas_price_wei %s is below current base fee %s", gasPrice, header.BaseFee)
+		}
+		if tip.Cmp(maxTip) > 0 {
+			tip = new(big.Int).Set(maxTip)
+		}
+
+		opts.GasPrice = nil
+		opts.GasTipCap = tip
+		opts.GasFeeCap = gasPrice
+	} else {
+		applyLegacyGasPrice(opts, gasPrice)
+	}
+
+	return nil
+}
+
+func applyLegacyGasPrice(opts *bind.TransactOpts, gasPrice *big.Int) {
+	opts.GasPrice = gasPrice
+	opts.GasFeeCap = nil
+	opts.GasTipCap = nil
+}
+
+// IsEIP1559Header reports whether the header indicates EIP-1559 support.
+func IsEIP1559Header(header *types.Header) bool {
+	return header != nil && header.BaseFee != nil
+}

--- a/chain/evm/gas/cap.go
+++ b/chain/evm/gas/cap.go
@@ -1,0 +1,14 @@
+package gas
+
+// EIP7825MaxTxGasLimit is the EIP-7825 per-transaction gas limit cap (2^24).
+// Used as a reference value in docs and tests; YAML max_tx_gas_limit accepts any uint64.
+const EIP7825MaxTxGasLimit = uint64(16_777_216)
+
+// CapGasLimit returns gas unchanged when maxTxGas is 0; otherwise returns min(gas, maxTxGas).
+func CapGasLimit(gas, maxTxGas uint64) uint64 {
+	if maxTxGas == 0 || gas <= maxTxGas {
+		return gas
+	}
+
+	return maxTxGas
+}

--- a/chain/evm/gas/cap_test.go
+++ b/chain/evm/gas/cap_test.go
@@ -1,0 +1,32 @@
+package gas_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
+)
+
+func TestCapGasLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		gas      uint64
+		maxTxGas uint64
+		want     uint64
+	}{
+		{name: "no cap", gas: 1_000_000, maxTxGas: 0, want: 1_000_000},
+		{name: "below cap", gas: 12_000_000, maxTxGas: gas.EIP7825MaxTxGasLimit, want: 12_000_000},
+		{name: "at cap", gas: gas.EIP7825MaxTxGasLimit, maxTxGas: gas.EIP7825MaxTxGasLimit, want: gas.EIP7825MaxTxGasLimit},
+		{name: "above cap", gas: 20_000_000, maxTxGas: gas.EIP7825MaxTxGasLimit, want: gas.EIP7825MaxTxGasLimit},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, gas.CapGasLimit(tt.gas, tt.maxTxGas))
+		})
+	}
+}

--- a/chain/evm/gas/config.go
+++ b/chain/evm/gas/config.go
@@ -1,0 +1,37 @@
+package gas
+
+import "math/big"
+
+// Config holds per-chain default gas settings applied to the chain deployer at load time.
+// These defaults apply to any code path that uses chain.DeployerKey (bind, gobindings, etc.).
+//
+// zkSync VM chains: defaults are applied to DeployerKey (bind/gobind writes, etc.).
+// Contract deploys on zkSync use DeployerKeyZkSyncVM with SDK fee estimation instead,
+// so gas_config does not affect the operations contract deploy path on those chains.
+//
+// Configure under a network entry's metadata block in .config/networks/*.yaml:
+//
+//	metadata:
+//	  gas_config:
+//	    default_gas_limit: 7500000
+//	    default_gas_price_wei: 210000000000
+//	    default_gas_tip_cap_wei: 40000000000  # optional EIP-1559 tip override
+type Config struct {
+	// DefaultGasLimit sets opts.GasLimit on the chain deployer when non-zero.
+	DefaultGasLimit uint64 `yaml:"default_gas_limit,omitempty" json:"defaultGasLimit,omitempty"`
+	// DefaultGasPriceWei sets legacy gasPrice on pre-EIP-1559 chains, or maxFeePerGas
+	// (GasFeeCap) on EIP-1559 chains, in wei.
+	DefaultGasPriceWei uint64 `yaml:"default_gas_price_wei,omitempty" json:"defaultGasPriceWei,omitempty"`
+	// DefaultGasTipCapWei sets maxPriorityFeePerGas (GasTipCap) on EIP-1559 chains only, in wei.
+	// Only applied when DefaultGasPriceWei is also set. When unset, the node suggestion is used.
+	// The tip is capped so feeCap >= baseFee + tip.
+	DefaultGasTipCapWei uint64 `yaml:"default_gas_tip_cap_wei,omitempty" json:"defaultGasTipCapWei,omitempty"`
+}
+
+func weiToBigInt(wei uint64) *big.Int {
+	if wei == 0 {
+		return nil
+	}
+
+	return new(big.Int).SetUint64(wei)
+}

--- a/chain/evm/gas/config.go
+++ b/chain/evm/gas/config.go
@@ -16,6 +16,7 @@ import "math/big"
 //	    default_gas_limit: 7500000
 //	    default_gas_price_wei: 210000000000
 //	    default_gas_tip_cap_wei: 40000000000  # optional EIP-1559 tip override
+//	    max_tx_gas_limit: 16777216           # optional cap on deployer limit and eth_estimateGas (e.g. EIP-7825)
 type Config struct {
 	// DefaultGasLimit sets opts.GasLimit on the chain deployer when non-zero.
 	DefaultGasLimit uint64 `yaml:"default_gas_limit,omitempty" json:"defaultGasLimit,omitempty"`
@@ -26,6 +27,9 @@ type Config struct {
 	// Only applied when DefaultGasPriceWei is also set. When unset, the node suggestion is used.
 	// The tip is capped so feeCap >= baseFee + tip.
 	DefaultGasTipCapWei uint64 `yaml:"default_gas_tip_cap_wei,omitempty" json:"defaultGasTipCapWei,omitempty"`
+	// MaxTxGasLimit caps gas when non-zero: min(value, max_tx_gas_limit) on default_gas_limit
+	// (deployer key) and on eth_estimateGas results from the chain client.
+	MaxTxGasLimit uint64 `yaml:"max_tx_gas_limit,omitempty" json:"maxTxGasLimit,omitempty"`
 }
 
 func weiToBigInt(wei uint64) *big.Int {

--- a/chain/evm/gas/gas_test.go
+++ b/chain/evm/gas/gas_test.go
@@ -1,0 +1,258 @@
+package gas_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
+)
+
+func TestApplyDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		client     gas.Client
+		cfg        gas.Config
+		setupMock  func(t *testing.T) gas.Client
+		wantErr    string
+		assertOpts func(t *testing.T, opts *bind.TransactOpts)
+	}{
+		{
+			name: "legacy chain",
+			cfg: gas.Config{
+				DefaultGasPriceWei: 50_000_000_000,
+				DefaultGasLimit:    5_000_000,
+			},
+			setupMock: func(t *testing.T) gas.Client {
+				t.Helper()
+				mockClient := evm.NewMockOnchainClient(t)
+				mockClient.EXPECT().HeaderByNumber(mock.Anything, (*big.Int)(nil)).
+					Return(&types.Header{BaseFee: nil}, nil)
+
+				return mockClient
+			},
+			assertOpts: func(t *testing.T, opts *bind.TransactOpts) {
+				t.Helper()
+				require.Equal(t, big.NewInt(50_000_000_000), opts.GasPrice)
+				require.Equal(t, uint64(5_000_000), opts.GasLimit)
+				require.Nil(t, opts.GasTipCap)
+				require.Nil(t, opts.GasFeeCap)
+			},
+		},
+		{
+			name: "EIP-1559 chain",
+			cfg: gas.Config{
+				DefaultGasPriceWei: 50_000_000_000,
+				DefaultGasLimit:    5_000_000,
+			},
+			setupMock: func(t *testing.T) gas.Client {
+				t.Helper()
+				mockClient := evm.NewMockOnchainClient(t)
+				mockClient.EXPECT().HeaderByNumber(mock.Anything, (*big.Int)(nil)).
+					Return(&types.Header{BaseFee: big.NewInt(100)}, nil)
+				mockClient.EXPECT().SuggestGasTipCap(mock.Anything).
+					Return(big.NewInt(1_000_000_000), nil)
+
+				return mockClient
+			},
+			assertOpts: func(t *testing.T, opts *bind.TransactOpts) {
+				t.Helper()
+				require.Nil(t, opts.GasPrice)
+				require.Equal(t, big.NewInt(1_000_000_000), opts.GasTipCap)
+				require.Equal(t, big.NewInt(50_000_000_000), opts.GasFeeCap)
+				require.Equal(t, uint64(5_000_000), opts.GasLimit)
+			},
+		},
+		{
+			name: "gas limit only",
+			cfg:  gas.Config{DefaultGasLimit: 10_000_000},
+			setupMock: func(t *testing.T) gas.Client {
+				t.Helper()
+				return evm.NewMockOnchainClient(t)
+			},
+			assertOpts: func(t *testing.T, opts *bind.TransactOpts) {
+				t.Helper()
+				require.Equal(t, uint64(10_000_000), opts.GasLimit)
+				require.Nil(t, opts.GasPrice)
+			},
+		},
+		{
+			name: "EIP-1559 with tip override",
+			cfg: gas.Config{
+				DefaultGasPriceWei:  100_000_000_000,
+				DefaultGasTipCapWei: 40_000_000_000,
+			},
+			setupMock: func(t *testing.T) gas.Client {
+				t.Helper()
+				mockClient := evm.NewMockOnchainClient(t)
+				mockClient.EXPECT().HeaderByNumber(mock.Anything, (*big.Int)(nil)).
+					Return(&types.Header{BaseFee: big.NewInt(100)}, nil)
+
+				return mockClient
+			},
+			assertOpts: func(t *testing.T, opts *bind.TransactOpts) {
+				t.Helper()
+				require.Nil(t, opts.GasPrice)
+				require.Equal(t, big.NewInt(40_000_000_000), opts.GasTipCap)
+				require.Equal(t, big.NewInt(100_000_000_000), opts.GasFeeCap)
+			},
+		},
+		{
+			name: "EIP-1559 caps tip override to fee cap minus base fee",
+			cfg: gas.Config{
+				DefaultGasPriceWei:  50_000_000_000,
+				DefaultGasTipCapWei: 100_000_000_000,
+			},
+			setupMock: func(t *testing.T) gas.Client {
+				t.Helper()
+				mockClient := evm.NewMockOnchainClient(t)
+				mockClient.EXPECT().HeaderByNumber(mock.Anything, (*big.Int)(nil)).
+					Return(&types.Header{BaseFee: big.NewInt(100)}, nil)
+
+				return mockClient
+			},
+			assertOpts: func(t *testing.T, opts *bind.TransactOpts) {
+				t.Helper()
+				require.Nil(t, opts.GasPrice)
+				require.Equal(t, big.NewInt(49_999_999_900), opts.GasTipCap)
+				require.Equal(t, big.NewInt(50_000_000_000), opts.GasFeeCap)
+			},
+		},
+		{
+			name: "EIP-1559 caps suggested tip to fee cap minus base fee",
+			cfg: gas.Config{
+				DefaultGasPriceWei: 50_000_000_000,
+			},
+			setupMock: func(t *testing.T) gas.Client {
+				t.Helper()
+				mockClient := evm.NewMockOnchainClient(t)
+				mockClient.EXPECT().HeaderByNumber(mock.Anything, (*big.Int)(nil)).
+					Return(&types.Header{BaseFee: big.NewInt(100)}, nil)
+				mockClient.EXPECT().SuggestGasTipCap(mock.Anything).
+					Return(big.NewInt(100_000_000_000), nil)
+
+				return mockClient
+			},
+			assertOpts: func(t *testing.T, opts *bind.TransactOpts) {
+				t.Helper()
+				require.Equal(t, big.NewInt(49_999_999_900), opts.GasTipCap)
+				require.Equal(t, big.NewInt(50_000_000_000), opts.GasFeeCap)
+			},
+		},
+		{
+			name: "EIP-1559 rejects fee cap below base fee",
+			cfg: gas.Config{
+				DefaultGasPriceWei: 50,
+			},
+			setupMock: func(t *testing.T) gas.Client {
+				t.Helper()
+				mockClient := evm.NewMockOnchainClient(t)
+				mockClient.EXPECT().HeaderByNumber(mock.Anything, (*big.Int)(nil)).
+					Return(&types.Header{BaseFee: big.NewInt(100)}, nil)
+				mockClient.EXPECT().SuggestGasTipCap(mock.Anything).
+					Return(big.NewInt(1), nil)
+
+				return mockClient
+			},
+			wantErr: "below current base fee",
+		},
+		{
+			name: "EIP-1559 rejects nil suggested tip",
+			cfg: gas.Config{
+				DefaultGasPriceWei: 50_000_000_000,
+			},
+			setupMock: func(t *testing.T) gas.Client {
+				t.Helper()
+				mockClient := evm.NewMockOnchainClient(t)
+				mockClient.EXPECT().HeaderByNumber(mock.Anything, (*big.Int)(nil)).
+					Return(&types.Header{BaseFee: big.NewInt(100)}, nil)
+				mockClient.EXPECT().SuggestGasTipCap(mock.Anything).
+					Return(nil, nil)
+
+				return mockClient
+			},
+			wantErr: "gas tip cap is nil",
+		},
+		{
+			name:    "nil client requires RPC for price",
+			client:  nil,
+			cfg:     gas.Config{DefaultGasPriceWei: 50_000_000_000},
+			wantErr: "gas client is required",
+		},
+		{
+			name: "nil header",
+			cfg:  gas.Config{DefaultGasPriceWei: 50_000_000_000},
+			setupMock: func(t *testing.T) gas.Client {
+				t.Helper()
+				mockClient := evm.NewMockOnchainClient(t)
+				mockClient.EXPECT().HeaderByNumber(mock.Anything, (*big.Int)(nil)).
+					Return(nil, nil)
+
+				return mockClient
+			},
+			wantErr: "latest block header is nil",
+		},
+		{
+			name:   "nil client allows limit only",
+			client: nil,
+			cfg:    gas.Config{DefaultGasLimit: 10_000_000},
+			assertOpts: func(t *testing.T, opts *bind.TransactOpts) {
+				t.Helper()
+				require.Equal(t, uint64(10_000_000), opts.GasLimit)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := tt.client
+			if tt.setupMock != nil {
+				client = tt.setupMock(t)
+			}
+
+			opts := &bind.TransactOpts{}
+			err := gas.ApplyDefaults(t.Context(), client, opts, tt.cfg)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.assertOpts != nil {
+				tt.assertOpts(t, opts)
+			}
+		})
+	}
+}
+
+func TestIsEIP1559Header(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		header *types.Header
+		want   bool
+	}{
+		{name: "nil header", header: nil},
+		{name: "legacy header", header: &types.Header{}},
+		{name: "EIP-1559 header", header: &types.Header{BaseFee: big.NewInt(1)}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, gas.IsEIP1559Header(tt.header))
+		})
+	}
+}

--- a/chain/evm/gas/gas_test.go
+++ b/chain/evm/gas/gas_test.go
@@ -84,6 +84,17 @@ func TestApplyDefaults(t *testing.T) {
 			},
 		},
 		{
+			name: "caps default gas limit at max tx gas limit",
+			cfg: gas.Config{
+				DefaultGasLimit: 20_000_000,
+				MaxTxGasLimit:   gas.EIP7825MaxTxGasLimit,
+			},
+			assertOpts: func(t *testing.T, opts *bind.TransactOpts) {
+				t.Helper()
+				require.Equal(t, gas.EIP7825MaxTxGasLimit, opts.GasLimit)
+			},
+		},
+		{
 			name: "EIP-1559 with tip override",
 			cfg: gas.Config{
 				DefaultGasPriceWei:  100_000_000_000,

--- a/chain/evm/provider/ctf_anvil_provider.go
+++ b/chain/evm/provider/ctf_anvil_provider.go
@@ -227,6 +227,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider/rpcclient"
 )
 
@@ -269,6 +270,9 @@ type CTFAnvilChainProviderConfig struct {
 	// provider. You can use this to set up custom HTTP clients, timeouts, or other
 	// configurations for the RPC connections.
 	ClientOpts []func(client *rpcclient.MultiClient)
+
+	// Optional: GasConfig configures default gas limit and price for the chain deployer.
+	GasConfig *gas.Config
 
 	// Optional: DockerCmdParamsOverrides allows customization of Docker command parameters
 	// for the Anvil container. These parameters are passed directly to the Docker container
@@ -396,26 +400,6 @@ func (p *CTFAnvilChainProvider) Initialize(ctx context.Context) (chain.BlockChai
 	}
 	p.httpURL = httpURL
 
-	lggr, err := logger.New()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create new logger: %w", err)
-	}
-
-	client, err := rpcclient.NewMultiClient(ctx, lggr, rpcclient.RPCConfig{
-		ChainSelector: p.selector,
-		RPCs: []rpcclient.RPC{
-			{
-				Name:               "anvil-local",
-				HTTPURL:            httpURL,
-				WSURL:              "", // Anvil typically doesn't provide WebSocket, only HTTP
-				PreferredURLScheme: rpcclient.URLSchemePreferenceHTTP,
-			},
-		},
-	}, p.config.ClientOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create multiclient for Anvil at %s: %w", httpURL, err)
-	}
-
 	// Get the Chain ID as big.Int for transactor generation
 	chainIDBigInt, ok := new(big.Int).SetString(chainID, 10)
 	if !ok {
@@ -458,6 +442,32 @@ func (p *CTFAnvilChainProvider) Initialize(ctx context.Context) (chain.BlockChai
 		}
 	}
 
+	lggr, err := logger.New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new logger: %w", err)
+	}
+
+	client, err := rpcclient.NewMultiClient(ctx, lggr, rpcclient.RPCConfig{
+		ChainSelector: p.selector,
+		RPCs: []rpcclient.RPC{
+			{
+				Name:               "anvil-local",
+				HTTPURL:            httpURL,
+				WSURL:              "", // Anvil typically doesn't provide WebSocket, only HTTP
+				PreferredURLScheme: rpcclient.URLSchemePreferenceHTTP,
+			},
+		},
+	}, multiClientOpts(p.config.GasConfig, p.config.ClientOpts)...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create multiclient for Anvil at %s: %w", httpURL, err)
+	}
+
+	if p.config.GasConfig != nil {
+		if applyErr := gas.ApplyDefaults(ctx, client, deployerKey, *p.config.GasConfig); applyErr != nil {
+			return nil, fmt.Errorf("failed to apply gas defaults for chain %d: %w", p.selector, applyErr)
+		}
+	}
+
 	// Build additional user transactors from the default Anvil accounts
 	userTransactors, err := p.getUserTransactors(chainID)
 	if err != nil {
@@ -478,6 +488,7 @@ func (p *CTFAnvilChainProvider) Initialize(ctx context.Context) (chain.BlockChai
 		Users:       userTransactors,
 		Confirm:     confirmFunc,
 		SignHash:    signHashFunc,
+		GasConfig:   p.config.GasConfig,
 	}
 
 	return *p.chain, nil

--- a/chain/evm/provider/ctf_geth_provider.go
+++ b/chain/evm/provider/ctf_geth_provider.go
@@ -232,6 +232,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider/rpcclient"
 )
 
@@ -271,6 +272,9 @@ type CTFGethChainProviderConfig struct {
 	// provider. You can use this to set up custom HTTP clients, timeouts, or other
 	// configurations for the RPC connections.
 	ClientOpts []func(client *rpcclient.MultiClient)
+
+	// Optional: GasConfig configures default gas limit and price for the chain deployer.
+	GasConfig *gas.Config
 
 	// Optional: DockerCmdParamsOverrides allows customization of Docker command parameters
 	// for the Geth container. These parameters are passed directly to the Docker container
@@ -407,7 +411,7 @@ func (p *CTFGethChainProvider) Initialize(ctx context.Context) (chain.BlockChain
 				PreferredURLScheme: rpcclient.URLSchemePreferenceHTTP,
 			},
 		},
-	}, p.config.ClientOpts...)
+	}, multiClientOpts(p.config.GasConfig, p.config.ClientOpts)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create multiclient for Geth at %s: %w", httpURL, err)
 	}
@@ -454,6 +458,12 @@ func (p *CTFGethChainProvider) Initialize(ctx context.Context) (chain.BlockChain
 		}
 	}
 
+	if p.config.GasConfig != nil {
+		if applyErr := gas.ApplyDefaults(ctx, client, deployerKey, *p.config.GasConfig); applyErr != nil {
+			return nil, fmt.Errorf("failed to apply gas defaults for chain %d: %w", p.selector, applyErr)
+		}
+	}
+
 	// Build additional user transactors from the default Geth accounts
 	userTransactors, err := p.getUserTransactors(chainID)
 	if err != nil {
@@ -483,6 +493,7 @@ func (p *CTFGethChainProvider) Initialize(ctx context.Context) (chain.BlockChain
 		Users:       userTransactors,
 		Confirm:     confirmFunc,
 		SignHash:    signHashFunc,
+		GasConfig:   p.config.GasConfig,
 	}
 
 	return *p.chain, nil

--- a/chain/evm/provider/gas_client_opts.go
+++ b/chain/evm/provider/gas_client_opts.go
@@ -1,0 +1,15 @@
+package provider
+
+import (
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider/rpcclient"
+)
+
+func multiClientOpts(cfg *gas.Config, base []func(*rpcclient.MultiClient)) []func(*rpcclient.MultiClient) {
+	opts := append([]func(*rpcclient.MultiClient){}, base...)
+	if cfg == nil || cfg.MaxTxGasLimit == 0 {
+		return opts
+	}
+
+	return append(opts, rpcclient.WithMaxTxGasLimit(cfg.MaxTxGasLimit))
+}

--- a/chain/evm/provider/gas_client_opts_test.go
+++ b/chain/evm/provider/gas_client_opts_test.go
@@ -1,0 +1,190 @@
+package provider
+
+import (
+	"testing"
+	"time"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider/rpcclient"
+)
+
+func Test_multiClientOpts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         *gas.Config
+		wantLen     int
+		wantMaxCap  uint64
+		checkBaseFn bool
+	}{
+		{name: "nil config", cfg: nil, wantLen: 1, checkBaseFn: true},
+		{name: "empty config", cfg: &gas.Config{}, wantLen: 1, checkBaseFn: true},
+		{
+			name:        "with max tx gas limit",
+			cfg:         &gas.Config{MaxTxGasLimit: gas.EIP7825MaxTxGasLimit},
+			wantLen:     2,
+			wantMaxCap:  gas.EIP7825MaxTxGasLimit,
+			checkBaseFn: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var baseCalled bool
+			base := []func(*rpcclient.MultiClient){
+				func(*rpcclient.MultiClient) { baseCalled = true },
+			}
+
+			opts := multiClientOpts(tt.cfg, base)
+			require.Len(t, opts, tt.wantLen)
+			_ = append(opts, func(*rpcclient.MultiClient) {})
+			require.Len(t, base, 1, "multiClientOpts must not alias the input slice")
+
+			mc := &rpcclient.MultiClient{}
+			for _, opt := range opts {
+				opt(mc)
+			}
+			if tt.checkBaseFn {
+				require.True(t, baseCalled)
+			}
+			require.Equal(t, tt.wantMaxCap, mc.MaxTxGasLimit())
+		})
+	}
+}
+
+//nolint:paralleltest // Initialize cannot run in parallel due to seth log initialization race
+func Test_providerInitialize_gasConfig(t *testing.T) {
+	chainSelector := chainsel.TEST_1000.Selector
+
+	mockSrv := newFakeRPCServer(t)
+	rpc := rpcclient.RPC{
+		Name:               "Test",
+		HTTPURL:            mockSrv.URL,
+		PreferredURLScheme: rpcclient.URLSchemePreferenceHTTP,
+	}
+	confirm := ConfirmFuncGeth(1 * time.Second)
+
+	tests := []struct {
+		name      string
+		zkSync    bool
+		gasConfig *gas.Config
+		wantErr   string
+		assert    func(t *testing.T, chain evm.Chain)
+	}{
+		{
+			name:      "RPC applies gas limit defaults",
+			gasConfig: &gas.Config{DefaultGasLimit: 7_500_000},
+			assert: func(t *testing.T, chain evm.Chain) {
+				t.Helper()
+				require.Equal(t, uint64(7_500_000), chain.DeployerKey.GasLimit)
+			},
+		},
+		{
+			name:      "RPC applies max tx gas limit to client",
+			gasConfig: &gas.Config{MaxTxGasLimit: gas.EIP7825MaxTxGasLimit},
+			assert: func(t *testing.T, chain evm.Chain) {
+				t.Helper()
+				requireMultiClientMaxTxGasLimit(t, chain.Client, gas.EIP7825MaxTxGasLimit)
+			},
+		},
+		{
+			name: "RPC caps default gas limit at max tx gas limit",
+			gasConfig: &gas.Config{
+				DefaultGasLimit: 20_000_000,
+				MaxTxGasLimit:   gas.EIP7825MaxTxGasLimit,
+			},
+			assert: func(t *testing.T, chain evm.Chain) {
+				t.Helper()
+				require.Equal(t, gas.EIP7825MaxTxGasLimit, chain.DeployerKey.GasLimit)
+				requireMultiClientMaxTxGasLimit(t, chain.Client, gas.EIP7825MaxTxGasLimit)
+			},
+		},
+		{
+			name:      "RPC fails when apply defaults errors",
+			gasConfig: &gas.Config{DefaultGasPriceWei: 210_000_000_000},
+			wantErr:   "failed to apply gas defaults",
+		},
+		{
+			name:      "ZkSync applies gas limit defaults to EVM deployer key",
+			zkSync:    true,
+			gasConfig: &gas.Config{DefaultGasLimit: 7_500_000},
+			assert: func(t *testing.T, chain evm.Chain) {
+				t.Helper()
+				require.True(t, chain.IsZkSyncVM)
+				require.Equal(t, uint64(7_500_000), chain.DeployerKey.GasLimit)
+			},
+		},
+		{
+			name:      "ZkSync applies max tx gas limit to client",
+			zkSync:    true,
+			gasConfig: &gas.Config{MaxTxGasLimit: gas.EIP7825MaxTxGasLimit},
+			assert: func(t *testing.T, chain evm.Chain) {
+				t.Helper()
+				requireMultiClientMaxTxGasLimit(t, chain.Client, gas.EIP7825MaxTxGasLimit)
+			},
+		},
+		{
+			name:      "ZkSync fails when apply defaults errors",
+			zkSync:    true,
+			gasConfig: &gas.Config{DefaultGasPriceWei: 210_000_000_000},
+			wantErr:   "failed to apply gas defaults",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				got evm.Chain
+				err error
+			)
+
+			if tt.zkSync {
+				p := NewZkSyncRPCChainProvider(chainSelector, ZkSyncRPCChainProviderConfig{
+					DeployerTransactorGen: TransactorRandom(),
+					ZkSyncSignerGen:       ZKSyncSignerRandom(),
+					RPCs:                  []rpcclient.RPC{rpc},
+					ConfirmFunctor:        confirm,
+					GasConfig:             tt.gasConfig,
+				})
+				blockchain, initErr := p.Initialize(t.Context())
+				err = initErr
+				got, _ = blockchain.(evm.Chain)
+			} else {
+				p := NewRPCChainProvider(chainSelector, RPCChainProviderConfig{
+					DeployerTransactorGen: TransactorRandom(),
+					RPCs:                  []rpcclient.RPC{rpc},
+					ConfirmFunctor:        confirm,
+					GasConfig:             tt.gasConfig,
+				})
+				blockchain, initErr := p.Initialize(t.Context())
+				err = initErr
+				got, _ = blockchain.(evm.Chain)
+			}
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.assert != nil {
+				tt.assert(t, got)
+			}
+		})
+	}
+}
+
+func requireMultiClientMaxTxGasLimit(t *testing.T, client evm.OnchainClient, want uint64) {
+	t.Helper()
+
+	mc, ok := client.(*rpcclient.MultiClient)
+	require.True(t, ok, "expected chain client to be *rpcclient.MultiClient")
+	require.Equal(t, want, mc.MaxTxGasLimit())
+}

--- a/chain/evm/provider/rpc_provider.go
+++ b/chain/evm/provider/rpc_provider.go
@@ -132,7 +132,7 @@ func (p *RPCChainProvider) Initialize(ctx context.Context) (chain.BlockChain, er
 	client, err := rpcclient.NewMultiClient(ctx, p.config.Logger, rpcclient.RPCConfig{
 		ChainSelector: p.selector,
 		RPCs:          p.config.RPCs,
-	}, p.config.ClientOpts...)
+	}, multiClientOpts(p.config.GasConfig, p.config.ClientOpts)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create multi-client: %w", err)
 	}

--- a/chain/evm/provider/rpc_provider.go
+++ b/chain/evm/provider/rpc_provider.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider/rpcclient"
 )
 
@@ -40,6 +41,8 @@ type RPCChainProviderConfig struct {
 	// Optional: Logger is the logger to use for the RPCChainProvider. If not provided, a default
 	// logger will be used.
 	Logger logger.Logger
+	// Optional: GasConfig configures default gas limit and price for the chain deployer.
+	GasConfig *gas.Config
 }
 
 // validate checks if the RPCChainProviderConfig is valid.
@@ -134,6 +137,12 @@ func (p *RPCChainProvider) Initialize(ctx context.Context) (chain.BlockChain, er
 		return nil, fmt.Errorf("failed to create multi-client: %w", err)
 	}
 
+	if p.config.GasConfig != nil {
+		if applyErr := gas.ApplyDefaults(ctx, client, deployerKey, *p.config.GasConfig); applyErr != nil {
+			return nil, fmt.Errorf("failed to apply gas defaults for chain %d: %w", p.selector, applyErr)
+		}
+	}
+
 	// Setup the confirm function
 	confirmFunc, err := p.config.ConfirmFunctor.Generate(
 		ctx, p.selector, client, deployerKey.From,
@@ -149,6 +158,7 @@ func (p *RPCChainProvider) Initialize(ctx context.Context) (chain.BlockChain, er
 		Users:       users,
 		Confirm:     confirmFunc,
 		SignHash:    p.config.DeployerTransactorGen.SignHash,
+		GasConfig:   p.config.GasConfig,
 	}
 
 	return *p.chain, nil

--- a/chain/evm/provider/rpcclient/multiclient.go
+++ b/chain/evm/provider/rpcclient/multiclient.go
@@ -142,6 +142,8 @@ func NewMultiClient(
 }
 
 // SendTransaction is a wrapper around the ethclient.SendTransaction method that retries on failure.
+// Gas bumping is not performed here because the transaction is already signed; adjust gas on
+// chain.DeployerKey at chain load (gas_config defaults) or before signing the transaction.
 func (mc *MultiClient) SendTransaction(ctx context.Context, tx *types.Transaction) error {
 	return mc.retryWithBackups(ctx, "SendTransaction", func(ct context.Context, client *ethclient.Client) error {
 		return client.SendTransaction(ct, tx)

--- a/chain/evm/provider/rpcclient/multiclient.go
+++ b/chain/evm/provider/rpcclient/multiclient.go
@@ -22,6 +22,7 @@ import (
 	chainsel "github.com/smartcontractkit/chain-selectors/remote"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 )
 
 const (
@@ -75,6 +76,20 @@ type MultiClient struct {
 	lggr        logger.Logger
 	chainName   string
 	mu          sync.RWMutex
+	// maxTxGasLimit caps eth_estimateGas results when non-zero.
+	maxTxGasLimit uint64
+}
+
+// MaxTxGasLimit returns the configured per-transaction gas limit cap, or 0 when unset.
+func (mc *MultiClient) MaxTxGasLimit() uint64 {
+	return mc.maxTxGasLimit
+}
+
+// WithMaxTxGasLimit configures a cap applied to EstimateGas results.
+func WithMaxTxGasLimit(maxTxGasLimit uint64) func(*MultiClient) {
+	return func(mc *MultiClient) {
+		mc.maxTxGasLimit = maxTxGasLimit
+	}
 }
 
 // rpcHealthCheck performs a basic health check on the RPC client by calling eth_blockNumber
@@ -295,15 +310,28 @@ func (mc *MultiClient) PendingNonceAt(ctx context.Context, account common.Addres
 
 // EstimateGas is a wrapper around the ethclient.EstimateGas method that retries on failure.
 func (mc *MultiClient) EstimateGas(ctx context.Context, call ethereum.CallMsg) (uint64, error) {
-	var gas uint64
+	var estimated uint64
 	err := mc.retryWithBackups(ctx, "EstimateGas", func(ct context.Context, client *ethclient.Client) error {
 		var err error
-		gas, err = client.EstimateGas(ct, call)
+		estimated, err = client.EstimateGas(ct, call)
 
 		return err
 	})
+	if err != nil {
+		return 0, err
+	}
 
-	return gas, err
+	capped := gas.CapGasLimit(estimated, mc.maxTxGasLimit)
+	if capped != estimated {
+		mc.lggr.Debugw("eth_estimateGas capped at max_tx_gas_limit",
+			"chain", mc.chainName,
+			"estimated", estimated,
+			"max_tx_gas_limit", mc.maxTxGasLimit,
+			"capped", capped,
+		)
+	}
+
+	return capped, nil
 }
 
 // BalanceAt is a wrapper around the ethclient.BalanceAt method that retries on failure.

--- a/chain/evm/provider/rpcclient/multiclient_test.go
+++ b/chain/evm/provider/rpcclient/multiclient_test.go
@@ -3,15 +3,19 @@ package rpcclient
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	"github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger"
 )
 
@@ -392,6 +396,104 @@ func TestMultiClient_reorderRPCs(t *testing.T) {
 				assert.Same(t, expected, mc.Backups[i],
 					"Backup at position %d should be as expected", i)
 			}
+		})
+	}
+}
+
+func newEstimateGasRPCServer(t *testing.T, estimateGasResult string, estimateGasError bool) *httptest.Server {
+	t.Helper()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		if strings.Contains(string(body), "eth_estimateGas") {
+			if estimateGasError {
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"execution reverted"}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"` + estimateGasResult + `"}`))
+
+			return
+		}
+
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x1"}`))
+	})
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func TestMultiClient_EstimateGas_cap(t *testing.T) {
+	t.Parallel()
+
+	const chainSelector uint64 = 16015286601757825753 // ethereum-testnet-sepolia
+
+	tests := []struct {
+		name          string
+		estimateHex   string
+		estimateError bool
+		maxTxGasLimit uint64
+		wantGas       uint64
+		wantErr       bool
+	}{
+		{
+			name:        "returns estimate unchanged when no cap",
+			estimateHex: "0xf4240", // 1_000_000
+			wantGas:     1_000_000,
+		},
+		{
+			name:          "caps estimate at max tx gas",
+			estimateHex:   "0x1312d00", // 20_000_000
+			maxTxGasLimit: gas.EIP7825MaxTxGasLimit,
+			wantGas:       gas.EIP7825MaxTxGasLimit,
+		},
+		{
+			name:          "does not cap failed estimate",
+			estimateHex:   "0xf4240",
+			estimateError: true,
+			maxTxGasLimit: gas.EIP7825MaxTxGasLimit,
+			wantErr:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := newEstimateGasRPCServer(t, tt.estimateHex, tt.estimateError)
+
+			var opts []func(*MultiClient)
+			if tt.maxTxGasLimit > 0 {
+				opts = append(opts, WithMaxTxGasLimit(tt.maxTxGasLimit))
+			}
+
+			mc, err := NewMultiClient(t.Context(), logger.Test(t), RPCConfig{
+				ChainSelector: chainSelector,
+				RPCs: []RPC{{
+					Name:               "test-rpc",
+					HTTPURL:            srv.URL,
+					PreferredURLScheme: URLSchemePreferenceHTTP,
+				}},
+			}, opts...)
+			require.NoError(t, err)
+
+			estimated, err := mc.EstimateGas(context.Background(), ethereum.CallMsg{})
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Equal(t, uint64(0), estimated)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantGas, estimated)
 		})
 	}
 }

--- a/chain/evm/provider/zksync_rpc_provider.go
+++ b/chain/evm/provider/zksync_rpc_provider.go
@@ -134,7 +134,7 @@ func (p *ZkSyncRPCChainProvider) Initialize(ctx context.Context) (chain.BlockCha
 	client, err := rpcclient.NewMultiClient(ctx, p.config.Logger, rpcclient.RPCConfig{
 		ChainSelector: p.selector,
 		RPCs:          p.config.RPCs,
-	}, p.config.ClientOpts...)
+	}, multiClientOpts(p.config.GasConfig, p.config.ClientOpts)...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create multi-client: %w", err)
 	}

--- a/chain/evm/provider/zksync_rpc_provider.go
+++ b/chain/evm/provider/zksync_rpc_provider.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider/rpcclient"
 )
 
@@ -45,6 +46,10 @@ type ZkSyncRPCChainProviderConfig struct {
 	// Optional: Logger is the logger to use for the RPCChainProvider. If not provided, a default
 	// logger will be used.
 	Logger logger.Logger
+	// Optional: GasConfig configures default gas limit and price for the EVM deployer key
+	// (bind.TransactOpts). Does not apply to zkSync contract deploys, which use
+	// DeployerKeyZkSyncVM and SDK fee estimation instead.
+	GasConfig *gas.Config
 }
 
 // validate checks if the config is valid.
@@ -134,6 +139,13 @@ func (p *ZkSyncRPCChainProvider) Initialize(ctx context.Context) (chain.BlockCha
 		return nil, fmt.Errorf("failed to create multi-client: %w", err)
 	}
 
+	if p.config.GasConfig != nil {
+		// Applied to the EVM deployer key only; zkSync deploys use DeployerKeyZkSyncVM below.
+		if applyErr := gas.ApplyDefaults(ctx, client, deployerKey, *p.config.GasConfig); applyErr != nil {
+			return nil, fmt.Errorf("failed to apply gas defaults for chain %d: %w", p.selector, applyErr)
+		}
+	}
+
 	// Setup the confirm function
 	confirmFunc, err := p.config.ConfirmFunctor.Generate(
 		ctx, p.selector, client, deployerKey.From,
@@ -163,6 +175,7 @@ func (p *ZkSyncRPCChainProvider) Initialize(ctx context.Context) (chain.BlockCha
 		IsZkSyncVM:          true,
 		ClientZkSyncVM:      clientZk,
 		DeployerKeyZkSyncVM: deployerKeyZkSyncVM,
+		GasConfig:           p.config.GasConfig,
 	}
 
 	return *p.chain, nil

--- a/engine/cld/chains/chains.go
+++ b/engine/cld/chains/chains.go
@@ -20,6 +20,7 @@ import (
 	cantonauthcode "github.com/smartcontractkit/chainlink-deployments-framework/chain/canton/provider/authentication/authorizationcode"
 	cantonclientcreds "github.com/smartcontractkit/chainlink-deployments-framework/chain/canton/provider/authentication/clientcredentials"
 	fevm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	evmgas "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	evmprov "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider"
 	evmclient "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/provider/rpcclient"
 	solanaprov "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana/provider"
@@ -535,11 +536,13 @@ func (l *chainLoaderEVM) Load(ctx context.Context, selector uint64) (fchain.Bloc
 		},
 	}
 
+	gasConfig, isZkSyncVM := l.evmMetadataFromNetwork(network, selector)
+
 	var c fchain.BlockChain
 
 	// Use the zkSync RPC if the chain should be treated as a zkSync VM chain. Per-chain network config may
 	// override the hardcoded classification via EVMMetadata.IsZkSync; otherwise the hardcoded allowlist is used.
-	if l.resolveIsZkSyncVM(network, selector) {
+	if isZkSyncVM {
 		var signerGen evmprov.ZkSyncSignerGenerator
 		signerGen, err = l.zkSyncSignerGenerator(l.cfg)
 		if err != nil {
@@ -554,6 +557,7 @@ func (l *chainLoaderEVM) Load(ctx context.Context, selector uint64) (fchain.Bloc
 				ConfirmFunctor:        confirmFunctor,
 				ClientOpts:            clientOpts,
 				Logger:                l.lggr,
+				GasConfig:             gasConfig,
 			},
 		).Initialize(ctx)
 	} else {
@@ -564,6 +568,7 @@ func (l *chainLoaderEVM) Load(ctx context.Context, selector uint64) (fchain.Bloc
 				ConfirmFunctor:        confirmFunctor,
 				ClientOpts:            clientOpts,
 				Logger:                l.lggr,
+				GasConfig:             gasConfig,
 			},
 		).Initialize(ctx)
 	}
@@ -574,21 +579,27 @@ func (l *chainLoaderEVM) Load(ctx context.Context, selector uint64) (fchain.Bloc
 	return c, nil
 }
 
-// resolveIsZkSyncVM determines whether a chain should use zkSync VM handling. A
-// per-chain EVMMetadata.IsZkSync override in the network config takes precedence;
-// when unset it falls back to the hardcoded isZkSyncVM allowlist.
-func (l *chainLoaderEVM) resolveIsZkSyncVM(network cfgnet.Network, selector uint64) bool {
-	if network.Metadata != nil {
-		switch md, err := cfgnet.DecodeMetadata[cfgnet.EVMMetadata](network.Metadata); {
-		case err != nil:
-			l.lggr.Warnw("Failed to decode EVM network metadata; falling back to hardcoded zkSync classification",
-				"selector", selector, "error", err)
-		case md.IsZkSync != nil:
-			return *md.IsZkSync
-		}
+// evmMetadataFromNetwork decodes EVMMetadata once per chain load and derives gas config
+// and zkSync classification from the result.
+func (l *chainLoaderEVM) evmMetadataFromNetwork(network cfgnet.Network, selector uint64) (*evmgas.Config, bool) {
+	if network.Metadata == nil {
+		return nil, l.isZkSyncVM(selector)
 	}
 
-	return l.isZkSyncVM(selector)
+	md, err := cfgnet.DecodeMetadata[cfgnet.EVMMetadata](network.Metadata)
+	if err != nil {
+		l.lggr.Warnw("Failed to decode EVM network metadata; falling back to hardcoded zkSync classification and skipping gas defaults",
+			"selector", selector, "error", err)
+
+		return nil, l.isZkSyncVM(selector)
+	}
+
+	isZkSyncVM := l.isZkSyncVM(selector)
+	if md.IsZkSync != nil {
+		isZkSyncVM = *md.IsZkSync
+	}
+
+	return md.GasConfig, isZkSyncVM
 }
 
 // isZkSyncVM checks if the given chain selector corresponds to a zkSyncchain.

--- a/engine/cld/chains/chains_test.go
+++ b/engine/cld/chains/chains_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/config"
 	cfgenv "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/config/env"
 	cfgnet "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/config/network"
@@ -1504,11 +1505,11 @@ func newFakeRPCServer(t *testing.T) *httptest.Server {
 	return srv
 }
 
-// Test_chainLoaderEVM_resolveIsZkSyncVM verifies that a per-chain
+// Test_chainLoaderEVM_evmMetadataFromNetwork_zkSync verifies that a per-chain
 // EVMMetadata.IsZkSync override in the network config takes precedence over the
 // hardcoded isZkSyncVM allowlist, and that the loader falls back to the allowlist
 // when no override is present.
-func Test_chainLoaderEVM_resolveIsZkSyncVM(t *testing.T) {
+func Test_chainLoaderEVM_evmMetadataFromNetwork_zkSync(t *testing.T) {
 	t.Parallel()
 
 	zkSel := chainsel.ETHEREUM_TESTNET_SEPOLIA_ZKSYNC_1.Selector // hardcoded zkSync
@@ -1564,7 +1565,58 @@ func Test_chainLoaderEVM_resolveIsZkSyncVM(t *testing.T) {
 			t.Parallel()
 
 			network := cfgnet.Network{ChainSelector: tt.selector, Metadata: tt.metadata}
-			assert.Equal(t, tt.want, l.resolveIsZkSyncVM(network, tt.selector))
+			_, isZkSyncVM := l.evmMetadataFromNetwork(network, tt.selector)
+			assert.Equal(t, tt.want, isZkSyncVM)
+		})
+	}
+}
+
+func Test_chainLoaderEVM_evmMetadataFromNetwork_gasConfig(t *testing.T) {
+	t.Parallel()
+
+	selector := chainsel.ETHEREUM_TESTNET_SEPOLIA.Selector
+
+	tests := []struct {
+		name      string
+		network   cfgnet.Network
+		assertCfg func(t *testing.T, cfg *gas.Config)
+	}{
+		{
+			name: "empty network",
+			network: cfgnet.Network{
+				ChainSelector: selector,
+			},
+			assertCfg: func(t *testing.T, cfg *gas.Config) {
+				t.Helper()
+				require.Nil(t, cfg)
+			},
+		},
+		{
+			name: "parses gas_config metadata",
+			network: cfgnet.Network{
+				ChainSelector: selector,
+				Metadata: map[string]any{
+					"gas_config": map[string]any{
+						"default_gas_limit":     int64(7_500_000),
+						"default_gas_price_wei": int64(210_000_000_000),
+					},
+				},
+			},
+			assertCfg: func(t *testing.T, cfg *gas.Config) {
+				t.Helper()
+				require.NotNil(t, cfg)
+				require.Equal(t, uint64(7_500_000), cfg.DefaultGasLimit)
+				require.Equal(t, uint64(210_000_000_000), cfg.DefaultGasPriceWei)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			l := &chainLoaderEVM{lggr: logger.Test(t)}
+			gasConfig, _ := l.evmMetadataFromNetwork(tt.network, tt.network.ChainSelector)
+			tt.assertCfg(t, gasConfig)
 		})
 	}
 }

--- a/engine/cld/chains/chains_test.go
+++ b/engine/cld/chains/chains_test.go
@@ -1599,6 +1599,7 @@ func Test_chainLoaderEVM_evmMetadataFromNetwork_gasConfig(t *testing.T) {
 					"gas_config": map[string]any{
 						"default_gas_limit":     int64(7_500_000),
 						"default_gas_price_wei": int64(210_000_000_000),
+						"max_tx_gas_limit":      int64(16_777_216),
 					},
 				},
 			},
@@ -1607,6 +1608,7 @@ func Test_chainLoaderEVM_evmMetadataFromNetwork_gasConfig(t *testing.T) {
 				require.NotNil(t, cfg)
 				require.Equal(t, uint64(7_500_000), cfg.DefaultGasLimit)
 				require.Equal(t, uint64(210_000_000_000), cfg.DefaultGasPriceWei)
+				require.Equal(t, uint64(16_777_216), cfg.MaxTxGasLimit)
 			},
 		},
 	}

--- a/engine/cld/config/network/metadata.go
+++ b/engine/cld/config/network/metadata.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/gas"
 )
 
 // EVMMetadata is a struct that holds metadata specific to EVM networks.
@@ -13,7 +15,8 @@ type EVMMetadata struct {
 	// IsZkSync overrides the default VM classification for this chain. When set, it
 	// takes precedence over the hardcoded isZkSyncVM allowlist in the EVM chain loader.
 	// Set false to force the standard EVM deploy path on zkStack chains
-	IsZkSync *bool `yaml:"is_zksync,omitempty"`
+	IsZkSync  *bool       `yaml:"is_zksync,omitempty"`
+	GasConfig *gas.Config `yaml:"gas_config,omitempty"`
 }
 
 // StellarMetadata holds metadata specific to Stellar networks.


### PR DESCRIPTION
## Summary

- Adds `gas_config` to EVM network metadata so domains configure deployer gas per chain in YAML instead of [hardcoded framework tables or changeset workarounds](https://github.com/smartcontractkit/chainlink-deployments/blob/6908cdff2162ee9ca0e83482e554b609109dee1f/domains/ccip/testnet/durable_pipelines.go#L805-L813).

### YAML fields

| Field | Purpose |
|-------|---------|
| `default_gas_limit` | Fixed gas limit on the deployer transactor |
| `default_gas_price_wei` | Legacy gas price or EIP-1559 max fee (wei) |
| `default_gas_tip_cap_wei` | Optional EIP-1559 priority fee override |
| `max_tx_gas_limit` | Ceiling on deployer gas and `eth_estimateGas` |

### Example

Add under a network entry's `metadata` block in `.config/networks/*.yaml`:
```yaml
metadata:
  gas_config:
    default_gas_limit: 7500000
    default_gas_price_wei: 210000000000
    default_gas_tip_cap_wei: 40000000000  # optional EIP-1559 tip
    max_tx_gas_limit: 16777216           # optional; e.g. EIP-7825 L2 cap
```
