### PR TITLE
fix: derive catalog gRPC retry policy service name from proto ServiceDesc

### DIFF
--- a/.changeset/great-ravens-retry.md
+++ b/.changeset/great-ravens-retry.md
@@ -1,0 +1,5 @@
+---
+"chainlink-deployments-framework": patch
+---
+
+fix: derive catalog gRPC retry policy service name from the proto ServiceDesc so it always matches the generated service name

--- a/datastore/catalog/remote/grpc.go
+++ b/datastore/catalog/remote/grpc.go
@@ -14,9 +14,13 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const retryPolicy = `{
+// retryPolicy derives the service name from the generated gRPC ServiceDesc so it
+// always matches the proto definition, even if the proto package is renamed.
+// Note: gRPC retry policies only apply to unary RPCs; the bidirectional streaming
+// DataAccess RPC is never retried by gRPC.
+var retryPolicy = fmt.Sprintf(`{
 	"methodConfig": [{
-		"name": [{"service": "op_catalog.v1.datastore.Datastore"}],
+		"name": [{"service": %q}],
 		"retryPolicy": {
 			"maxAttempts": 5,
 			"initialBackoff": "0.1s",
@@ -30,7 +34,7 @@ const retryPolicy = `{
 			]
 		}
 	}]
-}`
+}`, pb.Datastore_ServiceDesc.ServiceName)
 
 type CatalogClient struct {
 	protoClient pb.DatastoreClient

--- a/datastore/catalog/remote/grpc_internal_test.go
+++ b/datastore/catalog/remote/grpc_internal_test.go
@@ -1,0 +1,32 @@
+package remote
+
+import (
+	"encoding/json"
+	"testing"
+
+	pb "github.com/smartcontractkit/chainlink-protos/op-catalog/v1/datastore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRetryPolicy_ServiceNameMatchesProto ensures the retry policy's service name
+// is derived from the generated gRPC ServiceDesc and cannot drift from the proto
+// definition. The service config must also be valid JSON, as an unparseable config
+// would fail connection creation at dial time.
+func TestRetryPolicy_ServiceNameMatchesProto(t *testing.T) {
+	t.Parallel()
+
+	var config struct {
+		MethodConfig []struct {
+			Name []struct {
+				Service string `json:"service"`
+			} `json:"name"`
+		} `json:"methodConfig"`
+	}
+
+	require.NoError(t, json.Unmarshal([]byte(retryPolicy), &config))
+	require.NotEmpty(t, config.MethodConfig)
+	require.NotEmpty(t, config.MethodConfig[0].Name)
+
+	assert.Equal(t, pb.Datastore_ServiceDesc.ServiceName, config.MethodConfig[0].Name[0].Service)
+}


### PR DESCRIPTION
## Summary

The retry policy attached via `grpc.WithDefaultServiceConfig` in `datastore/catalog/remote/grpc.go` never took effect. Its `methodConfig` hardcoded the service name `op_catalog.v1.datastore.Datastore`, but the actual proto service is `api.datastore.v1.Datastore` (`/api.datastore.v1.Datastore/DataAccess`). Since no method name matched, gRPC silently ignored the retry policy.

## Changes

- Build the retry policy service config with `pb.Datastore_ServiceDesc.ServiceName` instead of a hardcoded string, so the name always matches the generated code even if the proto package is renamed.
- Document that gRPC service-config retries only apply to unary RPCs — the bidirectional streaming `DataAccess` RPC is never retried by gRPC and would need application-level reconnect logic if stream resilience is desired.
- Add a unit test asserting the rendered service config is valid JSON and matches the proto service name.