### PR TITLE
feat(pipeline): add deprecated chain guard for chainOverrides

### DIFF
--- a/.changeset/happy-horses-end.md
+++ b/.changeset/happy-horses-end.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": minor
+---
+
+feat(pipeline): add decommissioned chain guard for chainOverrides

--- a/engine/cld/commands/pipeline/run.go
+++ b/engine/cld/commands/pipeline/run.go
@@ -146,7 +146,7 @@ func runRun(cmd *cobra.Command, cfg *Config, f runFlags) error {
 		return err
 	}
 
-	envOptions, err := dprun.ConfigureEnvironmentOptions(registry, actualChangesetName, f.dryRun, cfg.Logger)
+	envOptions, err := dprun.ConfigureEnvironmentOptions(cmd.Context(), registry, actualChangesetName, f.dryRun, cfg.Logger)
 	if err != nil {
 		return err
 	}

--- a/engine/cld/pipeline/run/decommissioned.go
+++ b/engine/cld/pipeline/run/decommissioned.go
@@ -1,0 +1,64 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	chainselremote "github.com/smartcontractkit/chain-selectors/remote"
+)
+
+// chainDetailsChecker looks up chain details (including the Deprecated flag)
+// for a given selector. The default implementation delegates to the
+// chain-selectors package's remote API, which checks local embedded data first
+// and falls back to fetching the latest all_selectors.yml from GitHub; tests
+// can supply a stub to exercise the error path without network calls.
+type chainDetailsChecker interface {
+	GetChainDetails(ctx context.Context, selector uint64) (chainselremote.ChainDetailsWithMetadata, error)
+}
+
+// defaultChainDetailsChecker uses chainselremote.GetChainDetailsBySelector,
+// which checks local embedded data first and falls back to a remote fetch for
+// chains not found locally. This ensures deprecations are caught even before
+// the chain-selectors module is bumped to a version that includes them in the
+// embedded YAML.
+type defaultChainDetailsChecker struct{}
+
+func (defaultChainDetailsChecker) GetChainDetails(ctx context.Context, selector uint64) (chainselremote.ChainDetailsWithMetadata, error) {
+	return chainselremote.GetChainDetailsBySelector(ctx, selector)
+}
+
+// checkDecommissionedChains validates that none of the provided chain selectors
+// have been marked as decommissioned/deprecated. It collects all offending
+// selectors and returns a single error listing every one, so the caller sees
+// the full picture in a single failure rather than discovering them one at a
+// time.
+//
+// If the checker returns an error for any selector (e.g. unknown selector or
+// transient network failure during remote fetch), the error is propagated
+// immediately. An unknown selector would fail in LoadChains later anyway, so
+// failing early here gives a clearer error message.
+func checkDecommissionedChains(ctx context.Context, checker chainDetailsChecker, selectors []uint64) error {
+	var decommissioned []string
+	for _, sel := range selectors {
+		details, err := checker.GetChainDetails(ctx, sel)
+		if err != nil {
+			return fmt.Errorf("failed to look up chain details for selector %d: %w", sel, err)
+		}
+
+		if details.Deprecated {
+			decommissioned = append(decommissioned, fmt.Sprintf("%s (%s)", strconv.FormatUint(sel, 10), details.ChainName))
+		}
+	}
+
+	if len(decommissioned) > 0 {
+		return fmt.Errorf(
+			"chain overrides contain %d decommissioned chain(s): %s; "+
+				"remove them or replace with an active chain",
+			len(decommissioned), strings.Join(decommissioned, ", "),
+		)
+	}
+
+	return nil
+}

