### PR TITLE
fix: skip fork tests when a network is marked as "zksync"

### DIFF
--- a/.changeset/crisp-lands-ring.md
+++ b/.changeset/crisp-lands-ring.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix: skip fork tests when a network is marked as "zksync"

--- a/engine/cld/commands/mcms/cmd_execute_fork.go
+++ b/engine/cld/commands/mcms/cmd_execute_fork.go
@@ -178,16 +178,6 @@ func executeFork(
 		return fmt.Errorf("no rpcs loaded in forked environment for chain %d (fork tests require public RPCs)", cfg.chainSelector)
 	}
 
-	// zkSync VM chains (zkSync Era, Lens, Cronos zkEVM, etc.) require anvil-zksync,
-	// not standard Anvil. Derive this from the loaded chain which is set by the chain
-	// provider, so it stays in sync with new zkSync chains automatically.
-	if evmChain, ok := cfg.blockchains.EVMChains()[cfg.chainSelector]; ok && evmChain.IsZkSyncVM {
-		lggr.Infof("Skipping fork execution: chain selector %d is zkSync VM (chain ID %s), which requires anvil-zksync instead of standard anvil",
-			cfg.chainSelector, chainConfig.ChainID)
-
-		return nil
-	}
-
 	url := chainConfig.HTTPRPCs[0].External
 	anvilClient := rpc.New(url, nil)
 	mcmAddress := cfg.proposal.ChainMetadata[types.ChainSelector(cfg.chainSelector)].MCMAddress

--- a/engine/cld/environment/anvil.go
+++ b/engine/cld/environment/anvil.go
@@ -18,8 +18,10 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/go-resty/resty/v2"
+	"github.com/samber/lo"
 	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/blockchain"
 	"github.com/smartcontractkit/freeport"
+	"github.com/testcontainers/testcontainers-go"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/pkg/logger"
 
@@ -122,6 +124,7 @@ type AnvilChainsOutput struct {
 	Chains       map[uint64]fevm.Chain
 	ForkClients  map[uint64]ForkedOnchainClient
 	ChainConfigs map[uint64]ChainConfig
+	Containers   map[uint64]testcontainers.Container
 }
 
 // newAnvilChains creates chain abstractions using local anvil nodes.
