### PR TITLE
chore: update workflows owner check to allow for initial deployments

### DIFF
--- a/chain/evm/operations2/contract/write.go
+++ b/chain/evm/operations2/contract/write.go
@@ -309,7 +309,8 @@ func IsWorkflowsOwner(contract WorkflowRegistryContract, opts *bind.CallOpts, ca
 			if err != nil {
 				return false, err
 			}
-			if wfMetadata.Owner != caller {
+			// If a workflow does not yet exist, then it is a first deployment and the caller should be allowed.
+			if wfMetadata.WorkflowId != [32]byte{} && wfMetadata.Owner != caller {
 				return false, nil
 			}
 		}

--- a/chain/evm/operations2/contract/write_test.go
+++ b/chain/evm/operations2/contract/write_test.go
@@ -359,7 +359,7 @@ func TestIsWorkflowsOwner(t *testing.T) {
 					Once()
 				contract.EXPECT().
 					GetWorkflowById(opts, workflowId1).
-					Return(workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{Owner: caller}, nil).
+					Return(workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{}, nil).
 					Once()
 			},
 			wantAllowed: true,

--- a/chain/evm/operations2/contract/write_test.go
+++ b/chain/evm/operations2/contract/write_test.go
@@ -321,11 +321,11 @@ func TestIsWorkflowsOwner(t *testing.T) {
 					Once()
 				contract.EXPECT().
 					GetWorkflowById(opts, workflowId1).
-					Return(workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{Owner: caller}, nil).
+					Return(workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{WorkflowId: workflowId1, Owner: caller}, nil).
 					Once()
 				contract.EXPECT().
 					GetWorkflowById(opts, workflowId2).
-					Return(workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{Owner: caller}, nil).
+					Return(workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{WorkflowId: workflowId1, Owner: caller}, nil).
 					Once()
 			},
 			wantAllowed: true,
@@ -340,14 +340,29 @@ func TestIsWorkflowsOwner(t *testing.T) {
 					Once()
 				contract.EXPECT().
 					GetWorkflowById(opts, workflowId1).
-					Return(workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{Owner: caller}, nil).
+					Return(workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{WorkflowId: workflowId1, Owner: caller}, nil).
 					Once()
 				contract.EXPECT().
 					GetWorkflowById(opts, workflowId2).
-					Return(workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{Owner: other}, nil).
+					Return(workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{WorkflowId: workflowId2, Owner: other}, nil).
 					Once()
 			},
 			wantAllowed: false,
+		},
+		{
+			desc:        "returns true when a workflow does not exists",
+			workflowIds: [][32]byte{workflowId1},
+			setupMock: func(contract *contractmocks.MockWorkflowRegistryContract, opts *bind.CallOpts) {
+				contract.EXPECT().
+					Address().
+					Return(contractAddress).
+					Once()
+				contract.EXPECT().
+					GetWorkflowById(opts, workflowId1).
+					Return(workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{Owner: caller}, nil).
+					Once()
+			},
+			wantAllowed: true,
 		},
 		{
 			desc:        "returns error when workflow lookup fails",

--- a/chain/evm/operations2/contract/write_test.go
+++ b/chain/evm/operations2/contract/write_test.go
@@ -350,7 +350,7 @@ func TestIsWorkflowsOwner(t *testing.T) {
 			wantAllowed: false,
 		},
 		{
-			desc:        "returns true when a workflow does not exists",
+			desc:        "returns true when a workflow does not exist",
 			workflowIds: [][32]byte{workflowId1},
 			setupMock: func(contract *contractmocks.MockWorkflowRegistryContract, opts *bind.CallOpts) {
 				contract.EXPECT().

--- a/chain/evm/operations2/contract/write_test.go
+++ b/chain/evm/operations2/contract/write_test.go
@@ -325,7 +325,7 @@ func TestIsWorkflowsOwner(t *testing.T) {
 					Once()
 				contract.EXPECT().
 					GetWorkflowById(opts, workflowId2).
-					Return(workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{WorkflowId: workflowId1, Owner: caller}, nil).
+					Return(workflow_registry_wrapper_v2.WorkflowRegistryWorkflowMetadataView{WorkflowId: workflowId2, Owner: caller}, nil).
 					Once()
 			},
 			wantAllowed: true,


### PR DESCRIPTION
## Summary

Updates the `IsWorkflowsOwner` logic to allow for initial workflows deployments. 

Currently when a workflow has not been deployed yet, using the `workflows_owner` access type on the ops gen tool with cause `IsAllowedCaller` to return false, therefore only allowing updates and not initial deployments.

This PR addresses this by updating the behavior to return false if the caller does not match the workflow owner **AND** that the workflow ID is not zero.