--- a/engine/cld/pipeline/run/decommissioned_test.go
+++ b/engine/cld/pipeline/run/decommissioned_test.go
@@ -1,0 +1,147 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	chainselremote "github.com/smartcontractkit/chain-selectors/remote"
+	"github.com/stretchr/testify/require"
+)
+
+// stubChainDetailsChecker is a test-only chainDetailsChecker that returns
+// pre-configured details for selectors in the map. Selectors not in the map
+// return an "unknown chain selector" error, mimicking the real package's
+// behavior for unknown selectors.
+type stubChainDetailsChecker struct {
+	details map[uint64]chainselremote.ChainDetailsWithMetadata
+}
+
+func (s stubChainDetailsChecker) GetChainDetails(_ context.Context, selector uint64) (chainselremote.ChainDetailsWithMetadata, error) {
+	if d, ok := s.details[selector]; ok {
+		return d, nil
+	}
+
+	return chainselremote.ChainDetailsWithMetadata{}, fmt.Errorf("unknown chain selector %d", selector)
+}
+
+// networkErrorChecker simulates a transient network failure for all lookups.
+type networkErrorChecker struct{}
+
+func (networkErrorChecker) GetChainDetails(context.Context, uint64) (chainselremote.ChainDetailsWithMetadata, error) {
+	return chainselremote.ChainDetailsWithMetadata{}, errors.New("failed to fetch remote selectors from github.com: connection refused")
+}
+
+// formatSelector renders a selector as "selector (name)" for test assertions,
+// matching the format used by checkDecommissionedChains. Uses the local-only
+// chainsel package to avoid network calls during test setup.
+func formatSelector(sel uint64) string {
+	name, err := chainsel.GetChainNameFromSelector(sel)
+	if err != nil {
+		return strconv.FormatUint(sel, 10)
+	}
+
+	return fmt.Sprintf("%s (%s)", strconv.FormatUint(sel, 10), name)
+}
+
+// chainDetails is a test helper to build ChainDetailsWithMetadata with just
+// the fields checkDecommissionedChains reads.
+func chainDetails(selector uint64, name string, deprecated bool) chainselremote.ChainDetailsWithMetadata {
+	return chainselremote.ChainDetailsWithMetadata{
+		ChainDetails: chainsel.ChainDetails{
+			ChainSelector: selector,
+			ChainName:     name,
+			Deprecated:    deprecated,
+		},
+	}
+}
+
+func TestCheckDecommissionedChains(t *testing.T) {
+	t.Parallel()
+
+	// Use real selectors so the error message includes human-readable names.
+	eth := chainsel.ETHEREUM_MAINNET.Selector
+	avax := chainsel.AVALANCHE_MAINNET.Selector
+
+	tests := []struct {
+		name      string
+		checker   chainDetailsChecker
+		selectors []uint64
+		wantErr   string
+	}{
+		{
+			name:      "nil selectors",
+			checker:   stubChainDetailsChecker{details: map[uint64]chainselremote.ChainDetailsWithMetadata{}},
+			selectors: nil,
+		},
+		{
+			name:      "empty selectors",
+			checker:   stubChainDetailsChecker{details: map[uint64]chainselremote.ChainDetailsWithMetadata{}},
+			selectors: []uint64{},
+		},
+		{
+			name: "all active chains",
+			checker: stubChainDetailsChecker{details: map[uint64]chainselremote.ChainDetailsWithMetadata{
+				eth:  chainDetails(eth, "ethereum-mainnet", false),
+				avax: chainDetails(avax, "avalanche-mainnet", false),
+			}},
+			selectors: []uint64{eth, avax},
+		},
+		{
+			name: "single decommissioned chain",
+			checker: stubChainDetailsChecker{details: map[uint64]chainselremote.ChainDetailsWithMetadata{
+				eth: chainDetails(eth, "ethereum-mainnet", true),
+			}},
+			selectors: []uint64{eth},
+			wantErr:   "chain overrides contain 1 decommissioned chain(s): " + formatSelector(eth) + "; remove them or replace with an active chain",
+		},
+		{
+			name: "mixed active and decommissioned",
+			checker: stubChainDetailsChecker{details: map[uint64]chainselremote.ChainDetailsWithMetadata{
+				avax: chainDetails(avax, "avalanche-mainnet", false),
+				eth:  chainDetails(eth, "ethereum-mainnet", true),
+			}},
+			selectors: []uint64{avax, eth},
+			wantErr:   "chain overrides contain 1 decommissioned chain(s): " + formatSelector(eth) + "; remove them or replace with an active chain",
+		},
+		{
+			name: "all decommissioned",
+			checker: stubChainDetailsChecker{details: map[uint64]chainselremote.ChainDetailsWithMetadata{
+				eth:  chainDetails(eth, "ethereum-mainnet", true),
+				avax: chainDetails(avax, "avalanche-mainnet", true),
+			}},
+			selectors: []uint64{eth, avax},
+			wantErr:   "chain overrides contain 2 decommissioned chain(s): " + formatSelector(eth) + ", " + formatSelector(avax) + "; remove them or replace with an active chain",
+		},
+		{
+			name:      "unknown selector returns error",
+			checker:   stubChainDetailsChecker{details: map[uint64]chainselremote.ChainDetailsWithMetadata{}},
+			selectors: []uint64{9999999999999999999},
+			wantErr:   "failed to look up chain details for selector 9999999999999999999: unknown chain selector 9999999999999999999",
+		},
+		{
+			name:      "network error is propagated",
+			checker:   networkErrorChecker{},
+			selectors: []uint64{eth},
+			wantErr:   "failed to look up chain details for selector " + strconv.FormatUint(eth, 10) + ": failed to fetch remote selectors from github.com: connection refused",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := checkDecommissionedChains(t.Context(), tt.checker, tt.selectors)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Equal(t, tt.wantErr, err.Error())
+
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/engine/cld/pipeline/run/run.go
+++ b/engine/cld/pipeline/run/run.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"context"
+
 	cs "github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/changeset"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/domain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/cld/environment"
@@ -10,6 +12,7 @@ import (
 
 // ConfigureEnvironmentOptions builds the environment loading options for a changeset execution.
 func ConfigureEnvironmentOptions(
+	ctx context.Context,
 	registry *cs.ChangesetsRegistry,
 	changesetStr string,
 	dryRun bool,
@@ -24,7 +27,7 @@ func ConfigureEnvironmentOptions(
 		return nil, err
 	}
 
-	chainOverrides, err := GetChainOverrides(registry, changesetStr)
+	chainOverrides, err := GetChainOverrides(ctx, registry, changesetStr)
 	if err != nil {
 		return nil, err
 	}
@@ -48,22 +51,37 @@ func ConfigureEnvironmentOptions(
 }
 
 // GetChainOverrides retrieves the chain overrides for a given changeset.
-func GetChainOverrides(registry *cs.ChangesetsRegistry, changesetStr string) ([]uint64, error) {
+// It fails fast with a clear error if any of the resolved chain selectors have
+// been marked as decommissioned/deprecated, preventing misleading RPC errors
+// (e.g. "insufficient funds", "underpriced transaction") that occur when
+// interacting with a sunset chain.
+func GetChainOverrides(ctx context.Context, registry *cs.ChangesetsRegistry, changesetStr string) ([]uint64, error) {
 	changesetOptions, err := registry.GetChangesetOptions(changesetStr)
 	if err != nil {
 		return nil, err
 	}
 
+	var chainOverrides []uint64
 	if changesetOptions.ChainsToLoad != nil {
-		return changesetOptions.ChainsToLoad, nil
+		chainOverrides = changesetOptions.ChainsToLoad
+	} else {
+		configs, err := registry.GetConfigurations(changesetStr)
+		if err != nil {
+			return nil, err
+		}
+		chainOverrides = configs.InputChainOverrides
 	}
 
-	configs, err := registry.GetConfigurations(changesetStr)
-	if err != nil {
-		return nil, err
+	// Validate that no requested chain has been decommissioned. Only check
+	// when overrides are explicitly provided (non-nil); a nil value means
+	// "load all chains" and is handled by LoadChains downstream.
+	if chainOverrides != nil {
+		if err := checkDecommissionedChains(ctx, defaultChainDetailsChecker{}, chainOverrides); err != nil {
+			return nil, err
+		}
 	}
 
-	return configs.InputChainOverrides, nil
+	return chainOverrides, nil
 }
 
 // SaveReports saves any new operations reports generated during changeset execution.

--- a/engine/cld/pipeline/run/run_test.go
+++ b/engine/cld/pipeline/run/run_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
 	fdeployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -74,7 +75,7 @@ func TestConfigureEnvironmentOptions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			opts, err := ConfigureEnvironmentOptions(tt.regSetup(), tt.changeset, tt.dryRun, logger.Test(t))
+			opts, err := ConfigureEnvironmentOptions(t.Context(), tt.regSetup(), tt.changeset, tt.dryRun, logger.Test(t))
 
 			if tt.wantErr != "" {
 				require.Error(t, err)
@@ -117,13 +118,26 @@ func TestGetChainOverrides(t *testing.T) {
 			changeset: "0001_missing",
 			wantErr:   "changeset '0001_missing' not found",
 		},
+		{
+			name: "active chain overrides pass decommissioned check",
+			regSetup: func() *cs.ChangesetsRegistry {
+				reg := cs.NewChangesetsRegistry()
+				reg.Add("0001_test", cs.Configure(&runStubChangeset{}).With(map[string]any{}),
+					cs.OnlyLoadChainsFor(chainsel.ETHEREUM_MAINNET.Selector),
+				)
+
+				return reg
+			},
+			changeset: "0001_test",
+			want:      []uint64{chainsel.ETHEREUM_MAINNET.Selector},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := GetChainOverrides(tt.regSetup(), tt.changeset)
+			got, err := GetChainOverrides(t.Context(), tt.regSetup(), tt.changeset)
 
 			if tt.wantErr != "" {
 				require.Error(t, err)


### PR DESCRIPTION
Inspired by - https://chainlink-core.slack.com/archives/C09961Z99RD/p1783691136510839

## What changed

Added a deprecated-chain guard to `GetChainOverrides()` that fails fast with a clear error when a requested chain selector is marked as deprecated/decommissioned.

I intentionally only targeted chains that were specified in the chain overrides as checking for all the chains do not mean user will be using all the chains, i want to avoid failing the changeset on a chain that user is not using just because we want to load all the chains.

## Why

When a decommissioned chain is part of a request, the RPC starts returning misleading errors like `insufficient funds`, `underpriced transaction`, `gas errors`, etc. The real root cause is that the chain is no longer active, but that's not obvious from those messages, causing time lost chasing the wrong thing.

The check uses `chainselremote.GetChainDetailsBySelector` which checks local embedded data first and falls back to fetching the latest `all_selectors.yml` from GitHub (cached 5 min). This means deprecations are caught even before the `chain-selectors` module is bumped to a version that includes them in the embedded YAML.

The `chain-selectors` package already has a `Deprecated bool` field on `ChainDetails` — this change leverages that existing infrastructure rather than maintaining a separate `map[uint64]bool`.