### PR TITLE
refactor(changeset): remove SetValidate validation restriction

### DIFF
--- a/.changeset/polite-dingos-enjoy.md
+++ b/.changeset/polite-dingos-enjoy.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+refactor(changeset): remove SetValidate validation restriction

--- a/engine/cld/changeset/registry.go
+++ b/engine/cld/changeset/registry.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strconv"
-	"strings"
 	"sync"
 
 	fdeployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -96,9 +94,6 @@ type ChangesetsRegistry struct {
 	// keyHistory is a list of all changeset keys in the order they were added to the registry.
 	keyHistory []string
 
-	// validate enables or disables changeset key validation.
-	validate bool
-
 	// globalPreHooks run before every changeset in this registry.
 	globalPreHooks []PreHook
 	// globalPostHooks run after every changeset in this registry.
@@ -134,16 +129,14 @@ func NewChangesetsRegistry() *ChangesetsRegistry {
 	return &ChangesetsRegistry{
 		entries:    make(map[string]registryEntry),
 		keyHistory: []string{},
-		validate:   true,
 	}
 }
 
-// SetValidate sets the validate flag for the registry. If set to true, changeset keys will be validated.
+// SetValidate is deprecated and has no effect. Validation is now permanently disabled.
+// This method is kept for backward compatibility and will be removed in a future version.
+// Deprecated: SetValidate
 func (r *ChangesetsRegistry) SetValidate(validate bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	r.validate = validate
+	// no-op: kept for backward compatibility
 }
 
 // AddGlobalPreHooks appends pre-hooks that run before every changeset in this registry.
@@ -412,13 +405,6 @@ func (r *ChangesetsRegistry) Add(key string, cs ChangeSet, opts ...ChangesetOpti
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// Validate the key format and index
-	if r.validate {
-		if err := r.validateKey(key); err != nil {
-			panic(fmt.Errorf("invalid changeset key '%s': %w", key, err))
-		}
-	}
-
 	// Process the options
 	options := ChangesetConfig{}
 	for _, opt := range opts {
@@ -427,46 +413,6 @@ func (r *ChangesetsRegistry) Add(key string, cs ChangeSet, opts ...ChangesetOpti
 
 	r.entries[key] = newRegistryEntry(cs, options)
 	r.keyHistory = append(r.keyHistory, key)
-}
-
-func (r *ChangesetsRegistry) validateKey(key string) error {
-	// Extract the numerical prefix from the new key
-	currentIndex, err := extractIndexFromKey(key)
-	if err != nil {
-		return fmt.Errorf("invalid changeset key format '%s': %w", key, err)
-	}
-
-	// If there are existing changesets, validate that the new index is greater than the last one
-	if len(r.keyHistory) > 0 {
-		lastKey := r.keyHistory[len(r.keyHistory)-1]
-		lastIndex, err := extractIndexFromKey(lastKey)
-		if err != nil {
-			return fmt.Errorf("invalid previous changeset key format '%s': %w", lastKey, err)
-		}
-
-		if currentIndex <= lastIndex {
-			return fmt.Errorf("changeset index must be monotonically increasing: got %d, previous was %d",
-				currentIndex, lastIndex)
-		}
-	}
-
-	return nil
-}
-
-// extractIndexFromKey extracts the numerical index from a changeset key.
-// Expected format: "0001_changeset_name" where "0001" is the index.
-func extractIndexFromKey(key string) (int, error) {
-	parts := strings.Split(key, "_")
-	if len(parts) < 2 {
-		return 0, fmt.Errorf("key '%s' does not follow the format 'index_name'", key)
-	}
-
-	index, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return 0, fmt.Errorf("could not parse index from key '%s': %w", key, err)
-	}
-
-	return index, nil
 }
 
 // LatestKey returns the most recent changeset key.

--- a/engine/cld/changeset/registry.go
+++ b/engine/cld/changeset/registry.go
@@ -134,8 +134,10 @@ func NewChangesetsRegistry() *ChangesetsRegistry {
 
 // SetValidate is deprecated and has no effect. Validation is now permanently disabled.
 // This method is kept for backward compatibility and will be removed in a future version.
-// Deprecated: SetValidate
-func (r *ChangesetsRegistry) SetValidate(validate bool) {
+//
+// Deprecated: SetValidate no longer performs any validation; the call is a no-op
+// and callers should remove it. Changeset key validation has been removed entirely.
+func (r *ChangesetsRegistry) SetValidate(_ bool) {
 	// no-op: kept for backward compatibility
 }
 

--- a/engine/cld/changeset/registry_test.go
+++ b/engine/cld/changeset/registry_test.go
@@ -234,27 +234,6 @@ func Test_Changesets_Add(t *testing.T) {
 
 	r.Add("0002_cap_reg", noopChangeset{})
 	require.Equal(t, []string{"0001_cap_reg", "0002_cap_reg"}, r.keyHistory)
-
-	require.Panics(t, func() {
-		r.Add("0002_same_index", noopChangeset{})
-	}, "Add should panic when adding a key with the same index")
-
-	require.Panics(t, func() {
-		r.Add("0001_lower_index", noopChangeset{})
-	}, "Add should panic when adding a key with lower index")
-
-	require.Panics(t, func() {
-		r.Add("xxxx_invalid_key", noopChangeset{})
-	}, "Add should panic when adding a key with invalid format")
-
-	require.Panics(t, func() {
-		r.Add("InvalidChangesetKeyFormat", noopChangeset{})
-	}, "Add should panic when adding an invalid changeset key format")
-
-	r.SetValidate(false)
-	require.NotPanics(t, func() {
-		r.Add("0002_same_index", noopChangeset{})
-	}, "Add should not panic when validation is disabled")
 }
 
 func Test_Changesets_ListKeys(t *testing.T) {
@@ -314,20 +293,6 @@ func Test_Changesets_LatestKey(t *testing.T) {
 			}
 		})
 	}
-}
-
-func Test_Changesets_SetValidate(t *testing.T) {
-	t.Parallel()
-
-	r := NewChangesetsRegistry()
-
-	require.True(t, r.validate, "validate should be true by default")
-
-	r.SetValidate(false)
-	require.False(t, r.validate, "validate should be false after setting it to false")
-
-	r.SetValidate(true)
-	require.True(t, r.validate, "validate should be true after setting it to true")
 }
 
 func Test_Changesets_GetChangesetOptions(t *testing.T) {
@@ -589,7 +554,6 @@ func Test_Apply_PreHook_ConfigurationErrorAbortsPipeline(t *testing.T) {
 		return "", errors.New("config unavailable")
 	})
 	registry := NewChangesetsRegistry()
-	registry.SetValidate(false)
 	registry.Add("test-cs", changeset)
 
 	preHookRan := false
@@ -693,7 +657,6 @@ func Test_Apply_ExecutionOrder(t *testing.T) {
 	cs := &orderRecordingChangeset{}
 
 	r := NewChangesetsRegistry()
-	r.SetValidate(false)
 
 	r.AddGlobalPreHooks(PreHook{
 		HookDefinition: HookDefinition{Name: "global-pre"},
@@ -743,7 +706,6 @@ func Test_Apply_GlobalPreHookAbort_BlocksChangeset(t *testing.T) {
 	cs := &recordingChangeset{}
 
 	r := NewChangesetsRegistry()
-	r.SetValidate(false)
 
 	r.AddGlobalPreHooks(PreHook{
 		HookDefinition: HookDefinition{Name: "global-blocker", FailurePolicy: Abort},
@@ -875,7 +837,6 @@ func Test_FluentAPI_HooksExtractedByAdd(t *testing.T) {
 	}
 	newRegistry := func(cs ChangeSet) *ChangesetsRegistry {
 		r := NewChangesetsRegistry()
-		r.SetValidate(false)
 		r.Add("test-cs", cs)
 
 		return r
@@ -1048,7 +1009,6 @@ func Test_Integration_MultiChangeset_GlobalAndPerCSHooks(t *testing.T) {
 	csB := Configure(MyChangeSet).With("cfgB").WithPostHooks(csBPost)
 
 	r := NewChangesetsRegistry()
-	r.SetValidate(false)
 	r.AddGlobalPreHooks(globalPre)
 	r.AddGlobalPostHooks(globalPost)
 	r.Add("csA", csA)
@@ -1074,7 +1034,6 @@ func Test_Integration_MixedAbortWarn_GlobalAndPerCS(t *testing.T) {
 	var order []string
 
 	r := NewChangesetsRegistry()
-	r.SetValidate(false)
 
 	r.AddGlobalPreHooks(PreHook{
 		HookDefinition: HookDefinition{Name: "global-warn-pre", FailurePolicy: Warn},
@@ -1150,7 +1109,6 @@ func Test_Integration_HooksCoexistWithThenWith(t *testing.T) {
 		})
 
 	r := NewChangesetsRegistry()
-	r.SetValidate(false)
 	r.AddGlobalPreHooks(PreHook{
 		HookDefinition: HookDefinition{Name: "global-pre"},
 		Func: func(_ context.Context, _ PreHookParams) error {
@@ -1185,7 +1143,6 @@ func Test_Apply_HappyPath_WithHooks(t *testing.T) {
 	postHookRan := false
 
 	r := NewChangesetsRegistry()
-	r.SetValidate(false)
 
 	r.AddGlobalPreHooks(PreHook{
 		HookDefinition: HookDefinition{Name: "global-pre"},
@@ -1311,7 +1268,6 @@ func Test_Changesets_GetResolvedInput(t *testing.T) {
 				cs := Configure(MyChangeSet).WithConfigFrom(func() (string, error) {
 					return "", errors.New("config unavailable")
 				})
-				r.SetValidate(false)
 				r.Add("0001_cap_reg", cs)
 			},
 			key:     "0001_cap_reg",

--- a/engine/cld/scaffold/templates/cmd_internal_app.go.tmpl
+++ b/engine/cld/scaffold/templates/cmd_internal_app.go.tmpl
@@ -23,9 +23,6 @@ func LoadPipelinesRegistry(envKey string) (*changeset.ChangesetsRegistry, error)
 		return nil, fmt.Errorf("unsupported environment %s", envKey)
 	}
 
-	// Don't validate the registry for the durable pipelines
-	rp.Registry().SetValidate(false)
-
 	if err := rp.Init(); err != nil {
 		return nil, fmt.Errorf("failed to init changesets %w", err)
 	}

--- a/engine/test/runtime/task_registered_changesets_yaml.go
+++ b/engine/test/runtime/task_registered_changesets_yaml.go
@@ -87,8 +87,6 @@ func (t registeredChangesetsTask) Run(e fdeployment.Environment, state *State) e
 		return errors.New("input YAML has empty 'changesets' array")
 	}
 
-	provider.Registry().SetValidate(false)
-
 	if initErr := provider.Init(); initErr != nil {
 		return fmt.Errorf("failed to init registry provider: %w", initErr)
 	}


### PR DESCRIPTION
## What changed

Removed the `SetValidate` validation logic from `ChangesetsRegistry`. The `SetValidate()` method is now a no-op kept for backward compatibility (will be removed in a future version once i removed all the usages in CLD).

## Why

The `ChangesetsRegistry` previously enforced monotonically increasing changeset key indices (e.g. `0001_foo`, `0002_bar`) when validation was enabled. In practice, **every caller in the `chainlink-deployments` repo sets `SetValidate(false)`** to disable this check — no one uses `SetValidate(true)` anymore.

This restriction originates from the legacy normal merge queue pipelines that relied on strict ordering of changeset keys. Those pipelines are no longer in use, so the restriction is obsolete. Removing the validation logic means users no longer have to explicitly call `SetValidate(false)` to bypass it, eliminating boilerplate across every domain CLI and test that constructs a registry.