@@ -161,6 +164,7 @@ func newAnvilChains(
 
 	var once sync.Once
 	blockChains := make([]fchain.BlockChain, 0, len(filteredEvmNetworks))
+	containers := make(map[uint64]testcontainers.Container)
 	for _, network := range filteredEvmNetworks {
 		chainSelector := network.ChainSelector
 		if chainSelectorsToLoad != nil && !slices.Contains(chainSelectorsToLoad, chainSelector) {
@@ -178,6 +182,14 @@ func newAnvilChains(
 
 		// Extract the anvil metadata from the network
 		if network.Metadata == nil {
+			network.Metadata = cfgnet.EVMMetadata{}
+		}
+
+		metadata, err := cfgnet.DecodeMetadata[cfgnet.EVMMetadata](network.Metadata)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode network metadata for chain selector %d: %w", chainSelector, err)
+		}
+		if metadata.AnvilConfig == nil {
 			ports, errPort := freeport.Take(1)
 			if errPort != nil {
 				// Fallback (very unlikely to be hit)
@@ -186,20 +198,13 @@ func newAnvilChains(
 			if len(ports) == 0 {
 				return nil, fmt.Errorf("no free ports available for chain selector %d", chainSelector)
 			}
-			network.Metadata = cfgnet.EVMMetadata{
-				AnvilConfig: &cfgnet.AnvilConfig{
-					Image: "ghcr.io/foundry-rs/foundry:latest",
-					Port:  uint64(ports[0]), //nolint:gosec // G115: int to uint64 conversion is safe here (port numbers are always in valid range)
-				},
+
+			metadata.AnvilConfig = &cfgnet.AnvilConfig{
+				Image: "ghcr.io/foundry-rs/foundry:latest",
+				Port:  uint64(ports[0]), //nolint:gosec // G115: int to uint64 conversion is safe here (port numbers are always in valid range)
 			}
 		}
 
-		metadata, errMeta := cfgnet.DecodeMetadata[cfgnet.EVMMetadata](network.Metadata)
-		if errMeta != nil {
-			return nil, fmt.Errorf(
-				"failed to decode network metadata for chain selector %d: %w", chainSelector, errMeta,
-			)
-		}
 		forkURLs, err := selectPublicRPC(ctx, lggr, &metadata, network.ChainSelector, network.RPCs)
 		if err != nil {
 			lggr.Infof("Excluding chain with ID %d from environment: %s", chainID, err.Error())
@@ -207,6 +212,11 @@ func newAnvilChains(
 		}
 		if err = metadata.AnvilConfig.Validate(); err != nil {
 			lggr.Infof("Excluding chain with ID %d from environment due to failed anvil config validation: %s", chainID, err.Error())
+			continue
+		}
+
+		if lo.FromPtr(metadata.IsZkSync) {
+			lggr.Infof("skipping chain %d: zksync VM is not supported", network.ChainSelector)
 			continue
 		}
 
@@ -232,7 +242,7 @@ func newAnvilChains(
 		}
 
 		config := evmprov.CTFAnvilChainProviderConfig{
-			Name:                     fmt.Sprintf("anvil-fork-%d", network.ChainSelector),
+			Name:                     fmt.Sprintf("anvil-fork-%d-%d", network.ChainSelector, time.Now().UnixNano()),
 			Once:                     &once,
 			ConfirmFunctor:           evmprov.ConfirmFuncGeth(3 * time.Minute),
 			DockerCmdParamsOverrides: []string{"--auto-impersonate", "--no-storage-caching"},
@@ -252,6 +262,7 @@ func newAnvilChains(
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize anvil chain provider for chain selector %d: %w", chainSelector, err)
 		}
+		containers[chainSelector] = provider.Container
 
 		blockChains = append(blockChains, b)
 		anvilClients[chainSelector] = newAnvilForkClient(
@@ -279,6 +290,7 @@ func newAnvilChains(
 		Chains:       fchain.NewBlockChainsFromSlice(blockChains).EVMChains(),
 		ForkClients:  anvilClients,
 		ChainConfigs: chainConfigsBySelector,
+		Containers:   containers,
 	}, nil
 }
 

--- a/engine/cld/environment/fork.go
+++ b/engine/cld/environment/fork.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/testcontainers/testcontainers-go"
 
 	fchain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/cre"
@@ -36,6 +37,7 @@ type ForkedEnvironment struct {
 	fdeployment.Environment
 	ChainConfigs map[uint64]ChainConfig
 	ForkClients  map[uint64]ForkedOnchainClient
+	Containers   map[uint64]testcontainers.Container
 }
 
 // LoadFork loads a deployment environment in which the chains are forks of real networks.
@@ -155,6 +157,7 @@ func LoadFork(
 		Environment:  *environment,
 		ChainConfigs: anvilOutput.ChainConfigs,
 		ForkClients:  anvilOutput.ForkClients, // TODO: map should eventually include clients from other families
+		Containers:   anvilOutput.Containers,
 	}, nil
 }
 

--- a/engine/cld/environment/fork_test.go
+++ b/engine/cld/environment/fork_test.go
@@ -11,7 +11,6 @@ import (
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/mcms"
 	"github.com/smartcontractkit/mcms/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	fdeployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -22,12 +21,14 @@ func Test_LoadForkedEnvironment(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		domain       fdomain.Domain
-		env          string
-		blockNumbers map[uint64]*big.Int
-		options      []LoadEnvironmentOption
-		expectError  string
+		name          string
+		domain        fdomain.Domain
+		env           string
+		blockNumbers  map[uint64]*big.Int
+		options       []LoadEnvironmentOption
+		wantName      string
+		wantNumChains int
+		wantErr       string
 	}{
 		{
 			name:   "Invalid Environment",
@@ -36,7 +37,7 @@ func Test_LoadForkedEnvironment(t *testing.T) {
 			blockNumbers: map[uint64]*big.Int{
 				1: big.NewInt(1000),
 			},
-			expectError: "failed to load config",
+			wantErr: "failed to load config",
 		},
 		{
 			name:   "AddressBook Failure",
@@ -45,8 +46,8 @@ func Test_LoadForkedEnvironment(t *testing.T) {
 			blockNumbers: map[uint64]*big.Int{
 				16015286601757825753: big.NewInt(1000),
 			},
-			options:     []LoadEnvironmentOption{WithoutJD()},
-			expectError: "failed to load addressbook for domain test and environment staging:",
+			options: []LoadEnvironmentOption{WithoutJD()},
+			wantErr: "failed to load addressbook for domain test and environment staging:",
 		},
 		{
 			name:   "DataStore Failure",
@@ -55,15 +56,15 @@ func Test_LoadForkedEnvironment(t *testing.T) {
 			blockNumbers: map[uint64]*big.Int{
 				16015286601757825753: big.NewInt(1000),
 			},
-			options:     []LoadEnvironmentOption{WithoutJD()},
-			expectError: "failed to load datastore for domain test and environment staging:",
+			options: []LoadEnvironmentOption{WithoutJD()},
+			wantErr: "failed to load datastore for domain test and environment staging:",
 		},
 		{
 			name:         "Empty Block Numbers",
 			domain:       setupTest(t, setupTestConfig, setupAddressbook),
 			env:          "staging",
 			blockNumbers: map[uint64]*big.Int{},
-			expectError:  "failed to create anvil chains",
+			wantErr:      "failed to create anvil chains",
 		},
 		{
 			name:   "Invalid Nodes File",
@@ -72,7 +73,7 @@ func Test_LoadForkedEnvironment(t *testing.T) {
 			blockNumbers: map[uint64]*big.Int{
 				16015286601757825753: big.NewInt(1000),
 			},
-			expectError: "failed to load nodes",
+			wantErr: "failed to load nodes",
 		},
 		{
 			name:   "OffchainClient Failure",
@@ -81,16 +82,25 @@ func Test_LoadForkedEnvironment(t *testing.T) {
 			blockNumbers: map[uint64]*big.Int{
 				16015286601757825753: big.NewInt(1000),
 			},
-			expectError: "failed to load offchain client",
+			wantErr: "failed to load offchain client",
 		},
 		{
-			name:   "No Error",
-			domain: setupTest(t, setupTestConfig, setupAddressbook, setupDataStore, setupNodes),
-			env:    "staging",
-			blockNumbers: map[uint64]*big.Int{
-				16015286601757825753: big.NewInt(1000),
-			},
-			options: []LoadEnvironmentOption{WithoutJD()},
+			name:          "Skip ZK Sync chain",
+			domain:        setupTest(t, setupTestConfig, setupAddressbook, setupDataStore, setupNodes),
+			env:           "staging",
+			blockNumbers:  map[uint64]*big.Int{6898391096552792247: big.NewInt(1000)},
+			options:       []LoadEnvironmentOption{WithoutJD(), WithAnvilKeyAsDeployer()},
+			wantName:      "fork",
+			wantNumChains: 0,
+		},
+		{
+			name:          "No Error",
+			domain:        setupTest(t, setupTestConfig, setupAddressbook, setupDataStore, setupNodes),
+			env:           "staging",
+			blockNumbers:  map[uint64]*big.Int{5224473277236331295: big.NewInt(1000)},
+			options:       []LoadEnvironmentOption{WithoutJD(), WithAnvilKeyAsDeployer()},
+			wantName:      "fork",
+			wantNumChains: 1,
 		},
 	}
 
@@ -99,15 +109,19 @@ func Test_LoadForkedEnvironment(t *testing.T) {
 			t.Parallel()
 
 			forkEnv, err := LoadFork(t.Context(), tt.domain, tt.env, tt.blockNumbers, tt.options...)
+			t.Cleanup(func() {
+				for _, container := range forkEnv.Containers {
+					_ = container.Terminate(context.Background())
+				}
+			})
 
-			if tt.expectError != "" {
-				require.ErrorContains(t, err, tt.expectError)
-
-				return
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				require.Equal(t, tt.wantName, forkEnv.Name)
+				require.Len(t, forkEnv.BlockChains.EVMChains(), tt.wantNumChains)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
 			}
-
-			require.NoError(t, err)
-			assert.Equal(t, "fork", forkEnv.Name)
 		})
 	}
 }

--- a/engine/cld/environment/testdata/networks.yaml
+++ b/engine/cld/environment/testdata/networks.yaml
@@ -6,11 +6,29 @@ networks:
       - rpc_name: "sepolia-rpc"
         preferred_url_scheme: "http"
         http_url: "https://sepolia.infura.io/v3/test"
-        ws_url: "wss://sepolia.infura.io/ws/v3/test"
+
+  # Ethereum Mainnet
   - type: "mainnet"
     chain_selector: 5009297550715157269
     rpcs:
       - rpc_name: "mainnet-rpc"
         preferred_url_scheme: "http"
         http_url: "https://mainnet.infura.io/v3/test"
-        ws_url: "wss://mainnet.infura.io/ws/v3/test"
+
+  # Optimism Sepolia Testnet
+  - type: "testnet"
+    chain_selector: 5224473277236331295
+    rpcs:
+      - rpc_name: "optimism-sepolia-rpc"
+        preferred_url_scheme: "http"
+        http_url: "https://optimism-sepolia.drpc.org"
+
+  # ZkSync Era Testnet
+  - type: testnet
+    chain_selector: 6898391096552792247
+    metadata:
+      is_zksync: true
+    rpcs:
+      - rpc_name: Public
+        preferred_url_scheme: "http"
+        http_url: https://sepolia.era.zksync.dev


### PR DESCRIPTION
Skip fork tests of chains marked with `is_zksync: true` in the `.config/networks/*.yaml` files.